### PR TITLE
Trigger npm publish when a release/pre-release is created

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish package to NPM
 
 on:
-  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   deploy:

--- a/src/workflows/publish.sh
+++ b/src/workflows/publish.sh
@@ -30,20 +30,6 @@ if package_exists "$package_name" && grep --silent --line-regexp --fixed-strings
   exit 1
 fi
 
-version_tag="v$version"
-if git fetch --end-of-options origin "refs/tags/$version_tag" 2>/dev/null; then
-  echo "Tag $version_tag is already present"
-  exit 1
-fi
-
 yarn publish --access public
-
-if ! git config --get user.name &>/dev/null; then
-  git config user.name "$git_username"
-  git config user.email "$git_useremail"
-fi
-git tag -m "Version $version" --end-of-options "$version_tag"
-
-git push origin "refs/tags/$version_tag"
 
 echo "Package $package_name version $version successfully published."

--- a/src/workflows/publish.sh
+++ b/src/workflows/publish.sh
@@ -35,6 +35,13 @@ if ! git fetch --end-of-options origin "refs/tags/$version_tag" 2>/dev/null; the
   echo "Tag $version_tag is not created. Create the Release first."
   exit 1
 fi
+
+latest_tag="$(git describe --tags --abbrev=0)"
+if ! $version_tag == latest_tag; then
+  echo "Latest tag $latest_tag version doesn't match package.json version $version"
+  exit 1
+fi
+
 yarn publish --access public
 
 echo "Package $package_name version $version successfully published."

--- a/src/workflows/publish.sh
+++ b/src/workflows/publish.sh
@@ -30,6 +30,11 @@ if package_exists "$package_name" && grep --silent --line-regexp --fixed-strings
   exit 1
 fi
 
+version_tag="v$version"
+if ! git fetch --end-of-options origin "refs/tags/$version_tag" 2>/dev/null; then
+  echo "Tag $version_tag is not created. Create the Release first."
+  exit 1
+fi
 yarn publish --access public
 
 echo "Package $package_name version $version successfully published."


### PR DESCRIPTION
As discussed, we should be publishing npm packages when creating new releases and not doing it manually to avoid losing sync between npm versions and releases as we have now with `1.0.0-RC.0`

<img width="319" alt="image" src="https://user-images.githubusercontent.com/3328006/180211247-20f276cb-b30a-4ddc-93fa-d38ae1ca84b1.png">

<img width="124" alt="image" src="https://user-images.githubusercontent.com/3328006/180210922-16cd3ba8-c329-4cf5-a30b-97701198e455.png">
