### PR TITLE
Refactor app data tests

### DIFF
--- a/src/utils/appData.spec.ts
+++ b/src/utils/appData.spec.ts
@@ -12,195 +12,78 @@ const BASE_DOCUMENT = {
 
 const INVALID_CID_LENGTH = 'Incorrect length'
 
-// TODO: move unit tests to app-data package
-
-test('Valid minimal document', async () => {
-  const validation = await validateAppDataDocument(BASE_DOCUMENT, BASE_DOCUMENT.version)
-  expect(validation).toEqual(VALID_RESULT)
-})
-
-test('Valid minimal document + appCode', async () => {
-  const validation = await validateAppDataDocument(
-    {
-      version: '0.1.0',
-      appCode: 'MyApp',
-      metadata: {},
+describe('validateAppDataDocument', () => {
+  const v010Doc = {
+    ...BASE_DOCUMENT,
+    metatadata: {
+      referrer: { address: '0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9', version: '0.1.0' },
     },
-    '0.1.0'
-  )
-  expect(validation).toEqual(VALID_RESULT)
-})
-
-test('Valid minimal document + appCode + referrer', async () => {
-  const validation = await validateAppDataDocument(
-    {
-      version: '0.1.0',
-      appCode: 'MyApp',
-      metadata: {
-        referrer: {
-          version: '0.1.0',
-          address: '0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52',
-        },
-      },
-    },
-    '0.1.0'
-  )
-  expect(validation).toEqual(VALID_RESULT)
-})
-
-test('Invalid: Bad referrer', async () => {
-  const validation = await validateAppDataDocument(
-    {
-      version: '0.1.0',
-      appCode: 'MyApp',
-      metadata: {
-        referrer: {
-          version: '0.1.0',
-          address: 'this is not an ethereum address',
-        },
-      },
-    },
-    '0.1.0'
-  )
-  expect(validation.result).toBeFalsy()
-})
-
-test('Invalid: No version', async () => {
-  const validation = await validateAppDataDocument(
-    {
-      appCode: 'MyApp',
-      metadata: {},
-    },
-    '0.1.0'
-  )
-  expect(validation.result).toBeFalsy()
-})
-
-test('Invalid: No metadata', async () => {
-  const validation = await validateAppDataDocument(
-    {
-      version: '0.1.0',
-      appCode: 'MyApp',
-    },
-    '0.1.0'
-  )
-  expect(validation.result).toBeFalsy()
-})
-
-test('Invalid: No metadata', async () => {
-  const validation = await validateAppDataDocument(
-    {
-      version: '0.1.0',
-      appCode: 'MyApp',
-    },
-    '0.1.0'
-  )
-  expect(validation.result).toBeFalsy()
-})
-
-test('Invalid: No metadata', async () => {
-  const validation = await validateAppDataDocument(
-    {
-      version: '0.1.0',
-      appCode: 'MyApp',
-    },
-    '0.1.0'
-  )
-  expect(validation.result).toBeFalsy()
-})
-
-test('Valid serialized appData CID', async () => {
-  const hash = '0xa6c81f4ca727252a05b108f1742a07430f28d474d2a3492d8f325746824d22e5'
-  const serializedCidV0 = 'QmZZhNnqMF1gRywNKnTPuZksX7rVjQgTT3TJAZ7R6VE3b2'
-  const cidV0 = await getSerializedCID(hash)
-
-  expect(cidV0).toEqual(serializedCidV0)
-})
-
-test('Invalid: serialized appData CID format ', async () => {
-  const invalidHash = '0xa6c81f4ca727252a05b108f1742'
-  try {
-    await getSerializedCID(invalidHash)
-  } catch (e: unknown) {
-    const error = e as Error
-    expect(error.message).toEqual(INVALID_CID_LENGTH)
   }
+  const v040Doc = {
+    ...v010Doc,
+    version: '0.4.0',
+    metadata: { ...v010Doc.metadata, quote: { slippageBips: '1', version: '0.2.0' } },
+  }
+
+  test('Version matches schema', async () => {
+    // given
+    // when
+    const v010Validation = await validateAppDataDocument(v010Doc, v010Doc.version)
+    const v040Validation = await validateAppDataDocument(v040Doc, v040Doc.version)
+    // then
+    expect(v010Validation).toEqual(VALID_RESULT)
+    expect(v040Validation).toEqual(VALID_RESULT)
+  })
+
+  test("Version doesn't match schema", async () => {
+    // given
+    // when
+    const v030Validation = await validateAppDataDocument(v040Doc, '0.3.0')
+    // then
+    expect(v030Validation.result).toBeFalsy()
+    expect(v030Validation.errors).toEqual("data/metadata/quote must have required property 'sellAmount'")
+  })
+
+  test("Version doesn't exist", async () => {
+    // given
+    // when
+    const validation = validateAppDataDocument(v010Doc, '0.0.0')
+    // then
+    await expect(validation).rejects.toThrow('AppData version 0.0.0 does not exist')
+  })
 })
 
-test('Valid IPFS appData from CID', async () => {
-  fetchMock.mockResponseOnce(
-    '{"appCode":"CowSwap","metadata":{"referrer":{"address":"0x1f5B740436Fc5935622e92aa3b46818906F416E9","version":"0.1.0"}},"version":"0.1.0"}'
-  )
+describe('getSerializedCID', () => {
+  test('Valid serialized appData CID', async () => {
+    const hash = '0xa6c81f4ca727252a05b108f1742a07430f28d474d2a3492d8f325746824d22e5'
+    const serializedCidV0 = 'QmZZhNnqMF1gRywNKnTPuZksX7rVjQgTT3TJAZ7R6VE3b2'
+    const cidV0 = await getSerializedCID(hash)
 
-  const validSerializedCidV0 = 'QmZZhNnqMF1gRywNKnTPuZksX7rVjQgTT3TJAZ7R6VE3b2'
-  const appDataDocument = await loadIpfsFromCid(validSerializedCidV0)
-  const validation = await validateAppDataDocument(appDataDocument, '0.1.0')
+    expect(cidV0).toEqual(serializedCidV0)
+  })
 
-  expect(validation).toEqual(VALID_RESULT)
-  expect(fetchMock).toHaveBeenCalledTimes(1)
+  test('Invalid: serialized appData CID format ', async () => {
+    const invalidHash = '0xa6c81f4ca727252a05b108f1742'
+    try {
+      await getSerializedCID(invalidHash)
+    } catch (e: unknown) {
+      const error = e as Error
+      expect(error.message).toEqual(INVALID_CID_LENGTH)
+    }
+  })
 })
 
-test('Valid: quote metadata - slippage', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageBips: '5', newField: 'bla' } } }
-  const validation = await validateAppDataDocument(document, '0.1.0')
+describe('loadIpfsFromCid', () => {
+  test('Valid IPFS appData from CID', async () => {
+    fetchMock.mockResponseOnce(
+      '{"appCode":"CowSwap","metadata":{"referrer":{"address":"0x1f5B740436Fc5935622e92aa3b46818906F416E9","version":"0.1.0"}},"version":"0.1.0"}'
+    )
 
-  expect(validation).toEqual(VALID_RESULT)
-})
+    const validSerializedCidV0 = 'QmZZhNnqMF1gRywNKnTPuZksX7rVjQgTT3TJAZ7R6VE3b2'
+    const appDataDocument = await loadIpfsFromCid(validSerializedCidV0)
+    const validation = await validateAppDataDocument(appDataDocument, '0.1.0')
 
-test('Valid: quote metadata - slippage - decimals', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageBips: '0.1' } } }
-  const validation = await validateAppDataDocument(document, '0.1.0')
-
-  expect(validation).toEqual(VALID_RESULT)
-})
-
-test('Invalid: quote metadata - missing fields', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.2' } } }
-  const validation = await validateAppDataDocument(document, '0.4.0')
-
-  expect(validation.result).toBeFalsy()
-})
-
-test('Invalid: quote metadata - wrong amount type', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', sellAmount: 312, buyAmount: '0xbab3' } } }
-  const validation = await validateAppDataDocument(document, '0.3.0')
-
-  expect(validation.result).toBeFalsy()
-})
-
-test('Invalid: quote metadata - wrong slippage amount', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { version: '0.1.0', slippageBips: '.1' } } }
-  const validation = await validateAppDataDocument(document, '0.4.0')
-
-  expect(validation.result).toBeFalsy()
-})
-
-test('Invalid: quote metadata - amount missing buyAmount type', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { sellAmount: 312 } } }
-  const validation = await validateAppDataDocument(document, '0.3.0')
-
-  expect(validation.result).toBeFalsy()
-})
-
-test('Invalid: quote metadata - amount missing sellAmount type', async () => {
-  const document = { ...BASE_DOCUMENT, metadata: { quote: { buyAmount: 312 } } }
-  const validation = await validateAppDataDocument(document, '0.2.0')
-
-  expect(validation.result).toBeFalsy()
-})
-
-test('Valid: environment', async () => {
-  const document = { ...BASE_DOCUMENT, environment: 'test' }
-
-  const validation = await validateAppDataDocument(document, '0.1.0')
-
-  expect(validation).toEqual(VALID_RESULT)
-})
-
-test('Invalid: environment', async () => {
-  const document = { ...BASE_DOCUMENT, environment: 1234142 }
-
-  const validation = await validateAppDataDocument(document, '0.3.0')
-
-  expect(validation.result).toBeFalsy()
+    expect(validation).toEqual(VALID_RESULT)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/utils/appData.ts
+++ b/src/utils/appData.ts
@@ -1,5 +1,5 @@
 import Ajv, { ValidateFunction } from 'ajv'
-import { fromHexString } from './common'
+import { CowError, fromHexString } from './common'
 import { DEFAULT_IPFS_READ_URI } from '../constants'
 import { AnyAppDataDocVersion } from '../types'
 
@@ -18,7 +18,13 @@ async function getValidator(version: string): Promise<{ ajv: Ajv; validate: Vali
   validate = ajv.getSchema(version)
 
   if (!validate) {
-    const appDataSchema = await import(`@cowprotocol/app-data/schemas/v${version}.json`)
+    let appDataSchema
+
+    try {
+      appDataSchema = await import(`@cowprotocol/app-data/schemas/v${version}.json`)
+    } catch (e) {
+      throw new CowError(`AppData version ${version} does not exist`, 'MISSING_APP_DATA_VERSION')
+    }
     // add new schema to ajv cache
     ajv.addSchema(appDataSchema, version)
     // fetch and return it

--- a/src/utils/appData.ts
+++ b/src/utils/appData.ts
@@ -63,6 +63,6 @@ export async function validateAppDataDocument(appDataDocument: unknown, version:
 
   return {
     result,
-    errors: ajv.errors ? ajv.errorsText(ajv.errors) : undefined,
+    errors: validate.errors ? ajv.errorsText(validate.errors) : undefined,
   }
 }


### PR DESCRIPTION
# Summary

- Refactoring app data tests
    - Removed a bunch of appData schema tests. Those are being added to https://github.com/cowprotocol/app-data/pull/5
    - Added unit tests specific to the validation fn
    - Grouped/wrapped tests in `describe`
- Throwing CowError when trying to load/validate an appData schema version that doesn't exist
- Fixing ajv errors not being passed down

Built on top of https://github.com/cowprotocol/cow-sdk/pull/50

# Testing

Unit tests
