### PR TITLE
Calculate totalFee for orders

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+
+[{*.ts,*.tsx}]
+ij_typescript_force_quote_style = true
+ij_typescript_use_double_quotes = false
+ij_typescript_use_semicolon_after_statement = false

--- a/src/api/cow/index.ts
+++ b/src/api/cow/index.ts
@@ -30,7 +30,7 @@ import { ZERO_ADDRESS } from '../../constants'
 import { CowError, logPrefix, objectToQueryString } from '../../utils/common'
 import { Context, Env } from '../../utils/context'
 import BaseApi from '../base'
-import { orderTransform } from './orderTransform'
+import { transformOrder } from './transformOrder'
 
 const API_URL_VERSION = 'v1'
 
@@ -172,7 +172,7 @@ export class CowApi extends BaseApi {
       } else {
         const orders: OrderDto[] = await response.json()
 
-        return orders.map(orderTransform)
+        return orders.map(transformOrder)
       }
     } catch (error) {
       log.error(logPrefix, 'Error getting orders information:', error)
@@ -196,7 +196,7 @@ export class CowApi extends BaseApi {
       } else {
         const orders: OrderDto[] = await response.json()
 
-        return orders.map(orderTransform)
+        return orders.map(transformOrder)
       }
     } catch (error) {
       log.error('Error getting transaction orders information:', error)
@@ -218,7 +218,7 @@ export class CowApi extends BaseApi {
       } else {
         const order: OrderDto = await response.json()
 
-        return orderTransform(order)
+        return transformOrder(order)
       }
     } catch (error) {
       log.error(logPrefix, 'Error getting order information:', error)

--- a/src/api/cow/orderTransform.ts
+++ b/src/api/cow/orderTransform.ts
@@ -1,0 +1,39 @@
+import { OrderDto, OrderMetaData } from './types'
+import { BUY_ETH_ADDRESS } from '@cowprotocol/contracts'
+
+export function orderTransform(order: OrderDto): OrderMetaData {
+  return transformEthFlowOrder(addTotalFeeToOrder(order))
+}
+
+function addTotalFeeToOrder(dto: OrderDto): OrderMetaData {
+  const { executedFeeAmount, executedSurplusFee } = dto
+  const totalFee = executedSurplusFee ?? executedFeeAmount
+
+  return {
+    ...dto,
+    totalFee,
+  }
+}
+
+/**
+ * Transform order field for Native EthFlow orders
+ *
+ * A no-op for regular orders
+ * For Native EthFlow, due to how the contract is setup:
+ * - sellToken set to Native token address
+ * - owner set to `onchainUser`
+ * - validTo set to `ethflowData.userValidTo`
+ */
+function transformEthFlowOrder(order: OrderMetaData): OrderMetaData {
+  const { ethflowData } = order
+
+  if (!ethflowData) {
+    return order
+  }
+
+  const { userValidTo: validTo } = ethflowData
+  const owner = order.onchainUser || order.owner
+  const sellToken = BUY_ETH_ADDRESS
+
+  return { ...order, validTo, owner, sellToken }
+}

--- a/src/api/cow/transformOrder.ts
+++ b/src/api/cow/transformOrder.ts
@@ -1,10 +1,14 @@
 import { OrderDto, OrderMetaData } from './types'
 import { BUY_ETH_ADDRESS } from '@cowprotocol/contracts'
 
-export function orderTransform(order: OrderDto): OrderMetaData {
+export function transformOrder(order: OrderDto): OrderMetaData {
   return transformEthFlowOrder(addTotalFeeToOrder(order))
 }
 
+/**
+ * The executedSurplusFee represents exactly the fee that was charged (regardless of the fee signed with the order).
+ * So, while the protocol currently does not allow placing a limit order with any other fee than 0 - the backend is designed to support these kinds of orders for the future.
+ */
 function addTotalFeeToOrder(dto: OrderDto): OrderMetaData {
   const { executedFeeAmount, executedSurplusFee } = dto
   const totalFee = executedSurplusFee ?? executedFeeAmount

--- a/src/api/cow/types.ts
+++ b/src/api/cow/types.ts
@@ -12,7 +12,7 @@ export type OrderID = string
 export type ApiOrderStatus = 'fulfilled' | 'expired' | 'cancelled' | 'presignaturePending' | 'open'
 export type OrderClass = 'market' | 'limit' | 'liquidity'
 
-export interface OrderMetaData {
+export interface OrderDto {
   creationDate: string
   owner: string
   uid: OrderID
@@ -21,7 +21,7 @@ export interface OrderMetaData {
   executedSellAmount: string
   executedSellAmountBeforeFees: string
   executedFeeAmount: string
-  executedSurplusFee: string
+  executedSurplusFee: string | null
   invalidated: false
   sellToken: string
   buyToken: string
@@ -40,6 +40,10 @@ export interface OrderMetaData {
   // EthFlow related fields
   ethflowData?: EthFlowData
   onchainUser?: string
+}
+
+export interface OrderMetaData extends OrderDto {
+  totalFee: string
 }
 
 type EthFlowData = {


### PR DESCRIPTION
#Fixes: https://github.com/cowprotocol/cowswap/issues/1348

Based on: https://github.com/cowprotocol/cowswap/pull/1588#discussion_r1037501631

For limit-orders we should take `executedSurplusFee` as total fee amount and fallback to `executedFeeAmount`