### PR TITLE
Updated ethflow api response

### DIFF
--- a/src/api/cow/cow.spec.ts
+++ b/src/api/cow/cow.spec.ts
@@ -65,7 +65,7 @@ const ETH_FLOW_ORDER_RESPONSE = {
   ...ORDER_RESPONSE,
   owner: '0x76aaf674848311c7f21fc691b0b952f016da49f3', // EthFlowContract
   ethflowData: {
-    isRefunded: false,
+    isRefundable: false,
     validTo: Date.now() + 60 * 1000 * 5,
     refundTxHash: null,
   },

--- a/src/api/cow/cow.spec.ts
+++ b/src/api/cow/cow.spec.ts
@@ -67,8 +67,12 @@ const ETH_FLOW_ORDER_RESPONSE = {
   ethflowData: {
     isRefunded: false,
     validTo: Date.now() + 60 * 1000 * 5,
+    refundTxHash: null,
   },
-  onchainUser: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+  onchainOrderData: {
+    user: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+    placementError: null,
+  },
 }
 
 const ORDER_CANCELLATION = {
@@ -716,7 +720,7 @@ describe('Transform EthFlow orders', () => {
     const order = await cowSdk.cowApi.getOrder(ETH_FLOW_ORDER_RESPONSE.uid)
 
     // then
-    expect(order?.owner).toEqual(order?.onchainUser)
+    expect(order?.owner).toEqual(order?.onchainOrderData?.user)
     expect(order?.validTo).toEqual(order?.ethflowData?.userValidTo)
     expect(order?.sellToken).toEqual(BUY_ETH_ADDRESS)
   })
@@ -735,7 +739,7 @@ describe('Transform EthFlow orders', () => {
 
     // then
     // eth flow order
-    expect(orders[0].owner).toEqual(orders[0].onchainUser)
+    expect(orders[0].owner).toEqual(orders[0].onchainOrderData?.user)
     expect(orders[0].validTo).toEqual(orders[0].ethflowData?.userValidTo)
     expect(orders[0].sellToken).toEqual(BUY_ETH_ADDRESS)
     // regular order
@@ -755,7 +759,7 @@ describe('Transform EthFlow orders', () => {
 
     // then
     // eth flow order
-    expect(txOrders[0].owner).toEqual(txOrders[0].onchainUser)
+    expect(txOrders[0].owner).toEqual(txOrders[0].onchainOrderData?.user)
     expect(txOrders[0].validTo).toEqual(txOrders[0].ethflowData?.userValidTo)
     expect(txOrders[0].sellToken).toEqual(BUY_ETH_ADDRESS)
     // regular order

--- a/src/api/cow/index.ts
+++ b/src/api/cow/index.ts
@@ -349,20 +349,17 @@ export class CowApi extends BaseApi {
       partiallyFillable: false,
     }
 
-    const finalParams: QuoteQuery =
-      kind === OrderKind.SELL
-        ? {
-            kind: OrderKind.SELL,
-            sellAmountBeforeFee: amount,
-            ...baseParams,
-          }
-        : {
-            kind: OrderKind.BUY,
-            buyAmountAfterFee: amount,
-            ...baseParams,
-          }
-
-    return finalParams
+    return kind === OrderKind.SELL
+      ? {
+          kind: OrderKind.SELL,
+          sellAmountBeforeFee: amount,
+          ...baseParams,
+        }
+      : {
+          kind: OrderKind.BUY,
+          buyAmountAfterFee: amount,
+          ...baseParams,
+        }
   }
 
   private async fetchProfile(

--- a/src/api/cow/transformOrder.ts
+++ b/src/api/cow/transformOrder.ts
@@ -36,7 +36,7 @@ function transformEthFlowOrder(order: OrderMetaData): OrderMetaData {
   }
 
   const { userValidTo: validTo } = ethflowData
-  const owner = order.onchainUser || order.owner
+  const owner = order.onchainOrderData?.user || order.owner
   const sellToken = BUY_ETH_ADDRESS
 
   return { ...order, validTo, owner, sellToken }

--- a/src/api/cow/types.ts
+++ b/src/api/cow/types.ts
@@ -9,7 +9,7 @@ import type { StrictUnion } from '../../types/utilities'
  * where orderDigest = keccak256(orderStruct). bytes32.
  */
 export type OrderID = string
-export type ApiOrderStatus = 'fulfilled' | 'expired' | 'cancelled' | 'presignaturePending' | 'open'
+export type ApiOrderStatus = 'fulfilled' | 'expired' | 'cancelled' | 'presignaturePending' | 'open' | 'invalid'
 export type OrderClass = 'market' | 'limit' | 'liquidity'
 
 export interface OrderDto {

--- a/src/api/cow/types.ts
+++ b/src/api/cow/types.ts
@@ -39,7 +39,7 @@ export interface OrderDto {
   receiver: string
   // EthFlow related fields
   ethflowData?: EthFlowData
-  onchainUser?: string
+  onchainOrderData?: OnChainOrderData
 }
 
 export interface OrderMetaData extends OrderDto {
@@ -49,6 +49,12 @@ export interface OrderMetaData extends OrderDto {
 type EthFlowData = {
   userValidTo: number
   isRefunded: boolean
+  refundTxHash?: string | null
+}
+
+type OnChainOrderData = {
+  user: string
+  placementError?: string | null
 }
 
 export interface TradeMetaData {

--- a/src/api/cow/types.ts
+++ b/src/api/cow/types.ts
@@ -48,7 +48,7 @@ export interface OrderMetaData extends OrderDto {
 
 type EthFlowData = {
   userValidTo: number
-  isRefunded: boolean
+  isRefundable?: boolean | null
   refundTxHash?: string | null
 }
 


### PR DESCRIPTION
# Summary

Updating backend API types

See [this thread](https://cowservices.slack.com/archives/C049GSMCTMW/p1671693401501199) and [this doc](https://docs.google.com/document/d/17Xshqr-wPx3EZHkwIstqAaM7GIrFpzkqEA4oReuM9J4/edit#)

![Screenshot 2022-12-22 at 16 59 48](https://user-images.githubusercontent.com/43217/209188357-81ab9cdf-d95c-41d8-a586-e3eda40408bc.png)

- Added `isRefundable` to `ethflowData`
- Removed `isRefunded` from `ethflowData`
- Added `refundTxHash` to `ethflowData`
- Added `onchainOrderData` with: `user` and `placementError`
- Added `invalid` to `ApiOrderStatus`

# Testing

Unit tests