### PR TITLE
Add orderId param to getTrades method

### DIFF
--- a/src/api/cow/cow.spec.ts
+++ b/src/api/cow/cow.spec.ts
@@ -281,6 +281,19 @@ test('Valid: Get last 5 trades for a given order id ', async () => {
   expect(trades.length).toEqual(5)
 })
 
+test('Invalid: Get trades passing both the owner and orderId', async () => {
+  await expect(
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cowSdk.cowApi.getTrades({
+      owner: TRADE_RESPONSE.owner,
+      orderId: TRADE_RESPONSE.orderUid,
+      limit: 5,
+      offset: 0,
+    })
+  ).rejects.toThrowError(CowError)
+})
+
 test('Invalid: Get last 5 trades for an unexisting trader ', async () => {
   fetchMock.mockResponseOnce(
     JSON.stringify({

--- a/src/api/cow/cow.spec.ts
+++ b/src/api/cow/cow.spec.ts
@@ -283,8 +283,7 @@ test('Valid: Get last 5 trades for a given order id ', async () => {
 
 test('Invalid: Get trades passing both the owner and orderId', async () => {
   await expect(
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error both owner and orderId can't be passed at the same time
     cowSdk.cowApi.getTrades({
       owner: TRADE_RESPONSE.owner,
       orderId: TRADE_RESPONSE.orderUid,

--- a/src/api/cow/cow.spec.ts
+++ b/src/api/cow/cow.spec.ts
@@ -265,6 +265,22 @@ test('Valid: Get last 5 trades for a given trader ', async () => {
   expect(trades.length).toEqual(5)
 })
 
+test('Valid: Get last 5 trades for a given order id ', async () => {
+  const TRADES_RESPONSE = Array(5).fill(TRADE_RESPONSE)
+  fetchMock.mockResponseOnce(JSON.stringify(TRADES_RESPONSE), { status: HTTP_STATUS_OK })
+  const trades = await cowSdk.cowApi.getTrades({
+    orderId: TRADE_RESPONSE.orderUid,
+    limit: 5,
+    offset: 0,
+  })
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+  expect(fetchMock).toHaveBeenCalledWith(
+    `https://api.cow.fi/rinkeby/api/v1/trades?orderUid=${TRADE_RESPONSE.orderUid}&limit=5`,
+    FETCH_RESPONSE_PARAMETERS
+  )
+  expect(trades.length).toEqual(5)
+})
+
 test('Invalid: Get last 5 trades for an unexisting trader ', async () => {
   fetchMock.mockResponseOnce(
     JSON.stringify({

--- a/src/api/cow/index.ts
+++ b/src/api/cow/index.ts
@@ -127,10 +127,13 @@ export class CowApi {
   }
 
   async getTrades(params: GetTradesParams): Promise<TradeMetaData[]> {
-    const { owner, limit, offset } = params
-    const qsParams = objectToQueryString({ owner, limit, offset })
+    const { owner, orderId, limit, offset } = params
+    if (owner && orderId) {
+      throw new CowError('Cannot specify both owner and orderId')
+    }
+    const qsParams = objectToQueryString({ owner, orderUid: orderId, limit, offset })
     const chainId = await this.context.chainId
-    log.debug(logPrefix, '[util:operator] Get trades for', chainId, owner, { limit, offset })
+    log.debug(logPrefix, '[util:operator] Get trades for', chainId, { owner, orderId, limit, offset })
     try {
       const response = await this.get(`/trades${qsParams}`)
 

--- a/src/api/cow/types.ts
+++ b/src/api/cow/types.ts
@@ -70,13 +70,15 @@ export type GetOrdersParams = {
   owner: string
 } & PaginationParams
 
-export type GetTradesParams = StrictUnion<
-  | {
-      owner: string
-    }
-  | { orderId: string }
-> &
-  PaginationParams
+type WithOwner = {
+  owner: string
+}
+
+type WithOrderId = {
+  orderId: string
+}
+
+export type GetTradesParams = StrictUnion<WithOwner | WithOrderId> & PaginationParams
 
 export type ProfileData = {
   totalTrades: number

--- a/src/api/cow/types.ts
+++ b/src/api/cow/types.ts
@@ -1,4 +1,5 @@
 import { GetQuoteResponse, OrderKind } from '@gnosis.pm/gp-v2-contracts'
+import { StrictUnion } from 'utilities'
 import { SupportedChainId as ChainId } from '../../constants/chains'
 import { OrderCancellation, SigningSchemeValue } from '../../utils/sign'
 
@@ -69,9 +70,13 @@ export type GetOrdersParams = {
   owner: string
 } & PaginationParams
 
-export type GetTradesParams = {
-  owner: string
-} & PaginationParams
+export type GetTradesParams = StrictUnion<
+  | {
+      owner: string
+    }
+  | { orderId: string }
+> &
+  PaginationParams
 
 export type ProfileData = {
   totalTrades: number

--- a/src/types/utilities.d.ts
+++ b/src/types/utilities.d.ts
@@ -1,3 +1,5 @@
 type UnionKeys<T> = T extends T ? keyof T : never
-type StrictUnionHelper<T, TAll> = T extends any ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>> : never
+type StrictUnionHelper<T, TAll> = T extends unknown
+  ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>>
+  : never
 export type StrictUnion<T> = StrictUnionHelper<T, T>

--- a/src/types/utilities.d.ts
+++ b/src/types/utilities.d.ts
@@ -1,0 +1,3 @@
+type UnionKeys<T> = T extends T ? keyof T : never
+type StrictUnionHelper<T, TAll> = T extends any ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>> : never
+export type StrictUnion<T> = StrictUnionHelper<T, T>


### PR DESCRIPTION
The orderId param was left behind and it was never added to the getTrades method, to [simplify things](https://github.com/cowprotocol/explorer/blob/35-epic-home-page/src/api/operator/operatorApi.ts#L161) on the Explorer we need this change

Would fix https://github.com/cowprotocol/explorer/issues/118