### PR TITLE
62/export contract addresses

### DIFF
--- a/src/api/0x/index.ts
+++ b/src/api/0x/index.ts
@@ -1,6 +1,6 @@
 import { OrderKind } from '@cowprotocol/contracts'
 import log from 'loglevel'
-import { GP_SETTLEMENT_CONTRACT_ADDRESS } from '../../constants'
+import { COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS } from '../../constants'
 import { SupportedChainId } from '../../constants/chains'
 import { objectToQueryString } from '../../utils/common'
 import { Context } from '../../utils/context'
@@ -13,12 +13,12 @@ import { Options, PriceQuoteLegacyParams } from '../cow/types'
 import { logPrefix } from './error'
 import { ERC20BridgeSource, ZeroXOptions, ZeroXQuote } from './types'
 import {
-  throwOrReturnAffiliateAddress,
-  optionsToMatchaParamsUrl,
   extractExcludedSources,
-  handleQuoteResponse,
-  getMatchaChainId,
   get0xUrls,
+  getMatchaChainId,
+  handleQuoteResponse,
+  optionsToMatchaParamsUrl,
+  throwOrReturnAffiliateAddress,
 } from './utils'
 
 const EXCLUDED_SOURCES: ERC20BridgeSource[] = []
@@ -32,7 +32,7 @@ export class ZeroXApi extends BaseApi {
     super({ context: new Context(chainId, {}), name: '0x', apiVersion: API_VERSION, getApiUrl: get0xUrls })
 
     // get defaults if necessary
-    const affiliateAddressMap = options?.affiliateAddressMap || GP_SETTLEMENT_CONTRACT_ADDRESS
+    const affiliateAddressMap = options?.affiliateAddressMap || COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS
     const excludedSources = options?.excludedSources || EXCLUDED_SOURCES
     // checks if missing affiliate address from address map and throws if undefined else returns address string
     const affiliateAddress = throwOrReturnAffiliateAddress({

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,7 +3,7 @@ import { SupportedChainId as ChainId } from './chains'
 
 const { GPv2Settlement } = JSON.parse(contractNetworks as unknown as string) as typeof contractNetworks
 
-export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<number, string>> = {
+export const COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<number, string>> = {
   [ChainId.MAINNET]: GPv2Settlement[ChainId.MAINNET].address,
   [ChainId.RINKEBY]: GPv2Settlement[ChainId.RINKEBY].address,
   [ChainId.GOERLI]: GPv2Settlement[ChainId.GOERLI].address,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { CowSdk } from './CowSdk'
 export { CowError } from './utils/common'
 export { ALL_SUPPORTED_CHAIN_IDS, SupportedChainId } from './constants/chains'
+export { COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS } from './constants'
 export * from './types'
 export * as GraphQL from './api/cow-subgraph/graphql'

--- a/src/utils/sign.ts
+++ b/src/utils/sign.ts
@@ -1,20 +1,20 @@
 import {
   domain as domainGp,
-  signOrder as signOrderGp,
-  signOrderCancellation as signOrderCancellationGp,
   EcdsaSignature,
+  IntChainIdTypedDataV4Signer,
   Order,
   OrderCancellation as OrderCancellationGp,
   Signature,
-  TypedDataV3Signer,
-  IntChainIdTypedDataV4Signer,
   SigningScheme,
+  signOrder as signOrderGp,
+  signOrderCancellation as signOrderCancellationGp,
+  TypedDataV3Signer,
 } from '@cowprotocol/contracts'
 import log from 'loglevel'
 
 import { SupportedChainId as ChainId } from '../constants/chains'
-import { GP_SETTLEMENT_CONTRACT_ADDRESS } from '../constants'
-import { TypedDataDomain, Signer } from '@ethersproject/abstract-signer'
+import { COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS } from '../constants'
+import { Signer, TypedDataDomain } from '@ethersproject/abstract-signer'
 import { CowError, logPrefix } from './common'
 
 // For error codes, see:
@@ -103,7 +103,7 @@ export function getSigningSchemeLibValue(ecdaSigningScheme: SigningScheme): numb
 
 function _getDomain(chainId: ChainId): TypedDataDomain {
   // Get settlement contract address
-  const settlementContract = GP_SETTLEMENT_CONTRACT_ADDRESS[chainId]
+  const settlementContract = COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS[chainId]
 
   if (!settlementContract) {
     throw new CowError('Unsupported network. Settlement contract is not deployed')


### PR DESCRIPTION
# Summary

Closes #62 

Exposing `COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS`

![Screen Shot 2022-08-29 at 16 58 28](https://user-images.githubusercontent.com/43217/187243669-7bcef890-f02f-4f29-911a-266bca88065d.png)


# Testing

Installed built package using yalc and verified contract addresses were there