### PR TITLE
Cowswap332/fix ipfs uploading

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,4 +13,5 @@ export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 export const DEFAULT_APP_DATA_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000'
 
-export const DEFAULT_IPFS_GATEWAY_URI = 'https://gnosis.mypinata.cloud/ipfs'
+export const DEFAULT_IPFS_READ_URI = 'https://gnosis.mypinata.cloud/ipfs'
+export const DEFAULT_IPFS_WRITE_URI = 'https://api.pinata.cloud'

--- a/src/schemas/appData.schema.json
+++ b/src/schemas/appData.schema.json
@@ -77,7 +77,7 @@
       },
       "quote": {
         "$id": "#/definitions/quote",
-        "required": ["sellAmount", "buyAmount"],
+        "required": ["sellAmount", "buyAmount", "version"],
         "title": "Quote",
         "type": "object",
         "properties": {
@@ -94,6 +94,9 @@
           "buyAmount": {
             "$ref": "#/definitions/bigNumber",
             "title": "Quote buy amount"
+          },
+          "version": {
+            "$ref": "#/definitions/version"
           }
         }
       }

--- a/src/utils/appData.spec.ts
+++ b/src/utils/appData.spec.ts
@@ -117,14 +117,17 @@ test('Valid IPFS appData from CID', async () => {
 })
 
 test('Valid: quote metadata - minimal', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { sellAmount: '1', buyAmount: '1' } } }
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { sellAmount: '1', buyAmount: '1', version: '0.1.0' } } }
   const validation = await validateAppDataDocument(document)
 
   expect(validation).toEqual(VALID_RESULT)
 })
 
 test('Valid: quote metadata - with all fields', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { sellAmount: '1', buyAmount: '1', id: 'S09D8ZFAX' } } }
+  const document = {
+    ...BASE_DOCUMENT,
+    metadata: { quote: { sellAmount: '1', buyAmount: '1', id: 'S09D8ZFAX', version: '0.1.0' } },
+  }
   const validation = await validateAppDataDocument(document)
 
   expect(validation).toEqual(VALID_RESULT)

--- a/src/utils/appData.ts
+++ b/src/utils/appData.ts
@@ -1,6 +1,6 @@
 import Ajv, { ValidateFunction } from 'ajv'
 import { fromHexString } from './common'
-import { DEFAULT_IPFS_GATEWAY_URI } from '../constants'
+import { DEFAULT_IPFS_READ_URI } from '../constants'
 import { AppDataDoc } from '../types'
 
 let validate: ValidateFunction | undefined
@@ -40,7 +40,7 @@ export async function getSerializedCID(hash: string): Promise<void | string> {
   return CID.decode(uint8array).toV0().toString()
 }
 
-export async function loadIpfsFromCid(cid: string, ipfsUri = DEFAULT_IPFS_GATEWAY_URI): Promise<AppDataDoc> {
+export async function loadIpfsFromCid(cid: string, ipfsUri = DEFAULT_IPFS_READ_URI): Promise<AppDataDoc> {
   const { default: fetch } = await import('cross-fetch')
   const response = await fetch(`${ipfsUri}/${cid}`)
 

--- a/src/utils/context.spec.ts
+++ b/src/utils/context.spec.ts
@@ -1,0 +1,51 @@
+import { Context } from './context'
+import { VoidSigner } from '@ethersproject/abstract-signer'
+import { Provider } from '@ethersproject/providers'
+
+test('Context: update chainId', async () => {
+  const context = new Context(1, {})
+  let chainId = await context.chainId
+  expect(chainId).toEqual(1)
+
+  // works
+  chainId = await context.updateChainId(4)
+  expect(chainId).toEqual(4)
+})
+
+test('Context: update chainId fails', () => {
+  const context = new Context(1, {})
+
+  expect(() => {
+    context.updateChainId(123)
+  }).toThrow('Invalid chainId: 123')
+})
+
+test('Context: get chainId from provider - matches context', async () => {
+  const mockProvider = jest.fn<Provider, []>()
+  const provider = new mockProvider()
+  provider.getNetwork = jest.fn(async () => ({ chainId: 1, name: 'bla' }))
+
+  const signer = new VoidSigner('', provider)
+
+  const context = new Context(1, { signer })
+
+  const chainId = await context.chainId
+
+  expect(chainId).toEqual(1)
+  expect(provider.getNetwork).toHaveBeenCalledTimes(1)
+})
+
+test('Context: get chainId from provider - differs from context', async () => {
+  const mockProvider = jest.fn<Provider, []>()
+  const provider = new mockProvider()
+  provider.getNetwork = jest.fn(async () => ({ chainId: 100, name: 'bla' }))
+
+  const signer = new VoidSigner('', provider)
+
+  const context = new Context(1, { signer })
+
+  const chainId = await context.chainId
+
+  expect(chainId).toEqual(100)
+  expect(provider.getNetwork).toHaveBeenCalledTimes(1)
+})

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -43,7 +43,14 @@ export class Context implements Partial<CowContext> {
 
   constructor(chainId: ChainId, context: CowContext) {
     this.#chainId = this.updateChainId(chainId)
-    this.#context = { ...DefaultCowContext, ...context }
+    this.#context = {
+      ...DefaultCowContext,
+      ...context,
+      ipfs: {
+        ...DefaultCowContext.ipfs,
+        ...context.ipfs,
+      },
+    }
   }
 
   updateChainId(chainId: ChainId) {

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -2,10 +2,12 @@ import { Signer } from 'ethers'
 import log from 'loglevel'
 import { CowError, logPrefix } from './common'
 import { SupportedChainId as ChainId } from '../constants/chains'
-import { DEFAULT_APP_DATA_HASH, DEFAULT_IPFS_GATEWAY_URI } from '../constants'
+import { DEFAULT_APP_DATA_HASH, DEFAULT_IPFS_READ_URI, DEFAULT_IPFS_WRITE_URI } from '../constants'
 
 export interface Ipfs {
   uri?: string
+  writeUri?: string
+  readUri?: string
   pinataApiKey?: string
   pinataApiSecret?: string
 }
@@ -21,7 +23,8 @@ export const DefaultCowContext = {
   appDataHash: DEFAULT_APP_DATA_HASH,
   isDevEnvironment: false,
   ipfs: {
-    uri: DEFAULT_IPFS_GATEWAY_URI,
+    readUri: DEFAULT_IPFS_READ_URI,
+    writeUri: DEFAULT_IPFS_WRITE_URI,
     apiKey: undefined,
     apiSecret: undefined,
   },

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -1,6 +1,7 @@
 import { CowError } from './common'
 import { Ipfs } from './context'
 import { AppDataDoc } from '../api/metadata/types'
+import { DEFAULT_IPFS_WRITE_URI } from '../constants'
 
 type PinataPinResponse = {
   IpfsHash: string
@@ -10,7 +11,7 @@ type PinataPinResponse = {
 
 export async function pinJSONToIPFS(
   file: unknown,
-  { uri, pinataApiKey = '', pinataApiSecret = '' }: Ipfs
+  { writeUri = DEFAULT_IPFS_WRITE_URI, pinataApiKey = '', pinataApiSecret = '' }: Ipfs
 ): Promise<PinataPinResponse> {
   const { default: fetch } = await import('cross-fetch')
 
@@ -23,7 +24,7 @@ export async function pinJSONToIPFS(
     pinataMetadata: { name: 'appData-affiliate' },
   })
 
-  const pinataUrl = `${uri}/pinning/pinJSONToIPFS`
+  const pinataUrl = `${writeUri}/pinning/pinJSONToIPFS`
 
   const response = await fetch(pinataUrl, {
     method: 'POST',

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -21,7 +21,7 @@ export async function pinJSONToIPFS(
 
   const body = JSON.stringify({
     pinataContent: file,
-    pinataMetadata: { name: 'appData-affiliate' },
+    pinataMetadata: { name: 'appData' },
   })
 
   const pinataUrl = `${writeUri}/pinning/pinJSONToIPFS`


### PR DESCRIPTION
# Summary

Part of https://github.com/cowprotocol/cowswap/issues/332

Fixing 2 main issues:
- Ipfs uri set to undefined - default was overwritten in the constructor
- Split uri into read and write - because there's a different endpoint for each

Also:
- Updated pinned file name to `appData` - no longer only affiliate related
- Added `version` field as part of `quote` schema

# Testing

- Unit tests
- Also tested it locally on CowSwap using `yalc`