### PR TITLE
Expose metadata methods from app data

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ This will return a document similar to:
 ## Upload document to IPFS
 The SDK uses Pinata to upload it to IPFS, so you will need an API Key in order to upload it using the SDK.
 
-Alternativelly, you can upload the document on your own using any other service.
+Alternatively, you can upload the document on your own using any other service.
 
 ```js
 // Make sure you provide the IPFS params when instantiating the SDK
@@ -330,6 +330,20 @@ const decodedAppDataHex = await cowSdk.metadataApi.appDataHexToCid(hash)
 
 This will return an IPFS CIDv0: `QmUf2TrpSANVXdgcYfAAACe6kg551cY3rAemB7xfEMjYvs`
 
+
+## Getting appData schema files
+It's possible to get schema files directly for each exported version using `getAppDataSchema`
+
+```js
+const schema = await cowSdk.metadataApi.getAppDataSchema('0.4.0')
+```
+
+## Validating appDataDocs
+If for some reason you decide to create an `appDataDoc` without using the helper function, you can use `validateAppDataDoc` to validate it against the schema
+
+```js
+const { success, error } = await cowSdk.metadataApi.validateAppDataDoc({ version: '0.1.0', ... })
+```
 
 
 ## Querying the Cow Subgraph

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@cowprotocol/app-data": "^0.0.1-RC.2",
     "@cowprotocol/contracts": "^1.3.1",
-    "ajv": "^8.8.2",
     "cross-fetch": "^3.1.5",
     "ethers": "^5.5.3",
     "graphql": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "graphql:codegen": "graphql-codegen --config graphql-codegen.yml"
   },
   "dependencies": {
-    "@cowprotocol/app-data": "^0.0.1-RC.1",
+    "@cowprotocol/app-data": "^0.0.1-RC.2",
     "@cowprotocol/contracts": "^1.3.1",
     "ajv": "^8.8.2",
     "cross-fetch": "^3.1.5",

--- a/src/CowSdk.ts
+++ b/src/CowSdk.ts
@@ -3,7 +3,6 @@ import log, { LogLevelDesc } from 'loglevel'
 import { CowError } from './utils/common'
 import { CowApi, CowSubgraphApi, MetadataApi } from './api'
 import { SupportedChainId as ChainId, SupportedChainId } from './constants/chains'
-import { validateAppDataDocument } from './utils/appData'
 import { Context, CowContext } from './utils/context'
 import { signOrder, signOrderCancellation, UnsignedOrder } from './utils/sign'
 import { ZeroXApi } from './api/0x'
@@ -38,8 +37,6 @@ export class CowSdk<T extends ChainId> {
     const networkId = await this.context.chainId
     this.context.updateContext(cowContext, chainId || networkId)
   }
-
-  validateAppDataDocument = validateAppDataDocument
 
   async signOrder(order: Omit<UnsignedOrder, 'appData'>) {
     const signer = this._checkSigner()

--- a/src/api/metadata/index.ts
+++ b/src/api/metadata/index.ts
@@ -66,13 +66,7 @@ export class MetadataApi {
    * Validates given doc against the doc's own version
    */
   async validateAppDataDoc(appDataDoc: AnyAppDataDocVersion): ReturnType<typeof validateAppDataDoc> {
-    try {
-      return await validateAppDataDoc(appDataDoc)
-    } catch (e) {
-      // Wrapping @cowprotocol/app-data Error into CowError
-      const error = e as Error
-      throw new CowError(error.message)
-    }
+    return validateAppDataDoc(appDataDoc)
   }
 
   async decodeAppData(hash: string): Promise<void | AnyAppDataDocVersion> {

--- a/src/api/metadata/index.ts
+++ b/src/api/metadata/index.ts
@@ -50,7 +50,7 @@ export class MetadataApi {
    * Returns the appData schema for given version, if any
    * Throws CowError when version doesn't exist
    */
-  async getAppDataSchema(version: string): Promise<AnyAppDataDocVersion | void> {
+  async getAppDataSchema(version: string): Promise<AnyAppDataDocVersion> {
     try {
       return await getAppDataSchema(version)
     } catch (e) {

--- a/src/api/metadata/metadata.spec.ts
+++ b/src/api/metadata/metadata.spec.ts
@@ -189,3 +189,45 @@ describe('calculateAppDataHash', () => {
     expect(mock).toHaveBeenCalledWith(IPFS_HASH)
   })
 })
+
+describe('validateAppDataDocument', () => {
+  const v010Doc = {
+    ...DEFAULT_APP_DATA_DOC,
+    metatadata: {
+      referrer: { address: '0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9', version: '0.1.0' },
+    },
+  }
+  const v040Doc = {
+    ...v010Doc,
+    version: '0.4.0',
+    metadata: { ...v010Doc.metadata, quote: { slippageBips: '1', version: '0.2.0' } },
+  }
+
+  test('Version matches schema', async () => {
+    // given
+    // when
+    const v010Validation = await cowSdk.metadataApi.validateAppDataDoc(v010Doc)
+    const v040Validation = await cowSdk.metadataApi.validateAppDataDoc(v040Doc)
+    // then
+    expect(v010Validation.success).toBeTruthy()
+    expect(v040Validation.success).toBeTruthy()
+  })
+
+  test("Version doesn't match schema", async () => {
+    // given
+    // when
+    const v030Validation = await cowSdk.metadataApi.validateAppDataDoc({ ...v040Doc, version: '0.3.0' })
+    // then
+    expect(v030Validation.success).toBeFalsy()
+    expect(v030Validation.errors).toEqual("data/metadata/quote must have required property 'sellAmount'")
+  })
+
+  test("Version doesn't exist", async () => {
+    // given
+    // when
+    const validation = await cowSdk.metadataApi.validateAppDataDoc({ ...v010Doc, version: '0.0.0' })
+    // then
+    expect(validation.success).toBeFalsy()
+    expect(validation.errors).toEqual("AppData version 0.0.0 doesn't exist")
+  })
+})

--- a/src/api/metadata/metadata.spec.ts
+++ b/src/api/metadata/metadata.spec.ts
@@ -231,3 +231,27 @@ describe('validateAppDataDocument', () => {
     expect(validation.errors).toEqual("AppData version 0.0.0 doesn't exist")
   })
 })
+
+describe('getAppDataSchema', () => {
+  test('Returns existing schema', async () => {
+    // given
+    const version = '0.4.0'
+
+    // when
+    const schema = await cowSdk.metadataApi.getAppDataSchema(version)
+
+    // then
+    expect(schema.$id).toMatch(version)
+  })
+
+  test('Throws on invalid schema', async () => {
+    // given
+    const version = '0.0.0'
+
+    // when
+    const promise = cowSdk.metadataApi.getAppDataSchema(version)
+
+    // then
+    await expect(promise).rejects.toThrow(`AppData version ${version} doesn't exist`)
+  })
+})

--- a/src/api/metadata/metadata.spec.ts
+++ b/src/api/metadata/metadata.spec.ts
@@ -12,18 +12,18 @@ const HTTP_STATUS_INTERNAL_ERROR = 500
 const DEFAULT_APP_DATA_DOC = {
   version: '0.4.0',
   appCode: 'CowSwap',
-  environment: 'test',
   metadata: {},
 }
 
-const IPFS_HASH = 'QmRoosA9VFaZVPxBk9k9jhPGGmCAcLMeDP8L2Dd2RbjNv2'
-const APP_DATA_HEX = '0x3388186d8f802360e78ee4d57d489678a01c3ce922b1e0078eeb45c8f084b7e7'
+const IPFS_HASH = 'QmPvZL3KURfFR1ePyAk3sWxK86rgqNmcrGK3zyYyQMJUhW'
+const APP_DATA_HEX = '0x178b59ca7634e30a9b85867dd1c565e625d5920a7ecfbe31304e93406daa2cc1'
 
 const PINATA_API_KEY = 'apikey'
 const PINATA_API_SECRET = 'apiSecret'
 
 const CUSTOM_APP_DATA_DOC = {
   ...DEFAULT_APP_DATA_DOC,
+  environment: 'test',
   metadata: {
     referrer: {
       address: '0x1f5B740436Fc5935622e92aa3b46818906F416E9',
@@ -49,14 +49,15 @@ describe('generateAppDataDoc', () => {
     // when
     const appDataDoc = cowSdk.metadataApi.generateAppDataDoc({})
     // then
-    expect(appDataDoc.version).toEqual(DEFAULT_APP_DATA_DOC.version)
-    expect(appDataDoc.appCode).toEqual(DEFAULT_APP_DATA_DOC.appCode)
-    expect(appDataDoc.metadata).toEqual(DEFAULT_APP_DATA_DOC.metadata)
+    expect(appDataDoc).toEqual(DEFAULT_APP_DATA_DOC)
   })
 
   test('Creates appDataDoc with custom metadata ', () => {
     // given
     const params = {
+      appDataParams: {
+        environment: CUSTOM_APP_DATA_DOC.environment,
+      },
       metadataParams: {
         referrerParams: CUSTOM_APP_DATA_DOC.metadata.referrer,
         quoteParams: CUSTOM_APP_DATA_DOC.metadata.quote,
@@ -65,10 +66,7 @@ describe('generateAppDataDoc', () => {
     // when
     const appDataDoc = cowSdk.metadataApi.generateAppDataDoc(params)
     // then
-    expect(appDataDoc.metadata.referrer?.address).toEqual(CUSTOM_APP_DATA_DOC.metadata.referrer.address)
-    expect(appDataDoc.metadata.referrer?.version).toEqual(CUSTOM_APP_DATA_DOC.metadata.referrer.version)
-    expect(appDataDoc.metadata.quote?.slippageBips).toEqual(CUSTOM_APP_DATA_DOC.metadata.quote.slippageBips)
-    expect(appDataDoc.metadata.quote?.version).toEqual(CUSTOM_APP_DATA_DOC.metadata.quote.version)
+    expect(appDataDoc).toEqual(CUSTOM_APP_DATA_DOC)
   })
 })
 
@@ -133,10 +131,7 @@ describe('decodeAppData', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(`${DEFAULT_IPFS_READ_URI}/${IPFS_HASH}`)
-    expect(appDataDoc?.version).toEqual(CUSTOM_APP_DATA_DOC.version)
-    expect(appDataDoc?.appCode).toEqual(CUSTOM_APP_DATA_DOC.appCode)
-    expect(appDataDoc?.metadata.referrer?.address).toEqual(CUSTOM_APP_DATA_DOC.metadata.referrer.address)
-    expect(appDataDoc?.metadata.referrer?.version).toEqual(CUSTOM_APP_DATA_DOC.metadata.referrer.version)
+    expect(appDataDoc).toEqual(CUSTOM_APP_DATA_DOC)
   })
 
   test('Throws with wrong hash format', async () => {

--- a/src/api/metadata/metadata.spec.ts
+++ b/src/api/metadata/metadata.spec.ts
@@ -161,7 +161,7 @@ describe('appDataHexToCid', () => {
 })
 
 describe('calculateAppDataHash', () => {
-  test('Valid: pre-calculated CIDv0 and appDataHash', async () => {
+  test('Happy path', async () => {
     // when
     const result = await cowSdk.metadataApi.calculateAppDataHash(DEFAULT_APP_DATA_DOC)
     // then
@@ -169,7 +169,7 @@ describe('calculateAppDataHash', () => {
     expect(result).toEqual({ cidV0: IPFS_HASH, appDataHash: APP_DATA_HEX })
   })
 
-  test('Invalid: pre-calculated CIDv0 not valid appDoc', async () => {
+  test('Throws with invalid appDoc', async () => {
     // given
     const doc = {
       ...DEFAULT_APP_DATA_DOC,
@@ -181,7 +181,7 @@ describe('calculateAppDataHash', () => {
     await expect(promise).rejects.toThrow('Invalid appData provided')
   })
 
-  test('Invalid: Could not derive a the appDataHash', async () => {
+  test('Throws when cannot derive the appDataHash', async () => {
     // given
     const mock = jest.fn()
     cowSdk.metadataApi.cidToAppDataHex = mock

--- a/src/utils/appData.spec.ts
+++ b/src/utils/appData.spec.ts
@@ -1,58 +1,8 @@
 import fetchMock from 'jest-fetch-mock'
-import { validateAppDataDocument, getSerializedCID, loadIpfsFromCid } from './appData'
+import { getSerializedCID, loadIpfsFromCid } from './appData'
 import { DEFAULT_IPFS_READ_URI } from '../constants'
 
-const VALID_RESULT = {
-  result: true,
-}
-
-const BASE_DOCUMENT = {
-  version: '0.1.0',
-  metadata: {},
-}
-
 const INVALID_CID_LENGTH = 'Incorrect length'
-
-describe('validateAppDataDocument', () => {
-  const v010Doc = {
-    ...BASE_DOCUMENT,
-    metatadata: {
-      referrer: { address: '0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9', version: '0.1.0' },
-    },
-  }
-  const v040Doc = {
-    ...v010Doc,
-    version: '0.4.0',
-    metadata: { ...v010Doc.metadata, quote: { slippageBips: '1', version: '0.2.0' } },
-  }
-
-  test('Version matches schema', async () => {
-    // given
-    // when
-    const v010Validation = await validateAppDataDocument(v010Doc, v010Doc.version)
-    const v040Validation = await validateAppDataDocument(v040Doc, v040Doc.version)
-    // then
-    expect(v010Validation).toEqual(VALID_RESULT)
-    expect(v040Validation).toEqual(VALID_RESULT)
-  })
-
-  test("Version doesn't match schema", async () => {
-    // given
-    // when
-    const v030Validation = await validateAppDataDocument(v040Doc, '0.3.0')
-    // then
-    expect(v030Validation.result).toBeFalsy()
-    expect(v030Validation.errors).toEqual("data/metadata/quote must have required property 'sellAmount'")
-  })
-
-  test("Version doesn't exist", async () => {
-    // given
-    // when
-    const validation = validateAppDataDocument(v010Doc, '0.0.0')
-    // then
-    await expect(validation).rejects.toThrow('AppData version 0.0.0 does not exist')
-  })
-})
 
 describe('getSerializedCID', () => {
   test('Serializes hash into CID', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1097,10 +1097,12 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cowprotocol/app-data@^0.0.1-RC.1":
-  version "0.0.1-RC.1"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.0.1-RC.1.tgz#1d00036a1f49ffb6128f424e7a778c50973e9248"
-  integrity sha512-LYMRjU7xDd8t9KZXkRI36AN1RtgdxACXvqv/9yqNpi0AxRiePH5bqTOYm9RuFwIzmAbHq5xGN2/rSCxfvfU9eQ==
+"@cowprotocol/app-data@^0.0.1-RC.2":
+  version "0.0.1-RC.2"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.0.1-RC.2.tgz#0cde63b2efa9b36046c5c4c37e2ab72b9efe93d3"
+  integrity sha512-wA6DRCTStN+whPkawwRctAjUKlBXFrrAiysYIqsM02Vj0AuyhfygRBxRHG9g2vyssqR3dIYNQkJkserNyHX+pg==
+  dependencies:
+    ajv "^8.11.0"
 
 "@cowprotocol/contracts@^1.3.1":
   version "1.3.1"
@@ -2541,9 +2543,9 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.8.2:
+ajv@^8.11.0, ajv@^8.8.2:
   version "8.11.0"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
   integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
   dependencies:
     fast-deep-equal "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2543,7 +2543,7 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.11.0, ajv@^8.8.2:
+ajv@^8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
   integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==


### PR DESCRIPTION
# Summary

- Exposing new methods on metadata api:
    - `getAppDataSchema`
    - `validateAppDataDoc`
- Refactored appData and metadata unit tests

# Testing

Unit tests 