### PR TITLE
[Metadata API] Add methods left to complete metadata flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ SDK also includes a Metadata API to interact with AppData documents and IPFS CID
   // Decode AppData Hex to CID
   const decodedAppDataHex  = await cowSdk.metadataApi.appDataHexToCid(hash)
   console.log(decodedAppDataHex) //QmUf2TrpSANVXdgcYfAAACe6kg551cY3rAemB7xfEMjYvs
+
+  // Create an AppData Document
+    const appDataDoc = cowSdk.metadataApi.generateAppDataDoc({})
+    /* {
+        version: '0.1.0',
+        appCode: 'CowSwap',
+        metadata: {},
+      } */
+
+  // Upload AppDataDoc to IPFS
+   const cowSdk = new CowSdk(4, { ipfs: { apiKey: 'YOUR_API_KEY', apiSecret: 'YOUR_API_SECRET' } })
+   await cowSdk.metadataApi.uploadMetadataDocToIpfs(appDataDoc)
+   /* 0x5ddb2c8207c10b96fac92cb934ef9ba004bc007a073c9e5b13edc422f209ed80 */   
 ```
 
 ### Install Dependencies

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 </p>
 
 # CoW protocol SDK
+
 [![Styled With Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://prettier.io/)
 [![Coverage Status](https://coveralls.io/repos/github/cowprotocol/cow-sdk/badge.svg?branch=main)](https://coveralls.io/github/cowprotocol/cow-sdk?branch=main)
 
-
 > ⚠️⚠️ THE SDK IS IN Beta ⚠️⚠️
-> It is being currently develop and is a work in progress, also it's API is subjected to change. 
+> It is being currently develop and is a work in progress, also it's API is subjected to change.
 > If you experience any problems, please open an issue in Github trying to describe your problem.
 
 ### Getting started
@@ -35,17 +35,18 @@ The SDK will expose the CoW API operations (`cowSdk.cowApi`) and some convenient
 const trades = await cowSdk.cowApi.getOrders({
   owner: '0x00000000005ef87f8ca7014309ece7260bbcdaeb', // Trader
   limit: 5,
-  offset: 0
+  offset: 0,
 })
 console.log(trades)
 ```
 
 Let's see a full example on how to submit an order to CowSwap.
 
-> ⚠️ Before starting, the protocol requires you to approve the sell token before the order can be considered. 
+> ⚠️ Before starting, the protocol requires you to approve the sell token before the order can be considered.
 > For more details see https://docs.cow.fi/tutorials/how-to-submit-orders-via-the-api/1.-set-allowance-for-the-sell-token
 
 In this example, we will:
+
 - 1. **Instantiate the SDK and a wallet**: Used for signing orders
 - 2. **Get a price/fee quote from the API**: Get current market price and required protocol fee to settle your trade.
 - 3. **Sign the order using your wallet**: Only signed orders are considered by the protocol.
@@ -65,7 +66,7 @@ const cowSdk = new CowSdk(4, { signer: wallet })
 const quoteResponse = await cowSdk.cowApi.getQuote({
   kind: OrderKind.SELL, // Sell order (could also be BUY)
   sellToken: '0xc778417e063141139fce010982780140aa0cd5ab', // WETH
-  buyToken: '0x4dbcdf9b62e891a7cec5a2568c3f4faf9e8abe2b',  // USDC
+  buyToken: '0x4dbcdf9b62e891a7cec5a2568c3f4faf9e8abe2b', // USDC
   amount: '1000000000000000000', // 1 WETH
   userAddress: '0x1811be0994930fe9480eaede25165608b093ad7a', // Trader
   validTo: 2524608000,
@@ -100,14 +101,14 @@ console.log(`https://explorer.cow.fi/rinkeby/orders/${orderId}`)
 SDK also includes a Metadata API to interact with AppData documents and IPFS CIDs
 
 ```js
- const chainId = 4 // Rinkeby
- const cowSdk = new CowSdk(chainId)
- let hash = '0xa6c81f4ca727252a05b108f1742a07430f28d474d2a3492d8f325746824d22e5'
- 
- // Decode AppData document given a CID hash
- const appDataDoc = await cowSdk.metadataApi.decodeAppData(hash)
- console.log(appDataDoc)
-  /* {
+const chainId = 4 // Rinkeby
+const cowSdk = new CowSdk(chainId)
+let hash = '0xa6c81f4ca727252a05b108f1742a07430f28d474d2a3492d8f325746824d22e5'
+
+// Decode AppData document given a CID hash
+const appDataDoc = await cowSdk.metadataApi.decodeAppData(hash)
+console.log(appDataDoc)
+/* {
       "appCode": "CowSwap",
       "metadata": {
           "referrer": {
@@ -118,30 +119,56 @@ SDK also includes a Metadata API to interact with AppData documents and IPFS CID
       "version": "0.1.0"
   } */
 
-  const cid = 'QmUf2TrpSANVXdgcYfAAACe6kg551cY3rAemB7xfEMjYvs'
-  
-  // Decode CID hash to AppData Hex 
-  const decodedAppDataHex  = await cowSdk.metadataApi.cidToAppDataHex(cid)
-  console.log(decodedAppDataHex) //0x5ddb2c8207c10b96fac92cb934ef9ba004bc007a073c9e5b13edc422f209ed80
+const cid = 'QmUf2TrpSANVXdgcYfAAACe6kg551cY3rAemB7xfEMjYvs'
 
-  hash = '0x5ddb2c8207c10b96fac92cb934ef9ba004bc007a073c9e5b13edc422f209ed80'
+// Decode CID hash to AppData Hex
+const decodedAppDataHex = await cowSdk.metadataApi.cidToAppDataHex(cid)
+console.log(decodedAppDataHex) //0x5ddb2c8207c10b96fac92cb934ef9ba004bc007a073c9e5b13edc422f209ed80
 
-  // Decode AppData Hex to CID
-  const decodedAppDataHex  = await cowSdk.metadataApi.appDataHexToCid(hash)
-  console.log(decodedAppDataHex) //QmUf2TrpSANVXdgcYfAAACe6kg551cY3rAemB7xfEMjYvs
+hash = '0x5ddb2c8207c10b96fac92cb934ef9ba004bc007a073c9e5b13edc422f209ed80'
 
-  // Create an AppData Document
-    const appDataDoc = cowSdk.metadataApi.generateAppDataDoc({})
-    /* {
-        version: '0.1.0',
-        appCode: 'CowSwap',
-        metadata: {},
-      } */
+// Decode AppData Hex to CID
+const decodedAppDataHex = await cowSdk.metadataApi.appDataHexToCid(hash)
+console.log(decodedAppDataHex) //QmUf2TrpSANVXdgcYfAAACe6kg551cY3rAemB7xfEMjYvs
 
-  // Upload AppDataDoc to IPFS
-   const cowSdk = new CowSdk(4, { ipfs: { apiKey: 'YOUR_API_KEY', apiSecret: 'YOUR_API_SECRET' } })
-   await cowSdk.metadataApi.uploadMetadataDocToIpfs(appDataDoc)
-   /* 0x5ddb2c8207c10b96fac92cb934ef9ba004bc007a073c9e5b13edc422f209ed80 */   
+// Create an AppData Document with empty metadata and default appCode
+const appDataDoc = cowSdk.metadataApi.generateAppDataDoc({})
+/* {
+      version: '0.1.0',
+      appCode: 'CowSwap',
+      metadata: {},
+    } 
+*/
+
+// Create an AppData Document with custom metadata and appCode
+const appDataDoc = cowSdk.metadataApi.generateAppDataDoc(
+  {
+    referrer: {
+      address: '0x1f5B740436Fc5935622e92aa3b46818906F416E9',
+      version: '0.1.0',
+    },
+  },
+  'CowApp'
+)
+/* {
+      version: '0.1.0',
+      appCode: 'CowApp',
+      metadata: {
+        referrer: {
+          address: '0x1f5B740436Fc5935622e92aa3b46818906F416E9',
+          version: '0.1.0',
+        },
+      },
+    } 
+*/
+
+// Upload AppDataDoc to IPFS (Pinata)
+const cowSdk = new CowSdk(4, {
+  ipfs: { pinataApiKey: 'YOUR_PINATA_API_KEY', pinataApiSecret: 'YOUR_PINATA_API_SECRET' },
+})
+
+await cowSdk.metadataApi.uploadMetadataDocToIpfs(appDataDoc)
+/* 0x5ddb2c8207c10b96fac92cb934ef9ba004bc007a073c9e5b13edc422f209ed80 */
 ```
 
 ### Install Dependencies

--- a/README.md
+++ b/README.md
@@ -131,7 +131,11 @@ hash = '0x5ddb2c8207c10b96fac92cb934ef9ba004bc007a073c9e5b13edc422f209ed80'
 const decodedAppDataHex = await cowSdk.metadataApi.appDataHexToCid(hash)
 console.log(decodedAppDataHex) //QmUf2TrpSANVXdgcYfAAACe6kg551cY3rAemB7xfEMjYvs
 
-// Create an AppData Document with empty metadata and default appCode
+/*Create an AppData Document with empty metadata and default appCode
+  generateAppDataDoc receives as parameters: 
+    - metadata: MetadataDoc (Default: {})
+    - appCode: string (Default: 'Cowswap')
+*/
 const appDataDoc = cowSdk.metadataApi.generateAppDataDoc({})
 /* {
       version: '0.1.0',

--- a/src/api/metadata/index.ts
+++ b/src/api/metadata/index.ts
@@ -1,14 +1,27 @@
 import log from 'loglevel'
 import { Context } from '../../utils/context'
 import { getSerializedCID, loadIpfsFromCid } from '../../utils/appData'
-import { AppDataDoc } from './types'
+import { pinJSONToIPFS } from '../../utils/ipfs'
+import { AppDataDoc, MetadataDoc } from './types'
 import { CowError } from '../../utils/common'
+
+const DEFAULT_APP_CODE = 'CowSwap'
 
 export class MetadataApi {
   context: Context
 
   constructor(context: Context) {
     this.context = context
+  }
+
+  generateAppDataDoc(metadata: MetadataDoc = {}): AppDataDoc {
+    return {
+      version: '0.1.0',
+      appCode: DEFAULT_APP_CODE,
+      metadata: {
+        ...metadata,
+      },
+    }
   }
 
   async decodeAppData(hash: string): Promise<void | AppDataDoc> {
@@ -33,5 +46,14 @@ export class MetadataApi {
     const cidV0 = await getSerializedCID(hash)
     if (!cidV0) throw new CowError('Error getting serialized CID')
     return cidV0
+  }
+
+  async uploadMetadataDocToIpfs(appDataDoc: AppDataDoc): Promise<string | void> {
+    const { apiKey, apiSecret } = this.context.ipfs
+    if (!apiKey || !apiSecret) {
+      throw new CowError('You need to pass IPFS api credentials.')
+    }
+    const { IpfsHash } = await pinJSONToIPFS(appDataDoc, this.context.ipfs)
+    return this.cidToAppDataHex(IpfsHash)
   }
 }

--- a/src/api/metadata/index.ts
+++ b/src/api/metadata/index.ts
@@ -6,6 +6,7 @@ import { AppDataDoc, MetadataDoc } from './types'
 import { CowError } from '../../utils/common'
 
 const DEFAULT_APP_CODE = 'CowSwap'
+const DEFAULT_APP_VERSION = '0.1.0'
 
 export class MetadataApi {
   context: Context
@@ -14,10 +15,10 @@ export class MetadataApi {
     this.context = context
   }
 
-  generateAppDataDoc(metadata: MetadataDoc = {}): AppDataDoc {
+  generateAppDataDoc(metadata: MetadataDoc = {}, appCode: string = DEFAULT_APP_CODE): AppDataDoc {
     return {
-      version: '0.1.0',
-      appCode: DEFAULT_APP_CODE,
+      version: DEFAULT_APP_VERSION,
+      appCode,
       metadata: {
         ...metadata,
       },
@@ -30,7 +31,7 @@ export class MetadataApi {
       if (!cidV0) throw new CowError('Error getting serialized CID')
       return loadIpfsFromCid(cidV0)
     } catch (e) {
-      const error = e as Error
+      const error = e as CowError
       log.error('Error decoding AppData:', error)
       throw new CowError('Error decoding AppData: ' + error.message)
     }
@@ -50,10 +51,6 @@ export class MetadataApi {
   }
 
   async uploadMetadataDocToIpfs(appDataDoc: AppDataDoc): Promise<string | void> {
-    const { apiKey, apiSecret } = this.context.ipfs
-    if (!apiKey || !apiSecret) {
-      throw new CowError('You need to pass IPFS api credentials.')
-    }
     const { IpfsHash } = await pinJSONToIPFS(appDataDoc, this.context.ipfs)
     return this.cidToAppDataHex(IpfsHash)
   }

--- a/src/api/metadata/index.ts
+++ b/src/api/metadata/index.ts
@@ -28,10 +28,11 @@ export class MetadataApi {
     try {
       const cidV0 = await getSerializedCID(hash)
       if (!cidV0) throw new CowError('Error getting serialized CID')
-      return await loadIpfsFromCid(cidV0)
-    } catch (error) {
+      return loadIpfsFromCid(cidV0)
+    } catch (e) {
+      const error = e as Error
       log.error('Error decoding AppData:', error)
-      throw new CowError('Error decoding AppData: ' + error)
+      throw new CowError('Error decoding AppData: ' + error.message)
     }
   }
 

--- a/src/api/metadata/metadata.spec.ts
+++ b/src/api/metadata/metadata.spec.ts
@@ -65,7 +65,7 @@ test('Invalid: Upload to IPFS without passing credentials', async () => {
 test('Valid: Upload AppDataDoc to IPFS', async () => {
   fetchMock.mockResponseOnce(JSON.stringify({ IpfsHash: IPFS_HASH }), { status: HTTP_STATUS_OK })
   const appDataDoc = cowSdk.metadataApi.generateAppDataDoc(CUSTOM_APP_DATA_DOC.metadata)
-  const cowSdk1 = new CowSdk(chainId, { ipfs: { apiKey: 'validApiKey', apiSecret: 'ValidApiSecret' } })
+  const cowSdk1 = new CowSdk(chainId, { ipfs: { pinataApiKey: 'validApiKey', pinataApiSecret: 'ValidApiSecret' } })
   const appDataHex = await cowSdk1.metadataApi.uploadMetadataDocToIpfs(appDataDoc)
   expect(fetchMock).toHaveBeenCalledTimes(1)
   expect(appDataHex).toEqual(APP_DATA_HEX)
@@ -76,11 +76,12 @@ test('Invalid: Upload AppDataDoc to IPFS with wrong credentials', async () => {
     status: HTTP_STATUS_INTERNAL_ERROR,
   })
   const appDataDoc = cowSdk.metadataApi.generateAppDataDoc({})
-  const cowSdk1 = new CowSdk(chainId, { ipfs: { apiKey: 'InvalidApiKey', apiSecret: 'InvValidApiSecret' } })
+  const cowSdk1 = new CowSdk(chainId, { ipfs: { pinataApiKey: 'InvalidApiKey', pinataApiSecret: 'InvValidApiSecret' } })
   try {
     await cowSdk1.metadataApi.uploadMetadataDocToIpfs(appDataDoc)
+    await expect(cowSdk1.metadataApi.uploadMetadataDocToIpfs(appDataDoc)).rejects.toThrow('IPFS api keys are invalid')
   } catch (e) {
-    const error = e as Error
+    const error = e as CowError
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(error.message).toEqual('IPFS api keys are invalid')
   }

--- a/src/api/metadata/metadata.spec.ts
+++ b/src/api/metadata/metadata.spec.ts
@@ -1,0 +1,125 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+import { CowSdk } from '../../CowSdk'
+import { CowError } from '../../utils/common'
+
+enableFetchMocks()
+
+const chainId = 4 //Rinkeby
+
+const cowSdk = new CowSdk(chainId)
+
+const HTTP_STATUS_OK = 200
+const HTTP_STATUS_INTERNAL_ERROR = 500
+
+const DEFAULT_APP_DATA_DOC = {
+  version: '0.1.0',
+  appCode: 'CowSwap',
+  metadata: {},
+}
+
+const CUSTOM_APP_DATA_DOC = {
+  ...DEFAULT_APP_DATA_DOC,
+  metadata: {
+    referrer: {
+      address: '0x1f5B740436Fc5935622e92aa3b46818906F416E9',
+      version: '0.1.0',
+    },
+  },
+}
+
+const IPFS_HASH = 'QmUf2TrpSANVXdgcYfAAACe6kg551cY3rAemB7xfEMjYvs'
+
+const APP_DATA_HEX = '0x5ddb2c8207c10b96fac92cb934ef9ba004bc007a073c9e5b13edc422f209ed80'
+
+beforeEach(() => {
+  fetchMock.resetMocks()
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('Valid: Create appDataDoc with empty metadata ', () => {
+  const appDataDoc = cowSdk.metadataApi.generateAppDataDoc({})
+  expect(appDataDoc.version).toEqual(DEFAULT_APP_DATA_DOC.version)
+  expect(appDataDoc.appCode).toEqual(DEFAULT_APP_DATA_DOC.appCode)
+  expect(appDataDoc.metadata).toEqual(DEFAULT_APP_DATA_DOC.metadata)
+})
+
+test('Valid: Create appDataDoc with custom metadata ', () => {
+  const appDataDoc = cowSdk.metadataApi.generateAppDataDoc(CUSTOM_APP_DATA_DOC.metadata)
+  expect(appDataDoc.metadata.referrer?.address).toEqual(CUSTOM_APP_DATA_DOC.metadata.referrer.address)
+  expect(appDataDoc.metadata.referrer?.version).toEqual(CUSTOM_APP_DATA_DOC.metadata.referrer.version)
+})
+
+test('Invalid: Upload to IPFS without passing credentials', async () => {
+  const appDataDoc = cowSdk.metadataApi.generateAppDataDoc(CUSTOM_APP_DATA_DOC.metadata)
+  try {
+    await cowSdk.metadataApi.uploadMetadataDocToIpfs(appDataDoc)
+  } catch (e) {
+    const error = e as CowError
+    expect(error.message).toEqual('You need to pass IPFS api credentials.')
+  }
+})
+
+test('Valid: Upload AppDataDoc to IPFS', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({ IpfsHash: IPFS_HASH }), { status: HTTP_STATUS_OK })
+  const appDataDoc = cowSdk.metadataApi.generateAppDataDoc(CUSTOM_APP_DATA_DOC.metadata)
+  const cowSdk1 = new CowSdk(chainId, { ipfs: { apiKey: 'validApiKey', apiSecret: 'ValidApiSecret' } })
+  const appDataHex = await cowSdk1.metadataApi.uploadMetadataDocToIpfs(appDataDoc)
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+  expect(appDataHex).toEqual(APP_DATA_HEX)
+})
+
+test('Invalid: Upload AppDataDoc to IPFS with wrong credentials', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({ error: { details: 'IPFS api keys are invalid' } }), {
+    status: HTTP_STATUS_INTERNAL_ERROR,
+  })
+  const appDataDoc = cowSdk.metadataApi.generateAppDataDoc({})
+  const cowSdk1 = new CowSdk(chainId, { ipfs: { apiKey: 'InvalidApiKey', apiSecret: 'InvValidApiSecret' } })
+  try {
+    await cowSdk1.metadataApi.uploadMetadataDocToIpfs(appDataDoc)
+  } catch (e) {
+    const error = e as Error
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(error.message).toEqual('IPFS api keys are invalid')
+  }
+})
+
+test('Valid: Decode appData ', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify(CUSTOM_APP_DATA_DOC), { status: HTTP_STATUS_OK })
+  const appDataDoc = await cowSdk.metadataApi.decodeAppData(APP_DATA_HEX)
+
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+  expect(fetchMock).toHaveBeenCalledWith(
+    'https://gnosis.mypinata.cloud/ipfs/QmUf2TrpSANVXdgcYfAAACe6kg551cY3rAemB7xfEMjYvs'
+  )
+  expect(appDataDoc?.version).toEqual(CUSTOM_APP_DATA_DOC.version)
+  expect(appDataDoc?.appCode).toEqual(CUSTOM_APP_DATA_DOC.appCode)
+  expect(appDataDoc?.metadata.referrer?.address).toEqual(CUSTOM_APP_DATA_DOC.metadata.referrer.address)
+  expect(appDataDoc?.metadata.referrer?.version).toEqual(CUSTOM_APP_DATA_DOC.metadata.referrer.version)
+})
+
+test('Invalid: Decode appData with wrong hash format', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({}), { status: HTTP_STATUS_INTERNAL_ERROR })
+  try {
+    await cowSdk.metadataApi.decodeAppData('invalidHash')
+  } catch (e) {
+    const error = e as CowError
+    expect(error.message).toEqual('Error decoding AppData: Incorrect length')
+  }
+})
+
+test('Valid: AppData to CID ', async () => {
+  const decodedAppDataHex = await cowSdk.metadataApi.appDataHexToCid(APP_DATA_HEX)
+  expect(decodedAppDataHex).toEqual(IPFS_HASH)
+})
+
+test('Invalid: AppData to CID with wrong format ', async () => {
+  try {
+    await cowSdk.metadataApi.appDataHexToCid('invalidHash')
+  } catch (e) {
+    const error = e as CowError
+    expect(error.message).toEqual('Incorrect length')
+  }
+})

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -4,17 +4,27 @@ import { CowError, logPrefix } from './common'
 import { SupportedChainId as ChainId } from '../constants/chains'
 import { DEFAULT_APP_DATA_HASH, DEFAULT_IPFS_GATEWAY_URI } from '../constants'
 
+export interface Ipfs {
+  uri: string
+  apiKey?: string
+  apiSecret?: string
+}
+
 export interface CowContext {
   appDataHash?: string
   isDevEnvironment?: boolean
   signer?: Signer
-  ipfsUri?: string
+  ipfs?: Ipfs
 }
 
 export const DefaultCowContext = {
   appDataHash: DEFAULT_APP_DATA_HASH,
   isDevEnvironment: false,
-  ipfsUri: DEFAULT_IPFS_GATEWAY_URI,
+  ipfs: {
+    uri: DEFAULT_IPFS_GATEWAY_URI,
+    apiKey: undefined,
+    apiSecret: undefined,
+  },
 }
 
 /**
@@ -83,7 +93,7 @@ export class Context implements Partial<CowContext> {
     return this.#context.signer
   }
 
-  get ipfsUri(): string {
-    return this.#context.ipfsUri ?? DefaultCowContext.ipfsUri
+  get ipfs(): Ipfs {
+    return this.#context.ipfs ?? DefaultCowContext.ipfs
   }
 }

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -6,8 +6,8 @@ import { DEFAULT_APP_DATA_HASH, DEFAULT_IPFS_GATEWAY_URI } from '../constants'
 
 export interface Ipfs {
   uri?: string
-  apiKey?: string
-  apiSecret?: string
+  pinataApiKey?: string
+  pinataApiSecret?: string
 }
 
 export interface CowContext {

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -5,7 +5,7 @@ import { SupportedChainId as ChainId } from '../constants/chains'
 import { DEFAULT_APP_DATA_HASH, DEFAULT_IPFS_GATEWAY_URI } from '../constants'
 
 export interface Ipfs {
-  uri: string
+  uri?: string
   apiKey?: string
   apiSecret?: string
 }

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -8,7 +8,7 @@ type PinataPinResponse = {
 }
 
 export async function pinJSONToIPFS(
-  file: any,
+  file: unknown,
   { uri, pinataApiKey = '', pinataApiSecret = '' }: Ipfs
 ): Promise<PinataPinResponse> {
   const { default: fetch } = await import('cross-fetch')

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -1,0 +1,37 @@
+import { Ipfs } from './context'
+
+type PinataPinResponse = {
+  IpfsHash: string
+  PinSize: number
+  Timestamp: string
+}
+
+export async function pinJSONToIPFS(file: any, { uri, apiKey = '', apiSecret = '' }: Ipfs): Promise<PinataPinResponse> {
+  const body = JSON.stringify({
+    pinataContent: file,
+    pinataMetadata: { name: 'appData-affiliate' },
+  })
+
+  const pinataUrl = `${uri}/pinning/pinJSONToIPFS`
+
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    pinata_api_key: apiKey,
+    pinata_secret_api_key: apiSecret,
+  })
+
+  const request = new Request(pinataUrl, {
+    method: 'POST',
+    headers,
+    body,
+  })
+
+  const response = await fetch(request)
+  const data = await response.json()
+
+  if (response.status !== 200) {
+    throw new Error(data.error.details || data.error)
+  }
+
+  return data
+}


### PR DESCRIPTION
This PR closes #5 

Added the following methods to complete metadata flow: 

- `generateAppDataDoc`
- `uploadMetadataDocToIpfs`

Besides, IPFS logic was moved to the SDK.

Unit tests were added to improve coverage