### PR TITLE
Satsuma replace url

### DIFF
--- a/graphql-codegen.yml
+++ b/graphql-codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: "https://api.thegraph.com/subgraphs/name/cowprotocol/cow"
+schema: "  https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow/api"
 documents: './src/api/cow-subgraph/queries.ts'
 generates:
   src/api/cow-subgraph/graphql.ts:

--- a/src/api/cow-subgraph/graphql.ts
+++ b/src/api/cow-subgraph/graphql.ts
@@ -36,6 +36,7 @@ export type Bundle = {
 export type Bundle_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Bundle_Filter>>>;
   ethPriceUSD?: InputMaybe<Scalars['BigDecimal']>;
   ethPriceUSD_gt?: InputMaybe<Scalars['BigDecimal']>;
   ethPriceUSD_gte?: InputMaybe<Scalars['BigDecimal']>;
@@ -52,6 +53,7 @@ export type Bundle_Filter = {
   id_lte?: InputMaybe<Scalars['ID']>;
   id_not?: InputMaybe<Scalars['ID']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  or?: InputMaybe<Array<InputMaybe<Bundle_Filter>>>;
 };
 
 export enum Bundle_OrderBy {
@@ -97,6 +99,7 @@ export type DailyTotalTokensArgs = {
 export type DailyTotal_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<DailyTotal_Filter>>>;
   feesEth?: InputMaybe<Scalars['BigDecimal']>;
   feesEth_gt?: InputMaybe<Scalars['BigDecimal']>;
   feesEth_gte?: InputMaybe<Scalars['BigDecimal']>;
@@ -129,6 +132,7 @@ export type DailyTotal_Filter = {
   numberOfTrades_lte?: InputMaybe<Scalars['BigInt']>;
   numberOfTrades_not?: InputMaybe<Scalars['BigInt']>;
   numberOfTrades_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  or?: InputMaybe<Array<InputMaybe<DailyTotal_Filter>>>;
   orders?: InputMaybe<Scalars['BigInt']>;
   orders_gt?: InputMaybe<Scalars['BigInt']>;
   orders_gte?: InputMaybe<Scalars['BigInt']>;
@@ -238,6 +242,7 @@ export type HourlyTotalTokensArgs = {
 export type HourlyTotal_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<HourlyTotal_Filter>>>;
   feesEth?: InputMaybe<Scalars['BigDecimal']>;
   feesEth_gt?: InputMaybe<Scalars['BigDecimal']>;
   feesEth_gte?: InputMaybe<Scalars['BigDecimal']>;
@@ -270,6 +275,7 @@ export type HourlyTotal_Filter = {
   numberOfTrades_lte?: InputMaybe<Scalars['BigInt']>;
   numberOfTrades_not?: InputMaybe<Scalars['BigInt']>;
   numberOfTrades_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  or?: InputMaybe<Array<InputMaybe<HourlyTotal_Filter>>>;
   orders?: InputMaybe<Scalars['BigInt']>;
   orders_gt?: InputMaybe<Scalars['BigInt']>;
   orders_gte?: InputMaybe<Scalars['BigInt']>;
@@ -379,6 +385,7 @@ export enum OrderDirection {
 export type Order_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Order_Filter>>>;
   id?: InputMaybe<Scalars['ID']>;
   id_gt?: InputMaybe<Scalars['ID']>;
   id_gte?: InputMaybe<Scalars['ID']>;
@@ -403,6 +410,7 @@ export type Order_Filter = {
   isValid_in?: InputMaybe<Array<Scalars['Boolean']>>;
   isValid_not?: InputMaybe<Scalars['Boolean']>;
   isValid_not_in?: InputMaybe<Array<Scalars['Boolean']>>;
+  or?: InputMaybe<Array<InputMaybe<Order_Filter>>>;
   owner?: InputMaybe<Scalars['String']>;
   owner_?: InputMaybe<User_Filter>;
   owner_contains?: InputMaybe<Scalars['String']>;
@@ -511,6 +519,7 @@ export type PairDaily = {
 export type PairDaily_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<PairDaily_Filter>>>;
   id?: InputMaybe<Scalars['ID']>;
   id_gt?: InputMaybe<Scalars['ID']>;
   id_gte?: InputMaybe<Scalars['ID']>;
@@ -519,6 +528,7 @@ export type PairDaily_Filter = {
   id_lte?: InputMaybe<Scalars['ID']>;
   id_not?: InputMaybe<Scalars['ID']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  or?: InputMaybe<Array<InputMaybe<PairDaily_Filter>>>;
   timestamp?: InputMaybe<Scalars['Int']>;
   timestamp_gt?: InputMaybe<Scalars['Int']>;
   timestamp_gte?: InputMaybe<Scalars['Int']>;
@@ -681,6 +691,7 @@ export type PairHourly = {
 export type PairHourly_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<PairHourly_Filter>>>;
   id?: InputMaybe<Scalars['ID']>;
   id_gt?: InputMaybe<Scalars['ID']>;
   id_gte?: InputMaybe<Scalars['ID']>;
@@ -689,6 +700,7 @@ export type PairHourly_Filter = {
   id_lte?: InputMaybe<Scalars['ID']>;
   id_not?: InputMaybe<Scalars['ID']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  or?: InputMaybe<Array<InputMaybe<PairHourly_Filter>>>;
   timestamp?: InputMaybe<Scalars['Int']>;
   timestamp_gt?: InputMaybe<Scalars['Int']>;
   timestamp_gte?: InputMaybe<Scalars['Int']>;
@@ -823,6 +835,7 @@ export enum PairHourly_OrderBy {
 export type Pair_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Pair_Filter>>>;
   id?: InputMaybe<Scalars['ID']>;
   id_gt?: InputMaybe<Scalars['ID']>;
   id_gte?: InputMaybe<Scalars['ID']>;
@@ -831,6 +844,7 @@ export type Pair_Filter = {
   id_lte?: InputMaybe<Scalars['ID']>;
   id_not?: InputMaybe<Scalars['ID']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  or?: InputMaybe<Array<InputMaybe<Pair_Filter>>>;
   token0?: InputMaybe<Scalars['String']>;
   token0Price?: InputMaybe<Scalars['BigDecimal']>;
   token0Price_gt?: InputMaybe<Scalars['BigDecimal']>;
@@ -1330,6 +1344,7 @@ export type SettlementTradesArgs = {
 export type Settlement_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Settlement_Filter>>>;
   firstTradeTimestamp?: InputMaybe<Scalars['Int']>;
   firstTradeTimestamp_gt?: InputMaybe<Scalars['Int']>;
   firstTradeTimestamp_gte?: InputMaybe<Scalars['Int']>;
@@ -1346,6 +1361,7 @@ export type Settlement_Filter = {
   id_lte?: InputMaybe<Scalars['ID']>;
   id_not?: InputMaybe<Scalars['ID']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  or?: InputMaybe<Array<InputMaybe<Settlement_Filter>>>;
   solver?: InputMaybe<Scalars['String']>;
   solver_?: InputMaybe<User_Filter>;
   solver_contains?: InputMaybe<Scalars['String']>;
@@ -1827,6 +1843,7 @@ export type TokenDailyTotal = {
 export type TokenDailyTotal_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<TokenDailyTotal_Filter>>>;
   averagePrice?: InputMaybe<Scalars['BigDecimal']>;
   averagePrice_gt?: InputMaybe<Scalars['BigDecimal']>;
   averagePrice_gte?: InputMaybe<Scalars['BigDecimal']>;
@@ -1875,6 +1892,7 @@ export type TokenDailyTotal_Filter = {
   openPrice_lte?: InputMaybe<Scalars['BigDecimal']>;
   openPrice_not?: InputMaybe<Scalars['BigDecimal']>;
   openPrice_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  or?: InputMaybe<Array<InputMaybe<TokenDailyTotal_Filter>>>;
   timestamp?: InputMaybe<Scalars['Int']>;
   timestamp_gt?: InputMaybe<Scalars['Int']>;
   timestamp_gte?: InputMaybe<Scalars['Int']>;
@@ -1984,6 +2002,7 @@ export type TokenHourlyTotal = {
 export type TokenHourlyTotal_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<TokenHourlyTotal_Filter>>>;
   averagePrice?: InputMaybe<Scalars['BigDecimal']>;
   averagePrice_gt?: InputMaybe<Scalars['BigDecimal']>;
   averagePrice_gte?: InputMaybe<Scalars['BigDecimal']>;
@@ -2032,6 +2051,7 @@ export type TokenHourlyTotal_Filter = {
   openPrice_lte?: InputMaybe<Scalars['BigDecimal']>;
   openPrice_not?: InputMaybe<Scalars['BigDecimal']>;
   openPrice_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  or?: InputMaybe<Array<InputMaybe<TokenHourlyTotal_Filter>>>;
   timestamp?: InputMaybe<Scalars['Int']>;
   timestamp_gt?: InputMaybe<Scalars['Int']>;
   timestamp_gte?: InputMaybe<Scalars['Int']>;
@@ -2145,6 +2165,7 @@ export type TokenTradingEvent_Filter = {
   amountUsd_lte?: InputMaybe<Scalars['BigDecimal']>;
   amountUsd_not?: InputMaybe<Scalars['BigDecimal']>;
   amountUsd_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  and?: InputMaybe<Array<InputMaybe<TokenTradingEvent_Filter>>>;
   id?: InputMaybe<Scalars['ID']>;
   id_gt?: InputMaybe<Scalars['ID']>;
   id_gte?: InputMaybe<Scalars['ID']>;
@@ -2153,6 +2174,7 @@ export type TokenTradingEvent_Filter = {
   id_lte?: InputMaybe<Scalars['ID']>;
   id_not?: InputMaybe<Scalars['ID']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  or?: InputMaybe<Array<InputMaybe<TokenTradingEvent_Filter>>>;
   timestamp?: InputMaybe<Scalars['Int']>;
   timestamp_gt?: InputMaybe<Scalars['Int']>;
   timestamp_gte?: InputMaybe<Scalars['Int']>;
@@ -2223,6 +2245,7 @@ export type Token_Filter = {
   address_not?: InputMaybe<Scalars['Bytes']>;
   address_not_contains?: InputMaybe<Scalars['Bytes']>;
   address_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  and?: InputMaybe<Array<InputMaybe<Token_Filter>>>;
   dailyTotals_?: InputMaybe<TokenDailyTotal_Filter>;
   decimals?: InputMaybe<Scalars['Int']>;
   decimals_gt?: InputMaybe<Scalars['Int']>;
@@ -2278,6 +2301,7 @@ export type Token_Filter = {
   numberOfTrades_lte?: InputMaybe<Scalars['Int']>;
   numberOfTrades_not?: InputMaybe<Scalars['Int']>;
   numberOfTrades_not_in?: InputMaybe<Array<Scalars['Int']>>;
+  or?: InputMaybe<Array<InputMaybe<Token_Filter>>>;
   priceEth?: InputMaybe<Scalars['BigDecimal']>;
   priceEth_gt?: InputMaybe<Scalars['BigDecimal']>;
   priceEth_gte?: InputMaybe<Scalars['BigDecimal']>;
@@ -2385,6 +2409,7 @@ export type Total = {
 export type Total_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Total_Filter>>>;
   feesEth?: InputMaybe<Scalars['BigDecimal']>;
   feesEth_gt?: InputMaybe<Scalars['BigDecimal']>;
   feesEth_gte?: InputMaybe<Scalars['BigDecimal']>;
@@ -2417,6 +2442,7 @@ export type Total_Filter = {
   numberOfTrades_lte?: InputMaybe<Scalars['BigInt']>;
   numberOfTrades_not?: InputMaybe<Scalars['BigInt']>;
   numberOfTrades_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  or?: InputMaybe<Array<InputMaybe<Total_Filter>>>;
   orders?: InputMaybe<Scalars['BigInt']>;
   orders_gt?: InputMaybe<Scalars['BigInt']>;
   orders_gte?: InputMaybe<Scalars['BigInt']>;
@@ -2517,6 +2543,7 @@ export type Trade = {
 export type Trade_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Trade_Filter>>>;
   buyAmount?: InputMaybe<Scalars['BigInt']>;
   buyAmountEth?: InputMaybe<Scalars['BigDecimal']>;
   buyAmountEth_gt?: InputMaybe<Scalars['BigDecimal']>;
@@ -2586,6 +2613,7 @@ export type Trade_Filter = {
   id_lte?: InputMaybe<Scalars['ID']>;
   id_not?: InputMaybe<Scalars['ID']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  or?: InputMaybe<Array<InputMaybe<Trade_Filter>>>;
   order?: InputMaybe<Scalars['String']>;
   order_?: InputMaybe<Order_Filter>;
   order_contains?: InputMaybe<Scalars['String']>;
@@ -2732,6 +2760,7 @@ export type UniswapPool = {
 export type UniswapPool_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<UniswapPool_Filter>>>;
   id?: InputMaybe<Scalars['ID']>;
   id_gt?: InputMaybe<Scalars['ID']>;
   id_gte?: InputMaybe<Scalars['ID']>;
@@ -2748,6 +2777,7 @@ export type UniswapPool_Filter = {
   liquidity_lte?: InputMaybe<Scalars['BigInt']>;
   liquidity_not?: InputMaybe<Scalars['BigInt']>;
   liquidity_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  or?: InputMaybe<Array<InputMaybe<UniswapPool_Filter>>>;
   tick?: InputMaybe<Scalars['BigInt']>;
   tick_gt?: InputMaybe<Scalars['BigInt']>;
   tick_gte?: InputMaybe<Scalars['BigInt']>;
@@ -2889,6 +2919,7 @@ export type UniswapToken_Filter = {
   allowedPools_not?: InputMaybe<Array<Scalars['String']>>;
   allowedPools_not_contains?: InputMaybe<Array<Scalars['String']>>;
   allowedPools_not_contains_nocase?: InputMaybe<Array<Scalars['String']>>;
+  and?: InputMaybe<Array<InputMaybe<UniswapToken_Filter>>>;
   decimals?: InputMaybe<Scalars['Int']>;
   decimals_gt?: InputMaybe<Scalars['Int']>;
   decimals_gte?: InputMaybe<Scalars['Int']>;
@@ -2925,6 +2956,7 @@ export type UniswapToken_Filter = {
   name_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
   name_starts_with?: InputMaybe<Scalars['String']>;
   name_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  or?: InputMaybe<Array<InputMaybe<UniswapToken_Filter>>>;
   priceEth?: InputMaybe<Scalars['BigDecimal']>;
   priceEth_gt?: InputMaybe<Scalars['BigDecimal']>;
   priceEth_gte?: InputMaybe<Scalars['BigDecimal']>;
@@ -3016,6 +3048,7 @@ export type User_Filter = {
   address_not?: InputMaybe<Scalars['Bytes']>;
   address_not_contains?: InputMaybe<Scalars['Bytes']>;
   address_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  and?: InputMaybe<Array<InputMaybe<User_Filter>>>;
   firstTradeTimestamp?: InputMaybe<Scalars['Int']>;
   firstTradeTimestamp_gt?: InputMaybe<Scalars['Int']>;
   firstTradeTimestamp_gte?: InputMaybe<Scalars['Int']>;
@@ -3044,6 +3077,7 @@ export type User_Filter = {
   numberOfTrades_lte?: InputMaybe<Scalars['Int']>;
   numberOfTrades_not?: InputMaybe<Scalars['Int']>;
   numberOfTrades_not_in?: InputMaybe<Array<Scalars['Int']>>;
+  or?: InputMaybe<Array<InputMaybe<User_Filter>>>;
   ordersPlaced_?: InputMaybe<Order_Filter>;
   solvedAmountEth?: InputMaybe<Scalars['BigDecimal']>;
   solvedAmountEth_gt?: InputMaybe<Scalars['BigDecimal']>;

--- a/src/api/cow-subgraph/index.ts
+++ b/src/api/cow-subgraph/index.ts
@@ -7,19 +7,25 @@ import { SupportedChainId as ChainId } from '../../constants/chains'
 import { LastDaysVolumeQuery, LastHoursVolumeQuery, TotalsQuery } from './graphql'
 import { LAST_DAYS_VOLUME_QUERY, LAST_HOURS_VOLUME_QUERY, TOTALS_QUERY } from './queries'
 
-export function getDefaultSubgraphUrls(env: Env): Partial<Record<ChainId, string>> {
-  switch (env) {
-    case 'staging':
-      return {
-        [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-staging',
-        [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc-staging',
-      }
-    case 'prod':
-      return {
-        [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow',
-        [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-goerli',
-        [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc',
-      }
+export function getDefaultSubgraphUrls(_env: Env): Record<ChainId, string> {
+  // switch (env) {
+  //   case 'staging':
+  //     return {
+  //       [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-staging',
+  //       [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc-staging',
+  //     }
+  //   case 'prod':
+  //     return {
+  //       [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow',
+  //       [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-goerli',
+  //       [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc',
+  //     }
+  // }
+  // TODO: Ideally we would have a staging environment for Satsuma too. But this needs to be created
+  return {
+    [ChainId.MAINNET]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow/api',
+    [ChainId.GOERLI]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-goerli/api',
+    [ChainId.GNOSIS_CHAIN]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-gc/api',
   }
 }
 


### PR DESCRIPTION
> 🚨 This PR is ON HOLD while we evaluate the different options

Replaces the old subgraph URLs for satsuma one (to deal with TheGraph Sunset.

Pending
- [ ] Test first Satsuma in production (goerli)
- [ ] Create a staging environment
- [ ] Test in production Mainnet/Gnosis Chain
- [ ] Replace and release a new version of the SDK including the new URLs

## Test (devs)

You can test the code generation.

```
# Generate Typescript
graphql:codegen
```

# Test
In general, the test of satsuma will happen on several releases of the Explorer. So no need to test much here.

After releasing this https://github.com/cowprotocol/cow-sdk/pull/105  we can deploy new versions of explorer pointing to alternative graphs servers. So at the point we deploy this change, we will already have validations. So I don't think we have much to test.

