### PR TITLE
Cowswap 332/quote metadata

### DIFF
--- a/src/api/metadata/index.ts
+++ b/src/api/metadata/index.ts
@@ -6,7 +6,7 @@ import { AppDataDoc, MetadataDoc } from './types'
 import { CowError } from '../../utils/common'
 
 const DEFAULT_APP_CODE = 'CowSwap'
-const DEFAULT_APP_VERSION = '0.1.0'
+const DEFAULT_APP_VERSION = '0.2.0'
 
 export class MetadataApi {
   context: Context

--- a/src/api/metadata/metadata.spec.ts
+++ b/src/api/metadata/metadata.spec.ts
@@ -12,7 +12,7 @@ const HTTP_STATUS_OK = 200
 const HTTP_STATUS_INTERNAL_ERROR = 500
 
 const DEFAULT_APP_DATA_DOC = {
-  version: '0.1.0',
+  version: '0.2.0',
   appCode: 'CowSwap',
   metadata: {},
 }

--- a/src/api/metadata/types.ts
+++ b/src/api/metadata/types.ts
@@ -6,8 +6,15 @@ export interface ReferralMetadata extends Metadata {
   address: string
 }
 
+export interface QuoteMetadata extends Metadata {
+  id?: string
+  sellAmount: string
+  buyAmount: string
+}
+
 export type MetadataDoc = {
   referrer?: ReferralMetadata
+  quote?: QuoteMetadata
 }
 
 export type AppDataDoc = {

--- a/src/schemas/appData.schema.json
+++ b/src/schemas/appData.schema.json
@@ -30,6 +30,9 @@
       "properties": {
         "referrer": {
           "$ref": "#/definitions/kindMetadata/referrer"
+        },
+        "quote": {
+          "$ref": "#/definitions/kindMetadata/quote"
         }
       }
     }
@@ -49,6 +52,13 @@
       "examples": ["0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9"],
       "type": "string"
     },
+    "bigNumber": {
+      "$id": "#/definitions/bigNumber",
+      "pattern": "\\d+",
+      "title": "BigNumber",
+      "examples": ["90741097240912730913, 0, 75891372"],
+      "type": "string"
+    },
     "kindMetadata": {
       "referrer": {
         "$id": "#/definitions/referrer",
@@ -62,6 +72,28 @@
           "address": {
             "$ref": "#/definitions/ethereumAddress",
             "title": "Referrer address"
+          }
+        }
+      },
+      "quote": {
+        "$id": "#/definitions/quote",
+        "required": ["sellAmount", "buyAmount"],
+        "title": "Quote",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$id": "#/definitions/quote/id",
+            "title": "Quote id",
+            "examples": ["XA23443543534FF"],
+            "type": "string"
+          },
+          "sellAmount": {
+            "$ref": "#/definitions/bigNumber",
+            "title": "Quote sell amount"
+          },
+          "buyAmount": {
+            "$ref": "#/definitions/bigNumber",
+            "title": "Quote buy amount"
           }
         }
       }

--- a/src/utils/appData.spec.ts
+++ b/src/utils/appData.spec.ts
@@ -5,6 +5,11 @@ const VALID_RESULT = {
   result: true,
 }
 
+const BASE_DOCUMENT = {
+  version: '0.1.0',
+  metadata: {},
+}
+
 const INVALID_CID_LENGTH = 'Incorrect length'
 
 beforeEach(() => {
@@ -12,10 +17,7 @@ beforeEach(() => {
 })
 
 test('Valid minimal document', async () => {
-  const validation = await validateAppDataDocument({
-    version: '0.1.0',
-    metadata: {},
-  })
+  const validation = await validateAppDataDocument(BASE_DOCUMENT)
   expect(validation).toEqual(VALID_RESULT)
 })
 
@@ -111,4 +113,32 @@ test('Valid IPFS appData from CID', async () => {
   const validation = await validateAppDataDocument(appDataDocument)
 
   expect(validation).toEqual(VALID_RESULT)
+})
+
+test('Valid: quote metadata - minimal', async () => {
+  const document = {...BASE_DOCUMENT, metadata: {quote: {sellAmount: '1', buyAmount: '1'}}}
+  const validation = await validateAppDataDocument(document)
+
+  expect(validation).toEqual(VALID_RESULT)
+})
+
+test('Valid: quote metadata - with all fields', async () => {
+  const document = {...BASE_DOCUMENT, metadata: {quote: {sellAmount: '1', buyAmount: '1', id: 'S09D8ZFAX'}}}
+  const validation = await validateAppDataDocument(document)
+
+  expect(validation).toEqual(VALID_RESULT)
+})
+
+test('Invalid: quote metadata - missing fields', async () => {
+  const document = {...BASE_DOCUMENT, metadata: {quote: {}}}
+  const validation = await validateAppDataDocument(document)
+
+  expect(validation.result).toBeFalsy()
+})
+
+test('Invalid: quote metadata - wrong type', async () => {
+  const document = {...BASE_DOCUMENT, metadata: {quote: {sellAmount: 312, buyAmount: '0xbab3'}}}
+  const validation = await validateAppDataDocument(document)
+
+  expect(validation.result).toBeFalsy()
 })

--- a/src/utils/appData.spec.ts
+++ b/src/utils/appData.spec.ts
@@ -116,28 +116,28 @@ test('Valid IPFS appData from CID', async () => {
 })
 
 test('Valid: quote metadata - minimal', async () => {
-  const document = {...BASE_DOCUMENT, metadata: {quote: {sellAmount: '1', buyAmount: '1'}}}
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { sellAmount: '1', buyAmount: '1' } } }
   const validation = await validateAppDataDocument(document)
 
   expect(validation).toEqual(VALID_RESULT)
 })
 
 test('Valid: quote metadata - with all fields', async () => {
-  const document = {...BASE_DOCUMENT, metadata: {quote: {sellAmount: '1', buyAmount: '1', id: 'S09D8ZFAX'}}}
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { sellAmount: '1', buyAmount: '1', id: 'S09D8ZFAX' } } }
   const validation = await validateAppDataDocument(document)
 
   expect(validation).toEqual(VALID_RESULT)
 })
 
 test('Invalid: quote metadata - missing fields', async () => {
-  const document = {...BASE_DOCUMENT, metadata: {quote: {}}}
+  const document = { ...BASE_DOCUMENT, metadata: { quote: {} } }
   const validation = await validateAppDataDocument(document)
 
   expect(validation.result).toBeFalsy()
 })
 
 test('Invalid: quote metadata - wrong type', async () => {
-  const document = {...BASE_DOCUMENT, metadata: {quote: {sellAmount: 312, buyAmount: '0xbab3'}}}
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { sellAmount: 312, buyAmount: '0xbab3' } } }
   const validation = await validateAppDataDocument(document)
 
   expect(validation.result).toBeFalsy()


### PR DESCRIPTION
# Summary

Part of https://github.com/cowprotocol/cowswap/issues/332

Adding quote metadata as defined on [this doc](https://docs.google.com/document/d/1N8K-ueKxxuuFfKjnegbPUYx30Qk1H8zjeiLo3jg-X14/edit#)

In summary there's a new metadata key that we'll use to track original quote information with every order

Added the types, schema and unit tests