### PR TITLE
CowSdk options params to enable 0x and Paraswap APIs

### DIFF
--- a/src/CowSdk.ts
+++ b/src/CowSdk.ts
@@ -26,8 +26,8 @@ export class CowSdk<T extends ChainId> {
   paraswapApi?: ParaswapApi
 
   constructor(chainId: T = SupportedChainId.MAINNET as T, cowContext: CowContext = {}, options: Options = {}) {
-    const zeroXEnabled = !!options?.zeroXOptions?.enabled
-    const paraswapEnabled = !!options?.paraswapOptions?.enabled
+    const zeroXEnabled = options?.zeroXOptions?.enabled ?? false
+    const paraswapEnabled = options?.paraswapOptions?.enabled ?? false
 
     this.context = new Context(chainId, { ...cowContext })
     this.cowApi = new CowApi(this.context)

--- a/src/CowSdk.ts
+++ b/src/CowSdk.ts
@@ -6,12 +6,15 @@ import { SupportedChainId as ChainId, SupportedChainId } from './constants/chain
 import { Context, CowContext } from './utils/context'
 import { signOrder, signOrderCancellation, UnsignedOrder } from './utils/sign'
 import { ZeroXApi } from './api/0x'
-import { MatchaOptions } from './api/0x/types'
+import { ZeroXOptions } from './api/0x/types'
 import ParaswapApi from './api/paraswap'
+import { ParaswapOptions } from './api/paraswap/types'
+import { WithEnabled } from './types'
 
 type Options = {
   loglevel?: LogLevelDesc
-  matchaOptions?: MatchaOptions
+  zeroXOptions?: Partial<ZeroXOptions & WithEnabled>
+  paraswapOptions?: Partial<ParaswapOptions> & WithEnabled
 }
 
 export class CowSdk<T extends ChainId> {
@@ -19,16 +22,21 @@ export class CowSdk<T extends ChainId> {
   cowApi: CowApi
   metadataApi: MetadataApi
   cowSubgraphApi: CowSubgraphApi
-  zeroXApi: ZeroXApi
-  paraswapApi: ParaswapApi
+  zeroXApi?: ZeroXApi
+  paraswapApi?: ParaswapApi
 
   constructor(chainId: T = SupportedChainId.MAINNET as T, cowContext: CowContext = {}, options: Options = {}) {
+    const zeroXEnabled = !!options?.zeroXOptions?.enabled
+    const paraswapEnabled = !!options?.paraswapOptions?.enabled
+
     this.context = new Context(chainId, { ...cowContext })
     this.cowApi = new CowApi(this.context)
     this.cowSubgraphApi = new CowSubgraphApi(this.context)
     this.metadataApi = new MetadataApi(this.context)
-    this.zeroXApi = new ZeroXApi(chainId, options.matchaOptions)
-    this.paraswapApi = new ParaswapApi()
+
+    this.zeroXApi = zeroXEnabled ? new ZeroXApi(chainId, options.zeroXOptions) : undefined
+    this.paraswapApi = paraswapEnabled ? new ParaswapApi(options.paraswapOptions) : undefined
+
     log.setLevel(options.loglevel || 'ERROR')
   }
 

--- a/src/api/0x/0x-quote.spec.ts
+++ b/src/api/0x/0x-quote.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 import { OrderKind } from '@cowprotocol/contracts'
 import { PriceQuoteLegacyParams } from '../cow/types'
@@ -9,7 +10,7 @@ enableFetchMocks()
 
 const chainId = SupportedChainId.MAINNET
 
-const cowSdk = new CowSdk(chainId, {}, { loglevel: 'debug' })
+const cowSdk = new CowSdk(chainId, {}, { loglevel: 'debug', zeroXOptions: { enabled: true } })
 
 const HTTP_STATUS_OK = 200
 
@@ -67,7 +68,7 @@ describe('Get Quote', () => {
     fetchMock.mockResponseOnce(JSON.stringify(PRICE_QUOTE_RESPONSE), { status: HTTP_STATUS_OK })
 
     // WHEN - we fetch a quote
-    const price = await cowSdk.zeroXApi.getQuote(query)
+    const price = await cowSdk.zeroXApi!.getQuote(query)
 
     // THEN
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -87,7 +88,8 @@ describe('Get Quote', () => {
       chainId,
       {},
       {
-        matchaOptions: {
+        zeroXOptions: {
+          enabled: true,
           affiliateAddressMap: {
             [SupportedChainId.MAINNET]: '0xAFFILIATE_ADDRESS_MAINNET',
           },
@@ -96,7 +98,7 @@ describe('Get Quote', () => {
       }
     )
     // WHEN - we fetch a quote
-    const price = await cowSdk.zeroXApi.getQuote(query)
+    const price = await cowSdk.zeroXApi!.getQuote(query)
 
     // THEN
     expect(fetchMock).toHaveBeenCalledTimes(1)

--- a/src/api/0x/0x-quote.spec.ts
+++ b/src/api/0x/0x-quote.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 import { OrderKind } from '@cowprotocol/contracts'
 import { PriceQuoteLegacyParams } from '../cow/types'
@@ -68,7 +67,7 @@ describe('Get Quote', () => {
     fetchMock.mockResponseOnce(JSON.stringify(PRICE_QUOTE_RESPONSE), { status: HTTP_STATUS_OK })
 
     // WHEN - we fetch a quote
-    const price = await cowSdk.zeroXApi!.getQuote(query)
+    const price = await cowSdk.zeroXApi.getQuote(query)
 
     // THEN
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -98,7 +97,7 @@ describe('Get Quote', () => {
       }
     )
     // WHEN - we fetch a quote
-    const price = await cowSdk.zeroXApi!.getQuote(query)
+    const price = await cowSdk.zeroXApi.getQuote(query)
 
     // THEN
     expect(fetchMock).toHaveBeenCalledTimes(1)

--- a/src/api/0x/error/0x-error.spec.ts
+++ b/src/api/0x/error/0x-error.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { OrderKind } from '@cowprotocol/contracts'
 import { enableFetchMocks } from 'jest-fetch-mock'
 import ZeroXError from '.'
@@ -9,7 +10,7 @@ enableFetchMocks()
 
 const chainId = SupportedChainId.MAINNET
 
-const cowSdk = new CowSdk(chainId, {}, { loglevel: 'debug' })
+const cowSdk = new CowSdk(chainId, {}, { loglevel: 'debug', zeroXOptions: { enabled: true } })
 
 const query = {
   baseToken: '0x6810e776880c02933d47db1b9fc05908e5386b96',
@@ -47,7 +48,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN
-      await cowSdk.zeroXApi.getQuote(query)
+      await cowSdk.zeroXApi!.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the error to be properly constructed
@@ -77,7 +78,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi.getQuote(query)
+      await cowSdk.zeroXApi!.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed
@@ -94,7 +95,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi.getQuote(query)
+      await cowSdk.zeroXApi!.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed
@@ -111,7 +112,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi.getQuote(query)
+      await cowSdk.zeroXApi!.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed
@@ -128,7 +129,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi.getQuote(query)
+      await cowSdk.zeroXApi!.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed
@@ -145,7 +146,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi.getQuote(query)
+      await cowSdk.zeroXApi!.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed
@@ -162,7 +163,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi.getQuote(query)
+      await cowSdk.zeroXApi!.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed

--- a/src/api/0x/error/0x-error.spec.ts
+++ b/src/api/0x/error/0x-error.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { OrderKind } from '@cowprotocol/contracts'
 import { enableFetchMocks } from 'jest-fetch-mock'
 import ZeroXError from '.'
@@ -48,7 +47,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN
-      await cowSdk.zeroXApi!.getQuote(query)
+      await cowSdk.zeroXApi.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the error to be properly constructed
@@ -78,7 +77,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi!.getQuote(query)
+      await cowSdk.zeroXApi.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed
@@ -95,7 +94,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi!.getQuote(query)
+      await cowSdk.zeroXApi.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed
@@ -112,7 +111,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi!.getQuote(query)
+      await cowSdk.zeroXApi.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed
@@ -129,7 +128,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi!.getQuote(query)
+      await cowSdk.zeroXApi.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed
@@ -146,7 +145,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi!.getQuote(query)
+      await cowSdk.zeroXApi.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed
@@ -163,7 +162,7 @@ describe('0x Error handling', () => {
 
     try {
       // WHEN request is made
-      await cowSdk.zeroXApi!.getQuote(query)
+      await cowSdk.zeroXApi.getQuote(query)
     } catch (error) {
       const e = error instanceof ZeroXError ? error : undefined
       // THEN expect the e to be properly constructed

--- a/src/api/0x/index.ts
+++ b/src/api/0x/index.ts
@@ -11,7 +11,7 @@ import BaseApi from '../base'
 
 import { Options, PriceQuoteLegacyParams } from '../cow/types'
 import { logPrefix } from './error'
-import { ERC20BridgeSource, ZeroXOptions, MatchaPriceQuote } from './types'
+import { ERC20BridgeSource, ZeroXOptions, ZeroXQuote } from './types'
 import {
   throwOrReturnAffiliateAddress,
   optionsToMatchaParamsUrl,
@@ -47,7 +47,7 @@ export class ZeroXApi extends BaseApi {
     })
   }
 
-  async getQuote(params: PriceQuoteLegacyParams, options: Options = {}): Promise<MatchaPriceQuote | null> {
+  async getQuote(params: PriceQuoteLegacyParams, options: Options = {}): Promise<ZeroXQuote | null> {
     const { amount, baseToken, quoteToken, kind } = params
     const { chainId: customChainId, env = this.context.env } = options
     const chainId = customChainId || (await this.context.chainId)

--- a/src/api/0x/types.ts
+++ b/src/api/0x/types.ts
@@ -34,7 +34,7 @@ export interface MatchaPriceQuote extends MatchaBaseQuote {
   gas: string
 }
 
-export type MatchaOptions = {
+export type ZeroXOptions = {
   affiliateAddressMap: Partial<Record<number, string>>
   excludedSources: ERC20BridgeSource[]
 }

--- a/src/api/0x/types.ts
+++ b/src/api/0x/types.ts
@@ -11,7 +11,7 @@ interface GetSwapQuoteResponseLiquiditySource {
 }
 
 // https://github.com/0xProject/0x-api/blob/8c4cc7bb8d4fa06a220b7dfd5784361c05daa92a/src/types.ts#L229
-interface MatchaBaseQuote {
+interface ZeroXBaseQuote {
   chainId: SupportedChainId
   price: string
   buyAmount: string
@@ -27,7 +27,7 @@ interface MatchaBaseQuote {
 }
 
 // https://github.com/0xProject/0x-api/blob/8c4cc7bb8d4fa06a220b7dfd5784361c05daa92a/src/types.ts#L229
-export interface MatchaPriceQuote extends MatchaBaseQuote {
+export interface ZeroXQuote extends ZeroXBaseQuote {
   sellTokenAddress: string
   buyTokenAddress: string
   value: string

--- a/src/api/0x/utils.ts
+++ b/src/api/0x/utils.ts
@@ -4,7 +4,7 @@ import { SupportedChainId } from '../../constants/chains'
 import { objectToQueryString, CowError } from '../../utils/common'
 import { PriceInformation, PriceQuoteLegacyParams } from '../cow/types'
 import ZeroXError, { ZeroXErrorResponse, logPrefix } from './error'
-import { MatchaOptions, MatchaPriceQuote } from './types'
+import { ZeroXOptions, MatchaPriceQuote } from './types'
 
 export function get0xUrls(): Partial<Record<SupportedChainId, string>> {
   // Support: Mainnet, Ropsten, Polygon, Binance Smart Chain
@@ -46,7 +46,7 @@ export function optionsToMatchaParamsUrl({
   excludedSources,
   affiliateAddress,
 }: {
-  excludedSources: MatchaOptions['excludedSources']
+  excludedSources: ZeroXOptions['excludedSources']
   affiliateAddress: string
 }): string {
   const excludedSourceString = extractExcludedSources({ excludedSources })
@@ -84,7 +84,7 @@ export function throwOrReturnAffiliateAddress({
   affiliateAddressMap,
   chainId,
 }: {
-  affiliateAddressMap: MatchaOptions['affiliateAddressMap']
+  affiliateAddressMap: ZeroXOptions['affiliateAddressMap']
   chainId: SupportedChainId
 }): string {
   const affiliateAddress = affiliateAddressMap[chainId]
@@ -95,7 +95,7 @@ export function throwOrReturnAffiliateAddress({
   return affiliateAddress
 }
 
-export function extractExcludedSources({ excludedSources }: Pick<MatchaOptions, 'excludedSources'>) {
+export function extractExcludedSources({ excludedSources }: Pick<ZeroXOptions, 'excludedSources'>) {
   return excludedSources.length > 0 ? excludedSources.join(',') : ''
 }
 

--- a/src/api/0x/utils.ts
+++ b/src/api/0x/utils.ts
@@ -4,7 +4,7 @@ import { SupportedChainId } from '../../constants/chains'
 import { objectToQueryString, CowError } from '../../utils/common'
 import { PriceInformation, PriceQuoteLegacyParams } from '../cow/types'
 import ZeroXError, { ZeroXErrorResponse, logPrefix } from './error'
-import { ZeroXOptions, MatchaPriceQuote } from './types'
+import { ZeroXOptions, ZeroXQuote } from './types'
 
 export function get0xUrls(): Partial<Record<SupportedChainId, string>> {
   // Support: Mainnet, Ropsten, Polygon, Binance Smart Chain
@@ -14,7 +14,7 @@ export function get0xUrls(): Partial<Record<SupportedChainId, string>> {
   }
 }
 
-export function normaliseQuoteResponse(priceRaw: MatchaPriceQuote | null, kind: OrderKind): PriceInformation | null {
+export function normaliseQuoteResponse(priceRaw: ZeroXQuote | null, kind: OrderKind): PriceInformation | null {
   if (!priceRaw || !priceRaw.price) {
     return null
   }

--- a/src/api/paraswap/index.ts
+++ b/src/api/paraswap/index.ts
@@ -22,10 +22,10 @@ export default class ParaswapApi {
   #apiUrl: string
   #rateOptions: RateOptions
 
-  constructor() {
+  constructor(options: RateOptions = {}) {
     this.name = API_NAME
     this.#apiUrl = BASE_URL
-    this.#rateOptions = DEFAULT_RATE_OPTIONS
+    this.#rateOptions = { ...DEFAULT_RATE_OPTIONS, ...options }
   }
 
   async getQuote(

--- a/src/api/paraswap/paraswap.spec.ts
+++ b/src/api/paraswap/paraswap.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { OrderKind } from '@cowprotocol/contracts'
 import { SupportedChainId } from '../../constants/chains'
 import CowSdk from '../../CowSdk'
@@ -107,7 +108,7 @@ const query = {
 } as ParaswapPriceQuoteParams
 
 const chainId = SupportedChainId.MAINNET
-const cowSdk = new CowSdk(chainId, {}, { loglevel: 'debug' })
+const cowSdk = new CowSdk(chainId, {}, { loglevel: 'debug', paraswapOptions: { enabled: true } })
 
 describe('Get Quote', () => {
   beforeEach(() => {
@@ -119,7 +120,7 @@ describe('Get Quote', () => {
     // GIVEN
     // WHEN
     expect.assertions(1)
-    const price = await cowSdk.paraswapApi.getQuote({ ...query, chainId: 1 })
+    const price = await cowSdk.paraswapApi!.getQuote({ ...query, chainId: 1 })
 
     // THEN
     expect(price).toEqual(PRICE_QUOTE_RESPONSE)
@@ -130,7 +131,7 @@ describe('Get Quote', () => {
     // WHEN
     expect.assertions(1)
     // user forces TS to accept chain as valid
-    const promise = cowSdk.paraswapApi.getQuote({ ...query, chainId: 2 as NetworkID })
+    const promise = cowSdk.paraswapApi!.getQuote({ ...query, chainId: 2 as NetworkID })
 
     // THEN
     expect(promise).rejects.toThrow(new CowError("ParaswapApi isn't compatible with chainId " + 2))
@@ -140,7 +141,7 @@ describe('Get Quote', () => {
     // GIVEN
     // WHEN
     expect.assertions(1)
-    const price = await cowSdk.paraswapApi.getQuoteAllNetworks(query)
+    const price = await cowSdk.paraswapApi!.getQuoteAllNetworks(query)
 
     // THEN
     expect(price).toEqual(PRICE_QUOTE_RESPONSE)
@@ -150,7 +151,7 @@ describe('Get Quote', () => {
     // GIVEN
     // WHEN
     expect.assertions(1)
-    const price = await cowSdk.paraswapApi.getQuoteCowNetworks({ ...query, chainId: 1 })
+    const price = await cowSdk.paraswapApi!.getQuoteCowNetworks({ ...query, chainId: 1 })
 
     // THEN
     expect(price).toEqual(PRICE_QUOTE_RESPONSE)
@@ -172,7 +173,7 @@ describe('Error responses', () => {
 
     try {
       // WHEN
-      await cowSdk.paraswapApi.getQuote(query)
+      await cowSdk.paraswapApi!.getQuote(query)
     } catch (error) {
       // THEN
       expect(error).toEqual(
@@ -201,7 +202,7 @@ describe('Error responses', () => {
 
     try {
       // WHEN
-      await cowSdk.paraswapApi.getQuote(query)
+      await cowSdk.paraswapApi!.getQuote(query)
     } catch (error) {
       // THEN
       expect(error).toEqual(
@@ -221,23 +222,23 @@ describe('Changing class options', () => {
   test('RETURNS correct apiUrl after changing it', async () => {
     // GIVEN
     // WHEN - we fetch a quote passing in excludedSources as the RateOptions
-    cowSdk.paraswapApi.updateOptions({ apiUrl: 'https://apiv6.paraswap.io' })
+    cowSdk.paraswapApi!.updateOptions({ apiUrl: 'https://apiv6.paraswap.io' })
 
     // THEN
-    expect(cowSdk.paraswapApi.apiUrl).toEqual('https://apiv6.paraswap.io')
+    expect(cowSdk.paraswapApi!.apiUrl).toEqual('https://apiv6.paraswap.io')
   })
   test('RETURNS empty rateOptions object when passing null', async () => {
     // GIVEN
     // WHEN - we fetch a quote passing in excludedSources as the RateOptions
-    cowSdk.paraswapApi.updateOptions({ rateOptions: null })
+    cowSdk.paraswapApi!.updateOptions({ rateOptions: null })
 
     // THEN
-    expect(cowSdk.paraswapApi.rateOptions).toEqual({})
+    expect(cowSdk.paraswapApi!.rateOptions).toEqual({})
   })
   test('RETURNS updated rateOptions object', async () => {
     // GIVEN
     // WHEN - we fetch a quote passing in excludedSources as the RateOptions
-    cowSdk.paraswapApi.updateOptions({
+    cowSdk.paraswapApi!.updateOptions({
       rateOptions: {
         excludePools: 'UniswapV2',
         excludeDEXS: 'CowSwap',
@@ -245,10 +246,10 @@ describe('Changing class options', () => {
     })
 
     // THEN
-    expect(cowSdk.paraswapApi.rateOptions).toEqual({
+    expect(cowSdk.paraswapApi!.rateOptions).toEqual({
       excludePools: 'UniswapV2',
       // T_T - don't do this!
       excludeDEXS: 'CowSwap',
     })
-  })
+  })!
 })

--- a/src/api/paraswap/paraswap.spec.ts
+++ b/src/api/paraswap/paraswap.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { OrderKind } from '@cowprotocol/contracts'
 import { SupportedChainId } from '../../constants/chains'
 import CowSdk from '../../CowSdk'
@@ -120,7 +119,7 @@ describe('Get Quote', () => {
     // GIVEN
     // WHEN
     expect.assertions(1)
-    const price = await cowSdk.paraswapApi!.getQuote({ ...query, chainId: 1 })
+    const price = await cowSdk.paraswapApi.getQuote({ ...query, chainId: 1 })
 
     // THEN
     expect(price).toEqual(PRICE_QUOTE_RESPONSE)
@@ -131,7 +130,7 @@ describe('Get Quote', () => {
     // WHEN
     expect.assertions(1)
     // user forces TS to accept chain as valid
-    const promise = cowSdk.paraswapApi!.getQuote({ ...query, chainId: 2 as NetworkID })
+    const promise = cowSdk.paraswapApi.getQuote({ ...query, chainId: 2 as NetworkID })
 
     // THEN
     expect(promise).rejects.toThrow(new CowError("ParaswapApi isn't compatible with chainId " + 2))
@@ -141,7 +140,7 @@ describe('Get Quote', () => {
     // GIVEN
     // WHEN
     expect.assertions(1)
-    const price = await cowSdk.paraswapApi!.getQuoteAllNetworks(query)
+    const price = await cowSdk.paraswapApi.getQuoteAllNetworks(query)
 
     // THEN
     expect(price).toEqual(PRICE_QUOTE_RESPONSE)
@@ -151,7 +150,7 @@ describe('Get Quote', () => {
     // GIVEN
     // WHEN
     expect.assertions(1)
-    const price = await cowSdk.paraswapApi!.getQuoteCowNetworks({ ...query, chainId: 1 })
+    const price = await cowSdk.paraswapApi.getQuoteCowNetworks({ ...query, chainId: 1 })
 
     // THEN
     expect(price).toEqual(PRICE_QUOTE_RESPONSE)
@@ -173,7 +172,7 @@ describe('Error responses', () => {
 
     try {
       // WHEN
-      await cowSdk.paraswapApi!.getQuote(query)
+      await cowSdk.paraswapApi.getQuote(query)
     } catch (error) {
       // THEN
       expect(error).toEqual(
@@ -202,7 +201,7 @@ describe('Error responses', () => {
 
     try {
       // WHEN
-      await cowSdk.paraswapApi!.getQuote(query)
+      await cowSdk.paraswapApi.getQuote(query)
     } catch (error) {
       // THEN
       expect(error).toEqual(
@@ -222,23 +221,23 @@ describe('Changing class options', () => {
   test('RETURNS correct apiUrl after changing it', async () => {
     // GIVEN
     // WHEN - we fetch a quote passing in excludedSources as the RateOptions
-    cowSdk.paraswapApi!.updateOptions({ apiUrl: 'https://apiv6.paraswap.io' })
+    cowSdk.paraswapApi.updateOptions({ apiUrl: 'https://apiv6.paraswap.io' })
 
     // THEN
-    expect(cowSdk.paraswapApi!.apiUrl).toEqual('https://apiv6.paraswap.io')
+    expect(cowSdk.paraswapApi.apiUrl).toEqual('https://apiv6.paraswap.io')
   })
   test('RETURNS empty rateOptions object when passing null', async () => {
     // GIVEN
     // WHEN - we fetch a quote passing in excludedSources as the RateOptions
-    cowSdk.paraswapApi!.updateOptions({ rateOptions: null })
+    cowSdk.paraswapApi.updateOptions({ rateOptions: null })
 
     // THEN
-    expect(cowSdk.paraswapApi!.rateOptions).toEqual({})
+    expect(cowSdk.paraswapApi.rateOptions).toEqual({})
   })
   test('RETURNS updated rateOptions object', async () => {
     // GIVEN
     // WHEN - we fetch a quote passing in excludedSources as the RateOptions
-    cowSdk.paraswapApi!.updateOptions({
+    cowSdk.paraswapApi.updateOptions({
       rateOptions: {
         excludePools: 'UniswapV2',
         excludeDEXS: 'CowSwap',
@@ -246,10 +245,10 @@ describe('Changing class options', () => {
     })
 
     // THEN
-    expect(cowSdk.paraswapApi!.rateOptions).toEqual({
+    expect(cowSdk.paraswapApi.rateOptions).toEqual({
       excludePools: 'UniswapV2',
       // T_T - don't do this!
       excludeDEXS: 'CowSwap',
     })
-  })!
+  })
 })

--- a/src/api/paraswap/types.ts
+++ b/src/api/paraswap/types.ts
@@ -11,6 +11,7 @@ export type QuoteOptions<T extends boolean> = {
   // bypasses null return when passed non-cow compatible chainId
   allowParaswapNetworks?: T
 }
+export type ParaswapOptions = RateOptions
 export type ParaswapPriceQuoteParams = Omit<PriceQuoteLegacyParams, 'validTo'> & {
   fromDecimals: number
   toDecimals: number

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,10 +1,11 @@
 export * from '../api/cow/types'
 export * from '../api/metadata/types'
+export * from './sdk'
 export { OrderKind } from '@cowprotocol/contracts'
 export class Token {
   constructor(public symbol: string, public address: string) {}
 }
 
 export type WithEnabled = {
-  enabled?: boolean
+  enabled: boolean
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,7 @@ export { OrderKind } from '@cowprotocol/contracts'
 export class Token {
   constructor(public symbol: string, public address: string) {}
 }
+
+export type WithEnabled = {
+  enabled?: boolean
+}

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -1,0 +1,32 @@
+import { LogLevelDesc } from 'loglevel'
+import { ExtendsObject } from 'utilities'
+import { WithEnabled } from '.'
+// 0x
+import { ZeroXApi } from '../api/0x'
+import { ZeroXOptions } from '../api/0x/types'
+// paraswap
+import ParaswapApi from '../api/paraswap'
+import { ParaswapOptions } from '../api/paraswap/types'
+
+export type SdkOptions = {
+  loglevel?: LogLevelDesc
+  zeroXOptions?: Partial<ZeroXOptions> & WithEnabled
+  paraswapOptions?: Partial<ParaswapOptions> & WithEnabled
+}
+export type OptionsWithZeroXEnabled = SdkOptions & { zeroXOptions: Partial<ZeroXOptions> & { enabled: true } }
+export type OptionsWithParaswapEnabled = SdkOptions & { paraswapOptions: Partial<ParaswapOptions> & { enabled: true } }
+
+export type ZeroXEnabled<Opt> = ExtendsObject<Opt, OptionsWithZeroXEnabled, ZeroXApi, undefined>
+export type ParaswapEnabled<Opt> = ExtendsObject<Opt, OptionsWithParaswapEnabled, ParaswapApi, undefined>
+
+export type OptionsWithApisEnabledStatus = SdkOptions &
+  (
+    | {
+        paraswapOptions: Partial<ParaswapOptions> & { enabled: true }
+        zeroXOptions: Partial<ZeroXOptions> & { enabled: true }
+      }
+    | {
+        paraswapOptions: Partial<ParaswapOptions> & { enabled: false }
+        zeroXOptions: Partial<ZeroXOptions> & { enabled: false }
+      }
+  )

--- a/src/types/utilities.d.ts
+++ b/src/types/utilities.d.ts
@@ -3,3 +3,5 @@ type StrictUnionHelper<T, TAll> = T extends unknown
   ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>>
   : never
 export type StrictUnion<T> = StrictUnionHelper<T, T>
+export type ExtendsObject<ExtendingObject, ExtendableObject, ResultingType, FallbackType> =
+  ExtendingObject extends ExtendableObject ? ResultingType : FallbackType

--- a/yarn.lock
+++ b/yarn.lock
@@ -7335,29 +7335,6 @@ multicodec@^1.0.0:
     buffer "^5.6.0"
     varint "^5.0.0"
 
-multibase@~0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.6.1.tgz#b76df6298536cc17b9f6a6db53ec88f85f8cc12b"
-  integrity sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==
-  dependencies:
-    base-x "^3.0.8"
-    buffer "^5.5.0"
-
-multicodec@^0.5.5:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-0.5.7.tgz#1fb3f9dd866a10a55d226e194abba2dcc1ee9ffd"
-  integrity sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==
-  dependencies:
-    varint "^5.0.0"
-
-multicodec@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-1.0.4.tgz#46ac064657c40380c28367c90304d8ed175a714f"
-  integrity sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==
-  dependencies:
-    buffer "^5.6.0"
-    varint "^5.0.0"
-
 multicodec@^3.0.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-3.2.1.tgz#82de3254a0fb163a107c1aab324f2a91ef51efb2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7335,6 +7335,29 @@ multicodec@^1.0.0:
     buffer "^5.6.0"
     varint "^5.0.0"
 
+multibase@~0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.6.1.tgz#b76df6298536cc17b9f6a6db53ec88f85f8cc12b"
+  integrity sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==
+  dependencies:
+    base-x "^3.0.8"
+    buffer "^5.5.0"
+
+multicodec@^0.5.5:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-0.5.7.tgz#1fb3f9dd866a10a55d226e194abba2dcc1ee9ffd"
+  integrity sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==
+  dependencies:
+    varint "^5.0.0"
+
+multicodec@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-1.0.4.tgz#46ac064657c40380c28367c90304d8ed175a714f"
+  integrity sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==
+  dependencies:
+    buffer "^5.6.0"
+    varint "^5.0.0"
+
 multicodec@^3.0.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-3.2.1.tgz#82de3254a0fb163a107c1aab324f2a91ef51efb2"


### PR DESCRIPTION
CowSdk has options parameter to enable `ZeroXApi` and `ParaswapApi`

1. Adjusts tests
2. Small update to `ParaswapApi` constructor to allow passing options
3. Rename instances of `Matcha` to be `ZeroX`