### PR TITLE
Export SupportedChainId

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { CowError } from './utils/common'
-export { ALL_SUPPORTED_CHAIN_IDS } from './constants/chains'
+export { ALL_SUPPORTED_CHAIN_IDS, SupportedChainId } from './constants/chains'
 export * from './types'
 export { CowSdk } from './CowSdk'


### PR DESCRIPTION
There were places on the Explorer where the enum was needed directly like in https://github.com/cowprotocol/explorer/blob/c9ee4f1ce2008e481d53dc30a7e61074672d41ea/src/const.ts#L232