### PR TITLE
322/simplify quote metadata

### DIFF
--- a/src/api/metadata/index.ts
+++ b/src/api/metadata/index.ts
@@ -6,7 +6,7 @@ import { AppDataDoc, IpfsHashInfo, MetadataDoc, OptionalAppDataProperties } from
 import { CowError } from '../../utils/common'
 
 const DEFAULT_APP_CODE = 'CowSwap'
-const DEFAULT_APP_VERSION = '0.3.0'
+const DEFAULT_APP_VERSION = '0.4.0'
 
 export class MetadataApi {
   context: Context

--- a/src/api/metadata/metadata.spec.ts
+++ b/src/api/metadata/metadata.spec.ts
@@ -13,14 +13,14 @@ const HTTP_STATUS_OK = 200
 const HTTP_STATUS_INTERNAL_ERROR = 500
 
 const DEFAULT_APP_DATA_DOC = {
-  version: '0.3.0',
+  version: '0.4.0',
   appCode: 'CowSwap',
   environment: 'test',
   metadata: {},
 }
 
-const IPFS_HASH = 'QmZ1nPa5NkbHaSoH7EZk3xJHWpGMWshPAQPjLZeS7QGzxw'
-const APP_DATA_HEX = '0x9e9b34814745a905b59a56c15242381e6297fb5a2a63732a225defd7c066e6f8'
+const IPFS_HASH = 'QmRoosA9VFaZVPxBk9k9jhPGGmCAcLMeDP8L2Dd2RbjNv2'
+const APP_DATA_HEX = '0x3388186d8f802360e78ee4d57d489678a01c3ce922b1e0078eeb45c8f084b7e7'
 
 const PINATA_API_KEY = 'apikey'
 const PINATA_API_SECRET = 'apiSecret'

--- a/src/api/metadata/types.ts
+++ b/src/api/metadata/types.ts
@@ -1,17 +1,29 @@
-interface Metadata {
+type Metadata = {
   version: string
 }
 
-export interface ReferralMetadata extends Metadata {
+export type ReferralMetadata = Metadata & {
   address: string
 }
 
-export interface QuoteMetadata extends Metadata {
-  id?: string
-  sellAmount?: string
-  buyAmount?: string
-  slippageInBips?: string
+export type OnlyQuoteAmounts = {
+  sellAmount: string
+  buyAmount: string
+  slippageInBips?: never
 }
+
+export type OnlyQuoteSlippage = {
+  sellAmount?: never
+  buyAmount?: never
+  slippageInBips: string
+}
+
+export type OnlyQuoteAmountsOrSlippage = OnlyQuoteAmounts | OnlyQuoteSlippage
+
+export type QuoteMetadata = Metadata &
+  OnlyQuoteAmountsOrSlippage & {
+    id?: string
+  }
 
 export type MetadataDoc = {
   referrer?: ReferralMetadata

--- a/src/api/metadata/types.ts
+++ b/src/api/metadata/types.ts
@@ -8,8 +8,8 @@ export interface ReferralMetadata extends Metadata {
 
 export interface QuoteMetadata extends Metadata {
   id?: string
-  sellAmount: string
-  buyAmount: string
+  sellAmount?: string
+  buyAmount?: string
   slippageInBips?: string
 }
 

--- a/src/api/metadata/types.ts
+++ b/src/api/metadata/types.ts
@@ -10,6 +10,7 @@ export interface QuoteMetadata extends Metadata {
   id?: string
   sellAmount: string
   buyAmount: string
+  slippageInBips?: string
 }
 
 export type MetadataDoc = {

--- a/src/api/metadata/types.ts
+++ b/src/api/metadata/types.ts
@@ -9,13 +9,13 @@ export type ReferralMetadata = Metadata & {
 export type OnlyQuoteAmounts = {
   sellAmount: string
   buyAmount: string
-  slippageInBips?: never
+  slippageBips?: never
 }
 
 export type OnlyQuoteSlippage = {
   sellAmount?: never
   buyAmount?: never
-  slippageInBips: string
+  slippageBips: string
 }
 
 export type OnlyQuoteAmountsOrSlippage = OnlyQuoteAmounts | OnlyQuoteSlippage

--- a/src/schemas/appData.schema.json
+++ b/src/schemas/appData.schema.json
@@ -117,6 +117,10 @@
           "sellAmount": ["buyAmount"],
           "buyAmount": ["sellAmount"]
         },
+        "oneOf": [
+          {"required": ["slippageInBips"]},
+          {"required": ["sellAmount"]}
+        ]
       }
     }
   }

--- a/src/schemas/appData.schema.json
+++ b/src/schemas/appData.schema.json
@@ -107,8 +107,8 @@
           "version": {
             "$ref": "#/definitions/version"
           },
-          "slippageInBips": {
-            "$id": "#/definitions/quote/slippageInBips",
+          "slippageBips": {
+            "$id": "#/definitions/quote/slippageBips",
             "title": "Slippage percentage stored in Basis Points (BIPS)",
             "examples": ["5", "10", "20", "100"],
             "pattern": "^\\d+(\\.\\d+)?$",
@@ -120,7 +120,7 @@
           "buyAmount": ["sellAmount"]
         },
         "oneOf": [
-          {"required": ["slippageInBips"]},
+          {"required": ["slippageBips"]},
           {"required": ["sellAmount"]}
         ]
       }

--- a/src/schemas/appData.schema.json
+++ b/src/schemas/appData.schema.json
@@ -112,7 +112,11 @@
             "pattern": "^\\d+(\\.\\d+)?$",
             "type": "string"
           }
-        }
+        },
+        "dependencies": {
+          "sellAmount": ["buyAmount"],
+          "buyAmount": ["sellAmount"]
+        },
       }
     }
   }

--- a/src/schemas/appData.schema.json
+++ b/src/schemas/appData.schema.json
@@ -61,7 +61,7 @@
     },
     "bigNumber": {
       "$id": "#/definitions/bigNumber",
-      "pattern": "\\d+",
+      "pattern": "^\\d+$",
       "title": "BigNumber",
       "examples": ["90741097240912730913, 0, 75891372"],
       "type": "string"

--- a/src/schemas/appData.schema.json
+++ b/src/schemas/appData.schema.json
@@ -96,11 +96,13 @@
           },
           "sellAmount": {
             "$ref": "#/definitions/bigNumber",
-            "title": "Quote sell amount"
+            "title": "Quote sell amount",
+            "deprecated": true
           },
           "buyAmount": {
             "$ref": "#/definitions/bigNumber",
-            "title": "Quote buy amount"
+            "title": "Quote buy amount",
+            "deprecated": true
           },
           "version": {
             "$ref": "#/definitions/version"

--- a/src/schemas/appData.schema.json
+++ b/src/schemas/appData.schema.json
@@ -104,6 +104,13 @@
           },
           "version": {
             "$ref": "#/definitions/version"
+          },
+          "slippageInBips": {
+            "$id": "#/definitions/quote/slippageInBips",
+            "title": "Slippage percentage stored in Basis Points (BIPS)",
+            "examples": ["5", "10", "20", "100"],
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "type": "string"
           }
         }
       }

--- a/src/schemas/appData.schema.json
+++ b/src/schemas/appData.schema.json
@@ -84,7 +84,7 @@
       },
       "quote": {
         "$id": "#/definitions/quote",
-        "required": ["sellAmount", "buyAmount", "version"],
+        "required": ["version"],
         "title": "Quote",
         "type": "object",
         "properties": {

--- a/src/schemas/appData.schema.json
+++ b/src/schemas/appData.schema.json
@@ -109,7 +109,7 @@
           },
           "slippageBips": {
             "$id": "#/definitions/quote/slippageBips",
-            "title": "Slippage percentage stored in Basis Points (BIPS)",
+            "title": "Slippage tolerance that was applied to the order to get the limit price. Expressed in Basis Points (BIPS)",
             "examples": ["5", "10", "20", "100"],
             "pattern": "^\\d+(\\.\\d+)?$",
             "type": "string"

--- a/src/utils/appData.spec.ts
+++ b/src/utils/appData.spec.ts
@@ -134,14 +134,14 @@ test('Valid: quote metadata - amounts - with quoteId', async () => {
 })
 
 test('Valid: quote metadata - slippage', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageInBips: '5' } } }
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageBips: '5' } } }
   const validation = await validateAppDataDocument(document)
 
   expect(validation).toEqual(VALID_RESULT)
 })
 
 test('Valid: quote metadata - slippage - decimals', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageInBips: '0.1' } } }
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageBips: '0.1' } } }
   const validation = await validateAppDataDocument(document)
 
   expect(validation).toEqual(VALID_RESULT)
@@ -162,7 +162,7 @@ test('Invalid: quote metadata - wrong amount type', async () => {
 })
 
 test('Invalid: quote metadata - wrong slippage amount', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageInBips: '.1' } } }
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageBips: '.1' } } }
   const validation = await validateAppDataDocument(document)
 
   expect(validation.result).toBeFalsy()

--- a/src/utils/appData.spec.ts
+++ b/src/utils/appData.spec.ts
@@ -116,14 +116,14 @@ test('Valid IPFS appData from CID', async () => {
   expect(validation).toEqual(VALID_RESULT)
 })
 
-test('Valid: quote metadata - minimal', async () => {
+test('Valid: quote metadata - amounts', async () => {
   const document = { ...BASE_DOCUMENT, metadata: { quote: { sellAmount: '1', buyAmount: '1', version: '0.1.0' } } }
   const validation = await validateAppDataDocument(document)
 
   expect(validation).toEqual(VALID_RESULT)
 })
 
-test('Valid: quote metadata - with all fields', async () => {
+test('Valid: quote metadata - amounts - with quoteId', async () => {
   const document = {
     ...BASE_DOCUMENT,
     metadata: { quote: { sellAmount: '1', buyAmount: '1', id: 'S09D8ZFAX', version: '0.1.0' } },
@@ -133,15 +133,50 @@ test('Valid: quote metadata - with all fields', async () => {
   expect(validation).toEqual(VALID_RESULT)
 })
 
+test('Valid: quote metadata - slippage', async () => {
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageInBips: '5' } } }
+  const validation = await validateAppDataDocument(document)
+
+  expect(validation).toEqual(VALID_RESULT)
+})
+
+test('Valid: quote metadata - slippage - decimals', async () => {
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageInBips: '0.1' } } }
+  const validation = await validateAppDataDocument(document)
+
+  expect(validation).toEqual(VALID_RESULT)
+})
+
 test('Invalid: quote metadata - missing fields', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: {} } }
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.2' } } }
   const validation = await validateAppDataDocument(document)
 
   expect(validation.result).toBeFalsy()
 })
 
-test('Invalid: quote metadata - wrong type', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { sellAmount: 312, buyAmount: '0xbab3' } } }
+test('Invalid: quote metadata - wrong amount type', async () => {
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', sellAmount: 312, buyAmount: '0xbab3' } } }
+  const validation = await validateAppDataDocument(document)
+
+  expect(validation.result).toBeFalsy()
+})
+
+test('Invalid: quote metadata - wrong slippage amount', async () => {
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageInBips: '.1' } } }
+  const validation = await validateAppDataDocument(document)
+
+  expect(validation.result).toBeFalsy()
+})
+
+test('Invalid: quote metadata - amount missing buyAmount type', async () => {
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { sellAmount: 312 } } }
+  const validation = await validateAppDataDocument(document)
+
+  expect(validation.result).toBeFalsy()
+})
+
+test('Invalid: quote metadata - amount missing sellAmount type', async () => {
+  const document = { ...BASE_DOCUMENT, metadata: { quote: { buyAmount: 312 } } }
   const validation = await validateAppDataDocument(document)
 
   expect(validation.result).toBeFalsy()


### PR DESCRIPTION
# Summary

Waterfalls into https://github.com/cowprotocol/cow-sdk/pull/39

Based on a recent discussion, moving away from storing `sellAmount` and `buyAmount` on `quote` metadata in favor of storing only the `slippageInBips`.

This change should reduce significantly the number of IPFS docs we need to store, given that most users will have similar slippage settings.

# Testing

Unit tests