### PR TITLE
Publishing workflow fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,16 +8,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 14.x
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@cowprotocol'
       - run: yarn --frozen-lockfile
       - run: bash src/workflows/publish.sh
         env:
-          PUBLISH_SERVER: ${{ secrets.PUBLISH_SERVER }}
-          GITLAB_TRIGGER_TOKEN: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
-          BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+.idea
+*.iml


### PR DESCRIPTION
Attempt to fix publishing workflow to go straight to NPM rather than using internal gitlab setup.

Already added to repo secrets the env var `NODE_AUTH_TOKEN`

Copied workflow setup from https://github.com/cowprotocol/token/blob/main/src/workflows/publish.sh