### PR TITLE
SDK improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import { CowSdk, OrderKind } from 'cow-sdk'
 // 1. Instantiate wallet and SDK
 const mnemonic = 'fall dirt bread cactus...'
 const wallet = Wallet.fromMnemonic(mnemonic)
-const cowSdk = new CowSdk(4, { signer: wallet })
+const cowSdk = new CowSdk(4, { signer: wallet }) // Leaving chainId empty will default to MAINNET
 
 // 2. Get a price/fee quote from the API
 //    It will return the price and fee to "Sell 1 ETH for USDC"
@@ -96,6 +96,15 @@ const orderId = await cowSdk.cowApi.sendOrder({
 
 // We can inspect the Order details in the CoW Protocol Explorer
 console.log(`https://explorer.cow.fi/rinkeby/orders/${orderId}`)
+
+// You can also override defaults params when using CowApi methods
+const orderId = await cowSdk.cowApi.sendOrder(
+  {
+    order: { ...order, ...signedOrder },
+    owner: '0x1811be0994930fe9480eaede25165608b093ad7a',
+  },
+  { chainId: 1, isDevEnvironment: false }
+)
 ```
 
 SDK also includes a Metadata API to interact with AppData documents and IPFS CIDs
@@ -188,10 +197,11 @@ const chainId = 1 // Mainnet
 const cowSdk = new CowSdk(chainId)
 
 // Get Cow Protocol totals
-const { tokens, orders, traders, settlements, volumeUsd, volumeEth, feesUsd, feesEth } = await cowSdk.cowSubgraphApi.getTotals()
+const { tokens, orders, traders, settlements, volumeUsd, volumeEth, feesUsd, feesEth } =
+  await cowSdk.cowSubgraphApi.getTotals()
 console.log({ tokens, orders, traders, settlements, volumeUsd, volumeEth, feesUsd, feesEth })
 
-// Get last 24 hours volume in usd 
+// Get last 24 hours volume in usd
 const { hourlyTotals } = await cowSdk.cowSubgraphApi.getLastHoursVolume(24)
 console.log(hourlyTotals)
 

--- a/src/CowSdk.ts
+++ b/src/CowSdk.ts
@@ -2,7 +2,7 @@ import { Signer } from 'ethers'
 import log, { LogLevelDesc } from 'loglevel'
 import { CowError } from './utils/common'
 import { CowApi, CowSubgraphApi, MetadataApi } from './api'
-import { SupportedChainId as ChainId } from './constants/chains'
+import { SupportedChainId as ChainId, SupportedChainId } from './constants/chains'
 import { validateAppDataDocument } from './utils/appData'
 import { Context, CowContext } from './utils/context'
 import { signOrder, signOrderCancellation, UnsignedOrder } from './utils/sign'
@@ -17,7 +17,7 @@ export class CowSdk<T extends ChainId> {
   metadataApi: MetadataApi
   cowSubgraphApi: CowSubgraphApi
 
-  constructor(chainId: T, cowContext: CowContext = {}, options: Options = {}) {
+  constructor(chainId: T = SupportedChainId.MAINNET as T, cowContext: CowContext = {}, options: Options = {}) {
     this.context = new Context(chainId, { ...cowContext })
     this.cowApi = new CowApi(this.context)
     this.cowSubgraphApi = new CowSubgraphApi(this.context)
@@ -27,6 +27,11 @@ export class CowSdk<T extends ChainId> {
 
   updateChainId = (chainId: ChainId) => {
     this.context.updateChainId(chainId)
+  }
+
+  updateContext = async (cowContext: CowContext, chainId?: ChainId) => {
+    const networkId = await this.context.chainId
+    this.context.updateContext(cowContext, chainId || networkId)
   }
 
   validateAppDataDocument = validateAppDataDocument

--- a/src/api/cow-subgraph/graphql.ts
+++ b/src/api/cow-subgraph/graphql.ts
@@ -456,8 +456,16 @@ export type Pair = {
   id: Scalars['ID'];
   /** The token 0 address lower than token1 */
   token0: Token;
+  /** Token0 last trade price */
+  token0Price?: Maybe<Scalars['BigDecimal']>;
+  /** Token 0 price expressed in token1 in the last trade */
+  token0relativePrice?: Maybe<Scalars['BigDecimal']>;
   /** The token 1 address greater than token0 */
   token1: Token;
+  /** Token1 last trade price */
+  token1Price?: Maybe<Scalars['BigDecimal']>;
+  /** Token 1 price expressed in token1 in the last trade */
+  token1relativePrice?: Maybe<Scalars['BigDecimal']>;
   /** Total volume of token 0 traded */
   volumeToken0?: Maybe<Scalars['BigInt']>;
   /** Total volume of token 1 traded */
@@ -476,8 +484,16 @@ export type PairDaily = {
   timestamp: Scalars['Int'];
   /** The token 0 address lower than token1 */
   token0: Token;
+  /** Token0 last trade price */
+  token0Price?: Maybe<Scalars['BigDecimal']>;
+  /** Token 0 price expressed in token1 in the last trade */
+  token0relativePrice?: Maybe<Scalars['BigDecimal']>;
   /** The token 1 address greater than token0 */
   token1: Token;
+  /** Token1 last trade price */
+  token1Price?: Maybe<Scalars['BigDecimal']>;
+  /** Token 1 price expressed in token1 in the last trade */
+  token1relativePrice?: Maybe<Scalars['BigDecimal']>;
   /** Total volume of token 0 traded */
   volumeToken0?: Maybe<Scalars['BigInt']>;
   /** Total volume of token 1 traded */
@@ -508,6 +524,14 @@ export type PairDaily_Filter = {
   timestamp_not?: InputMaybe<Scalars['Int']>;
   timestamp_not_in?: InputMaybe<Array<Scalars['Int']>>;
   token0?: InputMaybe<Scalars['String']>;
+  token0Price?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token0Price_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_not?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   token0_contains?: InputMaybe<Scalars['String']>;
   token0_contains_nocase?: InputMaybe<Scalars['String']>;
   token0_ends_with?: InputMaybe<Scalars['String']>;
@@ -527,7 +551,23 @@ export type PairDaily_Filter = {
   token0_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
   token0_starts_with?: InputMaybe<Scalars['String']>;
   token0_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  token0relativePrice?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token0relativePrice_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_not?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   token1?: InputMaybe<Scalars['String']>;
+  token1Price?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token1Price_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_not?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   token1_contains?: InputMaybe<Scalars['String']>;
   token1_contains_nocase?: InputMaybe<Scalars['String']>;
   token1_ends_with?: InputMaybe<Scalars['String']>;
@@ -547,6 +587,14 @@ export type PairDaily_Filter = {
   token1_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
   token1_starts_with?: InputMaybe<Scalars['String']>;
   token1_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  token1relativePrice?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token1relativePrice_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_not?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   volumeToken0?: InputMaybe<Scalars['BigInt']>;
   volumeToken0_gt?: InputMaybe<Scalars['BigInt']>;
   volumeToken0_gte?: InputMaybe<Scalars['BigInt']>;
@@ -585,7 +633,11 @@ export enum PairDaily_OrderBy {
   Id = 'id',
   Timestamp = 'timestamp',
   Token0 = 'token0',
+  Token0Price = 'token0Price',
+  Token0relativePrice = 'token0relativePrice',
   Token1 = 'token1',
+  Token1Price = 'token1Price',
+  Token1relativePrice = 'token1relativePrice',
   VolumeToken0 = 'volumeToken0',
   VolumeToken1 = 'volumeToken1',
   VolumeTradedEth = 'volumeTradedEth',
@@ -600,8 +652,16 @@ export type PairHourly = {
   timestamp: Scalars['Int'];
   /** The token 0 address lower than token1 */
   token0: Token;
+  /** Token0 last trade price */
+  token0Price?: Maybe<Scalars['BigDecimal']>;
+  /** Token 0 price expressed in token1 in the last trade */
+  token0relativePrice?: Maybe<Scalars['BigDecimal']>;
   /** The token 1 address greater than token0 */
   token1: Token;
+  /** Token1 last trade price */
+  token1Price?: Maybe<Scalars['BigDecimal']>;
+  /** Token 1 price expressed in token1 in the last trade */
+  token1relativePrice?: Maybe<Scalars['BigDecimal']>;
   /** Total volume of token 0 traded */
   volumeToken0?: Maybe<Scalars['BigInt']>;
   /** Total volume of token 1 traded */
@@ -632,6 +692,14 @@ export type PairHourly_Filter = {
   timestamp_not?: InputMaybe<Scalars['Int']>;
   timestamp_not_in?: InputMaybe<Array<Scalars['Int']>>;
   token0?: InputMaybe<Scalars['String']>;
+  token0Price?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token0Price_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_not?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   token0_contains?: InputMaybe<Scalars['String']>;
   token0_contains_nocase?: InputMaybe<Scalars['String']>;
   token0_ends_with?: InputMaybe<Scalars['String']>;
@@ -651,7 +719,23 @@ export type PairHourly_Filter = {
   token0_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
   token0_starts_with?: InputMaybe<Scalars['String']>;
   token0_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  token0relativePrice?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token0relativePrice_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_not?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   token1?: InputMaybe<Scalars['String']>;
+  token1Price?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token1Price_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_not?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   token1_contains?: InputMaybe<Scalars['String']>;
   token1_contains_nocase?: InputMaybe<Scalars['String']>;
   token1_ends_with?: InputMaybe<Scalars['String']>;
@@ -671,6 +755,14 @@ export type PairHourly_Filter = {
   token1_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
   token1_starts_with?: InputMaybe<Scalars['String']>;
   token1_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  token1relativePrice?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token1relativePrice_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_not?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   volumeToken0?: InputMaybe<Scalars['BigInt']>;
   volumeToken0_gt?: InputMaybe<Scalars['BigInt']>;
   volumeToken0_gte?: InputMaybe<Scalars['BigInt']>;
@@ -709,7 +801,11 @@ export enum PairHourly_OrderBy {
   Id = 'id',
   Timestamp = 'timestamp',
   Token0 = 'token0',
+  Token0Price = 'token0Price',
+  Token0relativePrice = 'token0relativePrice',
   Token1 = 'token1',
+  Token1Price = 'token1Price',
+  Token1relativePrice = 'token1relativePrice',
   VolumeToken0 = 'volumeToken0',
   VolumeToken1 = 'volumeToken1',
   VolumeTradedEth = 'volumeTradedEth',
@@ -728,6 +824,14 @@ export type Pair_Filter = {
   id_not?: InputMaybe<Scalars['ID']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']>>;
   token0?: InputMaybe<Scalars['String']>;
+  token0Price?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token0Price_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_not?: InputMaybe<Scalars['BigDecimal']>;
+  token0Price_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   token0_contains?: InputMaybe<Scalars['String']>;
   token0_contains_nocase?: InputMaybe<Scalars['String']>;
   token0_ends_with?: InputMaybe<Scalars['String']>;
@@ -747,7 +851,23 @@ export type Pair_Filter = {
   token0_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
   token0_starts_with?: InputMaybe<Scalars['String']>;
   token0_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  token0relativePrice?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token0relativePrice_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_not?: InputMaybe<Scalars['BigDecimal']>;
+  token0relativePrice_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   token1?: InputMaybe<Scalars['String']>;
+  token1Price?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token1Price_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_not?: InputMaybe<Scalars['BigDecimal']>;
+  token1Price_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   token1_contains?: InputMaybe<Scalars['String']>;
   token1_contains_nocase?: InputMaybe<Scalars['String']>;
   token1_ends_with?: InputMaybe<Scalars['String']>;
@@ -767,6 +887,14 @@ export type Pair_Filter = {
   token1_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
   token1_starts_with?: InputMaybe<Scalars['String']>;
   token1_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  token1relativePrice?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_gt?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_gte?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  token1relativePrice_lt?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_lte?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_not?: InputMaybe<Scalars['BigDecimal']>;
+  token1relativePrice_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   volumeToken0?: InputMaybe<Scalars['BigInt']>;
   volumeToken0_gt?: InputMaybe<Scalars['BigInt']>;
   volumeToken0_gte?: InputMaybe<Scalars['BigInt']>;
@@ -804,7 +932,11 @@ export type Pair_Filter = {
 export enum Pair_OrderBy {
   Id = 'id',
   Token0 = 'token0',
+  Token0Price = 'token0Price',
+  Token0relativePrice = 'token0relativePrice',
   Token1 = 'token1',
+  Token1Price = 'token1Price',
+  Token1relativePrice = 'token1relativePrice',
   VolumeToken0 = 'volumeToken0',
   VolumeToken1 = 'volumeToken1',
   VolumeTradedEth = 'volumeTradedEth',

--- a/src/api/cow/cow.spec.ts
+++ b/src/api/cow/cow.spec.ts
@@ -139,6 +139,11 @@ afterEach(() => {
   jest.restoreAllMocks()
 })
 
+test('Valid: Get orders link ', async () => {
+  const orderLink = await cowSdk.cowApi.getOrderLink(ORDER_RESPONSE.uid)
+  expect(orderLink).toEqual(`https://api.cow.fi/rinkeby/api/v1/orders/${ORDER_RESPONSE.uid}`)
+})
+
 test('Valid: Get an order ', async () => {
   fetchMock.mockResponseOnce(JSON.stringify(ORDER_RESPONSE), { status: HTTP_STATUS_OK })
   const order = await cowSdk.cowApi.getOrder(ORDER_RESPONSE.uid)

--- a/src/api/cow/cow.spec.ts
+++ b/src/api/cow/cow.spec.ts
@@ -436,7 +436,7 @@ test('Valid: Get Profile Data', async () => {
   await cowSdk1.cowApi.getProfileData('0x6810e776880c02933d47db1b9fc05908e5386b96')
   expect(fetchMock).toHaveBeenCalledTimes(1)
   expect(fetchMock).toHaveBeenCalledWith(
-    'https://barn.api.cow.fi/affiliate/api/v1/profile/0x6810e776880c02933d47db1b9fc05908e5386b96',
+    'https://api.cow.fi/affiliate/api/v1/profile/0x6810e776880c02933d47db1b9fc05908e5386b96',
     FETCH_RESPONSE_PARAMETERS
   )
 })
@@ -459,7 +459,7 @@ test('Invalid: Get Profile Data from unexisting address', async () => {
     expect(error.message).toEqual("You've passed an invalid URL")
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://barn.api.cow.fi/affiliate/api/v1/profile/unexistingAddress',
+      'https://api.cow.fi/affiliate/api/v1/profile/unexistingAddress',
       FETCH_RESPONSE_PARAMETERS
     )
   }
@@ -494,7 +494,7 @@ test('Valid: Send sign order cancellation', async () => {
   await cowSdk.cowApi.sendSignedOrderCancellation(ORDER_CANCELLATION)
   expect(fetchMock).toHaveBeenCalledTimes(1)
   expect(fetchMock).toHaveBeenCalledWith(
-    `https://barn.api.cow.fi/rinkeby/api/v1/orders/${ORDER_CANCELLATION.cancellation.orderUid}`,
+    `https://api.cow.fi/rinkeby/api/v1/orders/${ORDER_CANCELLATION.cancellation.orderUid}`,
     {
       ...FETCH_RESPONSE_PARAMETERS,
       body: JSON.stringify({ ...SIGNED_ORDER_RESPONSE, signingScheme: 'eip712', from: ORDER_CANCELLATION.owner }),
@@ -520,7 +520,7 @@ test('Invalid: Send sign not found order cancellation', async () => {
     const error = e as CowError
     expect(error.message).toEqual('Token pair selected has insufficient liquidity')
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(fetchMock).toHaveBeenCalledWith('https://barn.api.cow.fi/rinkeby/api/v1/orders/unexistingOrder', {
+    expect(fetchMock).toHaveBeenCalledWith('https://api.cow.fi/rinkeby/api/v1/orders/unexistingOrder', {
       ...FETCH_RESPONSE_PARAMETERS,
       body: JSON.stringify({ ...SIGNED_ORDER_RESPONSE, signingScheme: 'eip712', from: ORDER_CANCELLATION.owner }),
       method: 'DELETE',
@@ -593,7 +593,7 @@ test('Valid: AppDataHash properly set on X-AppId header', async () => {
   cowSdk1.updateChainId(1)
   await cowSdk1.cowApi.getProfileData('0x6810e776880c02933d47db1b9fc05908e5386b96')
   expect(fetchMock).toHaveBeenCalledWith(
-    'https://barn.api.cow.fi/affiliate/api/v1/profile/0x6810e776880c02933d47db1b9fc05908e5386b96',
+    'https://api.cow.fi/affiliate/api/v1/profile/0x6810e776880c02933d47db1b9fc05908e5386b96',
     {
       ...FETCH_RESPONSE_PARAMETERS,
       headers: { ...FETCH_RESPONSE_PARAMETERS.headers, 'X-AppId': cowSdk1.context.appDataHash },
@@ -607,7 +607,7 @@ test('Valid: AppDataHash properly set on X-AppId header when undefined', async (
   cowSdk1.updateChainId(1)
   await cowSdk1.cowApi.getProfileData('0x6810e776880c02933d47db1b9fc05908e5386b96')
   expect(fetchMock).toHaveBeenCalledWith(
-    'https://barn.api.cow.fi/affiliate/api/v1/profile/0x6810e776880c02933d47db1b9fc05908e5386b96',
+    'https://api.cow.fi/affiliate/api/v1/profile/0x6810e776880c02933d47db1b9fc05908e5386b96',
     {
       ...FETCH_RESPONSE_PARAMETERS,
       headers: {

--- a/src/api/cow/index.ts
+++ b/src/api/cow/index.ts
@@ -22,6 +22,7 @@ import {
   OrderMetaData,
   ProfileData,
   TradeMetaData,
+  Options,
 } from './types'
 import { CowError, logPrefix, objectToQueryString } from '../../utils/common'
 import { Context } from '../../utils/context'
@@ -107,15 +108,16 @@ export class CowApi {
     return getProfileUrl(this.context.isDevEnvironment)
   }
 
-  async getProfileData(address: string): Promise<ProfileData | null> {
-    const chainId = await this.context.chainId
+  async getProfileData(address: string, options: Options = {}): Promise<ProfileData | null> {
+    const { chainId: networkId, isDevEnvironment } = options
+    const chainId = networkId || (await this.context.chainId)
     log.debug(logPrefix, `[api:${this.API_NAME}] Get profile data for`, chainId, address)
     if (chainId !== ChainId.MAINNET) {
       log.info(logPrefix, 'Profile data is only available for mainnet')
       return null
     }
 
-    const response = await this.getProfile(`/profile/${address}`)
+    const response = await this.getProfile(`/profile/${address}`, { chainId, isDevEnvironment })
 
     if (!response.ok) {
       const errorResponse = await response.json()
@@ -126,16 +128,17 @@ export class CowApi {
     }
   }
 
-  async getTrades(params: GetTradesParams): Promise<TradeMetaData[]> {
+  async getTrades(params: GetTradesParams, options: Options = {}): Promise<TradeMetaData[]> {
+    const { chainId: networkId, isDevEnvironment = this.context.isDevEnvironment } = options
     const { owner, orderId, limit, offset } = params
     if (owner && orderId) {
       throw new CowError('Cannot specify both owner and orderId')
     }
     const qsParams = objectToQueryString({ owner, orderUid: orderId, limit, offset })
-    const chainId = await this.context.chainId
+    const chainId = networkId || (await this.context.chainId)
     log.debug(logPrefix, '[util:operator] Get trades for', chainId, { owner, orderId, limit, offset })
     try {
-      const response = await this.get(`/trades${qsParams}`)
+      const response = await this.get(`/trades${qsParams}`, { chainId, isDevEnvironment })
 
       if (!response.ok) {
         const errorResponse = await response.json()
@@ -151,14 +154,15 @@ export class CowApi {
     }
   }
 
-  async getOrders(params: GetOrdersParams): Promise<OrderMetaData[]> {
+  async getOrders(params: GetOrdersParams, options: Options = {}): Promise<OrderMetaData[]> {
+    const { chainId: networkId, isDevEnvironment = this.context.isDevEnvironment } = options
     const { owner, limit = 1000, offset = 0 } = params
     const queryString = objectToQueryString({ limit, offset })
-    const chainId = await this.context.chainId
+    const chainId = networkId || (await this.context.chainId)
     log.debug(logPrefix, `[api:${this.API_NAME}] Get orders for `, chainId, owner, limit, offset)
 
     try {
-      const response = await this.get(`/account/${owner}/orders/${queryString}`)
+      const response = await this.get(`/account/${owner}/orders/${queryString}`, { chainId, isDevEnvironment })
 
       if (!response.ok) {
         const errorResponse: ApiErrorObject = await response.json()
@@ -174,12 +178,13 @@ export class CowApi {
     }
   }
 
-  async getTxOrders(txHash: string): Promise<OrderMetaData[]> {
-    const chainId = await this.context.chainId
+  async getTxOrders(txHash: string, options: Options = {}): Promise<OrderMetaData[]> {
+    const { chainId: networkId, isDevEnvironment } = options
+    const chainId = networkId || (await this.context.chainId)
     log.debug(`[api:${this.API_NAME}] Get tx orders for `, chainId, txHash)
 
     try {
-      const response = await this.get(`/transactions/${txHash}/orders`)
+      const response = await this.get(`/transactions/${txHash}/orders`, { chainId, isDevEnvironment })
 
       if (!response.ok) {
         const errorResponse: ApiErrorObject = await response.json()
@@ -194,11 +199,12 @@ export class CowApi {
     }
   }
 
-  async getOrder(orderId: string): Promise<OrderMetaData | null> {
-    const chainId = await this.context.chainId
+  async getOrder(orderId: string, options: Options = {}): Promise<OrderMetaData | null> {
+    const { chainId: networkId, isDevEnvironment } = options
+    const chainId = networkId || (await this.context.chainId)
     log.debug(logPrefix, `[api:${this.API_NAME}] Get order for `, chainId, orderId)
     try {
-      const response = await this.get(`/orders/${orderId}`)
+      const response = await this.get(`/orders/${orderId}`, { chainId, isDevEnvironment })
 
       if (!response.ok) {
         const errorResponse: ApiErrorObject = await response.json()
@@ -214,13 +220,15 @@ export class CowApi {
     }
   }
 
-  async getPriceQuoteLegacy(params: PriceQuoteParams): Promise<PriceInformation | null> {
+  async getPriceQuoteLegacy(params: PriceQuoteParams, options: Options = {}): Promise<PriceInformation | null> {
+    const { chainId: networkId, isDevEnvironment } = options
     const { baseToken, quoteToken, amount, kind } = params
-    const chainId = await this.context.chainId
+    const chainId = networkId || (await this.context.chainId)
     log.debug(logPrefix, `[api:${this.API_NAME}] Get price from API`, params, 'for', chainId)
 
     const response = await this.get(
-      `/markets/${toErc20Address(baseToken, chainId)}-${toErc20Address(quoteToken, chainId)}/${kind}/${amount}`
+      `/markets/${toErc20Address(baseToken, chainId)}-${toErc20Address(quoteToken, chainId)}/${kind}/${amount}`,
+      { chainId, isDevEnvironment }
     ).catch((error) => {
       log.error(logPrefix, 'Error getting price quote:', error)
       throw new QuoteError(UNHANDLED_QUOTE_ERROR)
@@ -229,24 +237,30 @@ export class CowApi {
     return _handleQuoteResponse<PriceInformation | null>(response)
   }
 
-  async getQuote(params: FeeQuoteParams): Promise<SimpleGetQuoteResponse> {
-    const chainId = await this.context.chainId
+  async getQuote(params: FeeQuoteParams, options: Options = {}): Promise<SimpleGetQuoteResponse> {
+    const { chainId: networkId, isDevEnvironment } = options
+    const chainId = networkId || (await this.context.chainId)
     const quoteParams = this.mapNewToLegacyParams(params, chainId)
-    const response = await this.post('/quote', quoteParams)
+    const response = await this.post('/quote', quoteParams, { chainId, isDevEnvironment })
 
     return _handleQuoteResponse<SimpleGetQuoteResponse>(response)
   }
 
-  async sendSignedOrderCancellation(params: OrderCancellationParams): Promise<void> {
+  async sendSignedOrderCancellation(params: OrderCancellationParams, options: Options = {}): Promise<void> {
+    const { chainId: networkId, isDevEnvironment } = options
     const { cancellation, owner: from } = params
-    const chainId = await this.context.chainId
+    const chainId = networkId || (await this.context.chainId)
     log.debug(logPrefix, `[api:${this.API_NAME}] Delete signed order for network`, chainId, cancellation)
 
-    const response = await this.delete(`/orders/${cancellation.orderUid}`, {
-      signature: cancellation.signature,
-      signingScheme: getSigningSchemeApiValue(cancellation.signingScheme),
-      from,
-    })
+    const response = await this.delete(
+      `/orders/${cancellation.orderUid}`,
+      {
+        signature: cancellation.signature,
+        signingScheme: getSigningSchemeApiValue(cancellation.signingScheme),
+        from,
+      },
+      { chainId, isDevEnvironment }
+    )
 
     if (!response.ok) {
       // Raise an exception
@@ -257,18 +271,26 @@ export class CowApi {
     log.debug(logPrefix, `[api:${this.API_NAME}] Cancelled order`, cancellation.orderUid, chainId)
   }
 
-  async sendOrder(params: { order: Omit<OrderCreation, 'appData'>; owner: string }): Promise<OrderID> {
+  async sendOrder(
+    params: { order: Omit<OrderCreation, 'appData'>; owner: string },
+    options: Options = {}
+  ): Promise<OrderID> {
     const fullOrder: OrderCreation = { ...params.order, appData: this.context.appDataHash }
-    const chainId = await this.context.chainId
+    const { chainId: networkId, isDevEnvironment } = options
+    const chainId = networkId || (await this.context.chainId)
     const { owner } = params
     log.debug(logPrefix, `[api:${this.API_NAME}] Post signed order for network`, chainId, fullOrder)
 
     // Call API
-    const response = await this.post(`/orders`, {
-      ...fullOrder,
-      signingScheme: getSigningSchemeApiValue(fullOrder.signingScheme),
-      from: owner,
-    })
+    const response = await this.post(
+      `/orders`,
+      {
+        ...fullOrder,
+        signingScheme: getSigningSchemeApiValue(fullOrder.signingScheme),
+        from: owner,
+      },
+      { chainId, isDevEnvironment }
+    )
 
     // Handle response
     if (!response.ok) {
@@ -340,8 +362,13 @@ export class CowApi {
     }
   }
 
-  private async fetch(url: string, method: 'GET' | 'POST' | 'DELETE', data?: unknown): Promise<Response> {
-    const baseUrl = await this.getApiBaseUrl()
+  private async fetch(
+    url: string,
+    method: 'GET' | 'POST' | 'DELETE',
+    data?: unknown,
+    baseUri?: string
+  ): Promise<Response> {
+    const baseUrl = baseUri || (await this.getApiBaseUrl())
     return fetch(baseUrl + url, {
       headers: this.DEFAULT_HEADERS,
       method,
@@ -349,8 +376,13 @@ export class CowApi {
     })
   }
 
-  private async fetchProfile(url: string, method: 'GET' | 'POST' | 'DELETE', data?: unknown): Promise<Response> {
-    const baseUrl = await this.getProfileApiBaseUrl()
+  private async fetchProfile(
+    url: string,
+    method: 'GET' | 'POST' | 'DELETE',
+    data?: unknown,
+    baseUri?: string
+  ): Promise<Response> {
+    const baseUrl = baseUri || (await this.getProfileApiBaseUrl())
     return fetch(baseUrl + url, {
       headers: this.DEFAULT_HEADERS,
       method,
@@ -358,19 +390,82 @@ export class CowApi {
     })
   }
 
-  private post(url: string, data: unknown): Promise<Response> {
-    return this.fetch(url, 'POST', data)
+  private async post(url: string, data: unknown, options: Options = {}): Promise<Response> {
+    const { chainId: networkId, isDevEnvironment } = options
+    const prodUri = getGnosisProtocolUrl(false)
+    const barnUri = getGnosisProtocolUrl(true)
+    const chainId = networkId || (await this.context.chainId)
+    let response
+    if (isDevEnvironment === undefined) {
+      try {
+        response = await this.fetch(url, 'POST', data, `${prodUri[chainId]}/v1`)
+      } catch (error) {
+        response = await this.fetch(url, 'POST', data, `${barnUri[chainId]}/v1`)
+      }
+      return response
+    } else {
+      const uri = isDevEnvironment ? barnUri : prodUri
+      return await this.fetch(url, 'POST', data, uri[chainId])
+    }
   }
 
-  private get(url: string): Promise<Response> {
-    return this.fetch(url, 'GET')
+  private async get(url: string, options: Options = {}): Promise<Response> {
+    const { chainId: networkId, isDevEnvironment } = options
+    const prodUri = getGnosisProtocolUrl(false)
+    const barnUri = getGnosisProtocolUrl(true)
+    const chainId = networkId || (await this.context.chainId)
+
+    let response
+    if (isDevEnvironment === undefined) {
+      try {
+        response = await this.fetch(url, 'GET', undefined, `${prodUri[chainId]}/v1`)
+      } catch (error) {
+        response = await this.fetch(url, 'GET', undefined, `${barnUri[chainId]}/v1`)
+      }
+    } else {
+      const uri = isDevEnvironment ? barnUri : prodUri
+      response = await this.fetch(url, 'GET', undefined, `${uri[chainId]}/v1`)
+    }
+    return response
   }
 
-  private getProfile(url: string): Promise<Response> {
-    return this.fetchProfile(url, 'GET')
+  private async getProfile(url: string, options: Options = {}): Promise<Response> {
+    const { chainId: networkId, isDevEnvironment } = options
+    const prodUri = getProfileUrl(false)
+    const barnUri = getProfileUrl(true)
+    const chainId = networkId || (await this.context.chainId)
+
+    let response
+    if (isDevEnvironment === undefined) {
+      try {
+        response = await this.fetchProfile(url, 'GET', undefined, `${barnUri[chainId]}/v1`)
+      } catch (error) {
+        response = await this.fetchProfile(url, 'GET', undefined, `${prodUri[chainId]}/v1`)
+      }
+    } else {
+      const uri = isDevEnvironment ? barnUri : prodUri
+      response = await this.fetchProfile(url, 'GET', undefined, `${uri[chainId]}/v1`)
+    }
+    return response
   }
 
-  private delete(url: string, data: unknown): Promise<Response> {
-    return this.fetch(url, 'DELETE', data)
+  private async delete(url: string, data: unknown, options: Options = {}): Promise<Response> {
+    const { chainId: networkId, isDevEnvironment } = options
+    const prodUri = getGnosisProtocolUrl(false)
+    const barnUri = getGnosisProtocolUrl(true)
+    const chainId = networkId || (await this.context.chainId)
+
+    let response
+    if (isDevEnvironment === undefined) {
+      try {
+        response = await this.fetch(url, 'DELETE', data, `${barnUri[chainId]}/v1`)
+      } catch (error) {
+        response = await this.fetch(url, 'DELETE', data, `${prodUri[chainId]}/v1`)
+      }
+    } else {
+      const uri = isDevEnvironment ? barnUri : prodUri
+      response = await this.fetch(url, 'DELETE', data, `${uri[chainId]}/v1`)
+    }
+    return response
   }
 }

--- a/src/api/cow/types.ts
+++ b/src/api/cow/types.ts
@@ -129,3 +129,8 @@ export type PriceQuoteParams = Omit<FeeQuoteParams, 'sellToken' | 'buyToken'> & 
   baseToken: string
   quoteToken: string
 }
+
+export type Options = {
+  chainId?: ChainId
+  isDevEnvironment?: boolean
+}

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,7 +1,7 @@
 import { Signer } from 'ethers'
 import log from 'loglevel'
 import { CowError, logPrefix } from './common'
-import { SupportedChainId as ChainId } from '../constants/chains'
+import { SupportedChainId as ChainId, SupportedChainId } from '../constants/chains'
 import { DEFAULT_APP_DATA_HASH, DEFAULT_IPFS_READ_URI, DEFAULT_IPFS_WRITE_URI } from '../constants'
 
 export interface Ipfs {
@@ -38,10 +38,17 @@ export const DefaultCowContext = {
  * @implements {Required<CowContext>}
  */
 export class Context implements Partial<CowContext> {
-  #context: CowContext
-  #chainId: ChainId
+  updateContext(cowContext: CowContext, chainId: ChainId) {
+    this.setParams(chainId, cowContext)
+  }
+  #context: CowContext = {}
+  #chainId: ChainId = SupportedChainId.MAINNET
 
   constructor(chainId: ChainId, context: CowContext) {
+    this.setParams(chainId, context)
+  }
+
+  private setParams(chainId: ChainId, context: CowContext) {
     this.#chainId = this.updateChainId(chainId)
     this.#context = {
       ...DefaultCowContext,


### PR DESCRIPTION
This PR closes #30 

We've added some new improvements to the SDK: 

- The possibility of instantiating the SDK without passing `chainId` as argument. It will default to `Mainnet`.
- The possibility of overriding default params (chainId and env) for every method in `CowApi` .
- When query is not paginated, we will get data from both envs (barn and prod) if the environment is not set in the method params.