### PR TITLE
Remove ESlint warnings

### DIFF
--- a/src/api/cow/errors/OperatorError.ts
+++ b/src/api/cow/errors/OperatorError.ts
@@ -6,7 +6,7 @@ type ApiActionType = 'get' | 'create' | 'delete'
 export interface ApiErrorObject {
   errorType: ApiErrorCodes
   description: string
-  data?: any
+  data?: unknown
 }
 
 // Conforms to backend API
@@ -137,6 +137,6 @@ export default class OperatorError extends CowError {
   }
 }
 
-export function isValidOperatorError(error: any): error is OperatorError {
+export function isValidOperatorError(error: unknown): error is OperatorError {
   return error instanceof OperatorError
 }

--- a/src/api/cow/errors/QuoteError.ts
+++ b/src/api/cow/errors/QuoteError.ts
@@ -5,7 +5,7 @@ import { ApiErrorCodes, ApiErrorObject } from './OperatorError'
 export interface GpQuoteErrorObject {
   errorType: GpQuoteErrorCodes
   description: string
-  data?: any
+  data?: unknown
 }
 
 // Conforms to backend API
@@ -61,7 +61,7 @@ export default class GpQuoteError extends CowError {
   name = 'QuoteErrorObject'
   description: string
   // any data attached
-  data?: any
+  data?: unknown
 
   // Status 400 errors
   // https://github.com/gnosis/gp-v2-services/blob/9014ae55412a356e46343e051aefeb683cc69c41/orderbook/openapi.yml#L563
@@ -110,6 +110,6 @@ export default class GpQuoteError extends CowError {
   }
 }
 
-export function isValidQuoteError(error: any): error is GpQuoteError {
+export function isValidQuoteError(error: unknown): error is GpQuoteError {
   return error instanceof GpQuoteError
 }

--- a/src/api/cow/index.ts
+++ b/src/api/cow/index.ts
@@ -64,7 +64,7 @@ const UNHANDLED_ORDER_ERROR: ApiErrorObject = {
   description: ApiErrorCodeDetails.UNHANDLED_CREATE_ERROR,
 }
 
-async function _handleQuoteResponse<T = any, P extends QuoteQuery = QuoteQuery>(
+async function _handleQuoteResponse<T = unknown, P extends QuoteQuery = QuoteQuery>(
   response: Response,
   params?: P
 ): Promise<T> {
@@ -337,7 +337,7 @@ export class CowApi {
     }
   }
 
-  private async fetch(url: string, method: 'GET' | 'POST' | 'DELETE', data?: any): Promise<Response> {
+  private async fetch(url: string, method: 'GET' | 'POST' | 'DELETE', data?: unknown): Promise<Response> {
     const baseUrl = await this.getApiBaseUrl()
     return fetch(baseUrl + url, {
       headers: this.DEFAULT_HEADERS,
@@ -346,7 +346,7 @@ export class CowApi {
     })
   }
 
-  private async fetchProfile(url: string, method: 'GET' | 'POST' | 'DELETE', data?: any): Promise<Response> {
+  private async fetchProfile(url: string, method: 'GET' | 'POST' | 'DELETE', data?: unknown): Promise<Response> {
     const baseUrl = await this.getProfileApiBaseUrl()
     return fetch(baseUrl + url, {
       headers: this.DEFAULT_HEADERS,
@@ -355,7 +355,7 @@ export class CowApi {
     })
   }
 
-  private post(url: string, data: any): Promise<Response> {
+  private post(url: string, data: unknown): Promise<Response> {
     return this.fetch(url, 'POST', data)
   }
 
@@ -367,7 +367,7 @@ export class CowApi {
     return this.fetchProfile(url, 'GET')
   }
 
-  private delete(url: string, data: any): Promise<Response> {
+  private delete(url: string, data: unknown): Promise<Response> {
     return this.fetch(url, 'DELETE', data)
   }
 }

--- a/src/utils/appData.spec.ts
+++ b/src/utils/appData.spec.ts
@@ -100,8 +100,9 @@ test('Invalid: serialized appData CID format ', async () => {
   const invalidHash = '0xa6c81f4ca727252a05b108f1742'
   try {
     await getSerializedCID(invalidHash)
-  } catch (e: any) {
-    expect(e.message).toEqual(INVALID_CID_LENGTH)
+  } catch (e: unknown) {
+    const error = e as Error
+    expect(error.message).toEqual(INVALID_CID_LENGTH)
   }
 })
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -7,7 +7,7 @@ export class CowError extends Error {
   }
 }
 
-export function objectToQueryString(o: any): string {
+export function objectToQueryString(o: { [key: string]: string | number | undefined }): string {
   if (!o) {
     return ''
   }
@@ -17,7 +17,7 @@ export function objectToQueryString(o: any): string {
   for (const key of Object.keys(o)) {
     const value = o[key]
     if (value) {
-      qs.append(key, value)
+      qs.append(key, value.toString())
     }
   }
 

--- a/src/utils/sign.ts
+++ b/src/utils/sign.ts
@@ -127,15 +127,16 @@ async function _signOrderCancellation(params: SingOrderCancellationParams): Prom
   return signOrderCancellationGp(domain, orderId, signer, getSigningSchemeLibValue(signingScheme))
 }
 
-export type SigningResult = { signature: string; signingScheme: SigningScheme }
+export type SigningResult = { signature?: string; signingScheme: SigningScheme }
 
 async function _signPayload(
-  payload: any,
-  signFn: typeof _signOrder | typeof _signOrderCancellation,
+  payload: Pick<SignOrderParams, 'order' & 'chainId'> | Pick<SingOrderCancellationParams, 'chainId' & 'orderId'>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  signFn: (params: any) => Promise<Signature>,
   signer: Signer,
   signingMethod: 'v4' | 'int_v4' | 'v3' | 'eth_sign' = 'v4'
 ): Promise<SigningResult> {
-  const signingScheme = signingMethod === 'eth_sign' ? SigningScheme.ETHSIGN : SigningScheme.EIP712
+  const signingScheme: SigningScheme = signingMethod === 'eth_sign' ? SigningScheme.ETHSIGN : SigningScheme.EIP712
   let signature: Signature | null = null
 
   let _signer
@@ -194,7 +195,7 @@ async function _signPayload(
       return _signPayload(payload, signFn, signer, 'eth_sign')
     }
   }
-  return { signature: signature!.data.toString(), signingScheme }
+  return { signature: signature?.data.toString(), signingScheme }
 }
 /**
  * Returns the signature for the specified order with the signing scheme encoded


### PR DESCRIPTION
This PR closes #10 

Removed ESlint warnings by updating data types.

--
There's only one `any` type in `_signPayload` function that I was not able to get rid out so I commented the line. The thing is we could receive two different functions in `signFn` param with different payload data, which causes typing mismatch. 