### PR TITLE
Fix string comparison in publish script

### DIFF
--- a/src/workflows/publish.sh
+++ b/src/workflows/publish.sh
@@ -37,7 +37,7 @@ if ! git fetch --end-of-options origin "refs/tags/$version_tag" 2>/dev/null; the
 fi
 
 latest_tag="$(git describe --tags --abbrev=0)"
-if ! $version_tag == latest_tag; then
+if ! [ "$version_tag" = "$latest_tag" ]; then
   echo "Latest tag $latest_tag version doesn't match package.json version $version"
   exit 1
 fi


### PR DESCRIPTION
There's an issue in the string comparison of latest_tag which caused the script to try to run `latest_tag` string as a command.

Same as https://github.com/cowprotocol/app-data/pull/14