### PR TITLE
Add Staging to the subgraph API & other fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cross-fetch": "^3.1.5",
     "ethers": "^5.5.3",
     "graphql": "^16.3.0",
-    "graphql-request": "^4.1.0",
+    "graphql-request": "^4.3.0",
     "ipfs-only-hash": "^4.0.0",
     "loglevel": "^1.8.0",
     "multiformats": "^9.6.4",

--- a/src/api/cow/cow.spec.ts
+++ b/src/api/cow/cow.spec.ts
@@ -262,12 +262,10 @@ test('Valid: Get last 5 trades for a given trader ', async () => {
   fetchMock.mockResponseOnce(JSON.stringify(TRADES_RESPONSE), { status: HTTP_STATUS_OK, headers: HEADERS })
   const trades = await cowSdk.cowApi.getTrades({
     owner: TRADE_RESPONSE.owner, // Trader
-    limit: 5,
-    offset: 0,
   })
   expect(fetchMock).toHaveBeenCalledTimes(1)
   expect(fetchMock).toHaveBeenCalledWith(
-    `https://api.cow.fi/rinkeby/api/v1/trades?owner=${TRADE_RESPONSE.owner}&limit=5`,
+    `https://api.cow.fi/rinkeby/api/v1/trades?owner=${TRADE_RESPONSE.owner}`,
     FETCH_RESPONSE_PARAMETERS
   )
   expect(trades.length).toEqual(5)
@@ -278,12 +276,10 @@ test('Valid: Get last 5 trades for a given order id ', async () => {
   fetchMock.mockResponseOnce(JSON.stringify(TRADES_RESPONSE), { status: HTTP_STATUS_OK, headers: HEADERS })
   const trades = await cowSdk.cowApi.getTrades({
     orderId: TRADE_RESPONSE.orderUid,
-    limit: 5,
-    offset: 0,
   })
   expect(fetchMock).toHaveBeenCalledTimes(1)
   expect(fetchMock).toHaveBeenCalledWith(
-    `https://api.cow.fi/rinkeby/api/v1/trades?orderUid=${TRADE_RESPONSE.orderUid}&limit=5`,
+    `https://api.cow.fi/rinkeby/api/v1/trades?orderUid=${TRADE_RESPONSE.orderUid}`,
     FETCH_RESPONSE_PARAMETERS
   )
   expect(trades.length).toEqual(5)
@@ -295,8 +291,6 @@ test('Invalid: Get trades passing both the owner and orderId', async () => {
     cowSdk.cowApi.getTrades({
       owner: TRADE_RESPONSE.owner,
       orderId: TRADE_RESPONSE.orderUid,
-      limit: 5,
-      offset: 0,
     })
   ).rejects.toThrowError(CowError)
 })
@@ -313,15 +307,13 @@ test('Invalid: Get last 5 trades for an unexisting trader ', async () => {
   try {
     await cowSdk.cowApi.getTrades({
       owner: 'invalidOwner',
-      limit: 5,
-      offset: 0,
     })
   } catch (e: unknown) {
     const error = e as OperatorError
     expect(error.message).toEqual('Token pair selected has insufficient liquidity')
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.cow.fi/rinkeby/api/v1/trades?owner=invalidOwner&limit=5',
+      'https://api.cow.fi/rinkeby/api/v1/trades?owner=invalidOwner',
       FETCH_RESPONSE_PARAMETERS
     )
   }
@@ -618,14 +610,12 @@ test('Valid: Get last 5 trades changing options parameters', async () => {
   const trades = await cowSdk.cowApi.getTrades(
     {
       owner: TRADE_RESPONSE.owner, // Trader
-      limit: 5,
-      offset: 0,
     },
     { env: 'staging', chainId: SupportedChainId.MAINNET }
   )
   expect(fetchMock).toHaveBeenCalledTimes(1)
   expect(fetchMock).toHaveBeenCalledWith(
-    `https://barn.api.cow.fi/mainnet/api/v1/trades?owner=${TRADE_RESPONSE.owner}&limit=5`,
+    `https://barn.api.cow.fi/mainnet/api/v1/trades?owner=${TRADE_RESPONSE.owner}`,
     FETCH_RESPONSE_PARAMETERS
   )
   expect(trades.length).toEqual(5)

--- a/src/api/cow/index.ts
+++ b/src/api/cow/index.ts
@@ -129,13 +129,13 @@ export class CowApi extends BaseApi {
 
   async getTrades(params: GetTradesParams, options: Options = {}): Promise<TradeMetaData[]> {
     const { chainId: networkId, env = this.context.env } = options
-    const { owner, orderId, limit, offset } = params
+    const { owner, orderId } = params
     if (owner && orderId) {
       throw new CowError('Cannot specify both owner and orderId')
     }
-    const qsParams = objectToQueryString({ owner, orderUid: orderId, limit, offset })
+    const qsParams = objectToQueryString({ owner, orderUid: orderId })
     const chainId = networkId || (await this.context.chainId)
-    log.debug(logPrefix, '[util:operator] Get trades for', chainId, { owner, orderId, limit, offset })
+    log.debug(logPrefix, '[util:operator] Get trades for', chainId, { owner, orderId })
     try {
       const response = await this.get(`/trades${qsParams}`, { chainId, env })
 

--- a/src/api/cow/types.ts
+++ b/src/api/cow/types.ts
@@ -79,7 +79,7 @@ type WithOrderId = {
   orderId: string
 }
 
-export type GetTradesParams = StrictUnion<WithOwner | WithOrderId> & PaginationParams
+export type GetTradesParams = StrictUnion<WithOwner | WithOrderId>
 
 export type ProfileData = {
   totalTrades: number

--- a/src/api/cow/types.ts
+++ b/src/api/cow/types.ts
@@ -1,8 +1,8 @@
 import { GetQuoteResponse, OrderKind } from '@cowprotocol/contracts'
-import { StrictUnion } from 'utilities'
 import { SupportedChainId as ChainId } from '../../constants/chains'
 import { Env } from '../../utils/context'
 import { OrderCancellation, SigningSchemeValue } from '../../utils/sign'
+import type { StrictUnion } from '../../types/utilities'
 
 /**
  * Unique identifier for the order, calculated by keccak256(orderDigest, ownerAddress, validTo),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5225,7 +5225,7 @@ graphql-config@^4.1.0:
     minimatch "4.2.1"
     string-env-interpolation "1.0.1"
 
-graphql-request@^4.0.0, graphql-request@^4.1.0:
+graphql-request@^4.0.0, graphql-request@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.3.0.tgz#b934e08fcae764aa2cdc697d3c821f046cb5dbf2"
   integrity sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==


### PR DESCRIPTION
* Add the Options object to the subgraph API to change the network and environment on each method call
* Add mainnet and gc staging endpoints to the subgraph API
* Remove unneeded pagination for the [`/trades` endpoint](https://api.cow.fi/docs/#/default/get_api_v1_trades)
* Fixes a `StrictUnion` import which [caused issues](https://github.com/cowprotocol/cow-sdk/issues/36#issuecomment-1208288514)