### PR TITLE
322/quote id on price information types

### DIFF
--- a/src/api/cow/types.ts
+++ b/src/api/cow/types.ts
@@ -116,6 +116,7 @@ export type SimpleGetQuoteResponse = Pick<GetQuoteResponse, 'from'> & {
     feeAmount: string
   }
   expiration: string
+  id: number | null
 }
 
 export type FeeQuoteParams = Pick<OrderMetaData, 'sellToken' | 'buyToken' | 'kind'> & {

--- a/src/api/cow/types.ts
+++ b/src/api/cow/types.ts
@@ -103,6 +103,7 @@ export interface FeeInformation {
 export interface PriceInformation {
   token: string
   amount: string | null
+  quoteId?: number
 }
 
 // GetQuoteResponse from @cowprotocol/contracts types Timestamp and BigNumberish


### PR DESCRIPTION
# Summary

- Added `id` to quote response
- Added `quoteId` to Price information

# Testing

Tested using `yalc` on cowswap