### PR TITLE
Refactor SDK to allow to specify your own subgraph

### DIFF
--- a/graphql-codegen.yml
+++ b/graphql-codegen.yml
@@ -1,7 +1,5 @@
 overwrite: true
-# TODO: Delete before merging
-#schema: "https://api.thegraph.com/subgraphs/name/cowprotocol/cow"
-schema: "  https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow/api"
+schema: "https://api.thegraph.com/subgraphs/name/cowprotocol/cow"
 documents: './src/api/cow-subgraph/queries.ts'
 generates:
   src/api/cow-subgraph/graphql.ts:

--- a/graphql-codegen.yml
+++ b/graphql-codegen.yml
@@ -1,5 +1,7 @@
 overwrite: true
-schema: "https://api.thegraph.com/subgraphs/name/cowprotocol/cow"
+# TODO: Delete before merging
+#schema: "https://api.thegraph.com/subgraphs/name/cowprotocol/cow"
+schema: "  https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow/api"
 documents: './src/api/cow-subgraph/queries.ts'
 generates:
   src/api/cow-subgraph/graphql.ts:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "1.0.1-RC9",
+  "version": "1.0.1-RC.10",
   "license": "(MIT OR Apache-2.0)",
   "source": "src/index.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "1.0.1-RC.8",
+  "version": "1.0.1-RC9",
   "license": "(MIT OR Apache-2.0)",
   "source": "src/index.ts",
   "main": "./dist/index.js",

--- a/src/api/cow-subgraph/cow-subgraph.spec.ts
+++ b/src/api/cow-subgraph/cow-subgraph.spec.ts
@@ -358,7 +358,7 @@ describe('Passing Options object', () => {
 
 describe('Override URLs', () => {
   test('Override default chain', async () => {
-    // GIVEN: We instantiate the SDK with a different URL for Gnosis Chain
+    // GIVEN: We instantiate the SDK with a different URL for MAINNET (default chain)
     const anotherGraphUrl = 'http://cow.fi'
     const cowSdk = new CowSdk(SupportedChainId.MAINNET, {
       subgraphBaseUrls: {
@@ -367,11 +367,47 @@ describe('Override URLs', () => {
     })
     mock24hVolume()
 
-    // WHEN: We query this chain/env
+    // WHEN: We query without specifying the chain
     await cowSdk.cowSubgraphApi.getLastHoursVolume(24)
 
-    // THEN: The API is called with the correct parameters
+    // THEN: The URL is the modified one
     const fetchParameters = getFetchParameters(LAST_HOURS_VOLUME_QUERY, 'LastHoursVolume', { hours: 24 })
     expect(fetchMock).toHaveBeenCalledWith(anotherGraphUrl, fetchParameters)
+  })
+
+  test('Override GC chain', async () => {
+    // GIVEN: We instantiate the SDK with a different URL for Gnosis Chain
+    const anotherGraphUrl = 'http://cow.fi'
+    const cowSdk = new CowSdk(SupportedChainId.MAINNET, {
+      subgraphBaseUrls: {
+        [SupportedChainId.GNOSIS_CHAIN]: anotherGraphUrl,
+      },
+    })
+    mock24hVolume()
+
+    // WHEN: We query for Gnosis Chain
+    await cowSdk.cowSubgraphApi.getLastHoursVolume(24, { chainId: SupportedChainId.GNOSIS_CHAIN })
+
+    // THEN: The URL is the modified one
+    const fetchParameters = getFetchParameters(LAST_HOURS_VOLUME_QUERY, 'LastHoursVolume', { hours: 24 })
+    expect(fetchMock).toHaveBeenCalledWith(anotherGraphUrl, fetchParameters)
+  })
+
+  test("Override GC chain, shouldn't affect the main chain", async () => {
+    // GIVEN: We instantiate the SDK with a different URL for Gnosis Chain
+    const anotherGraphUrl = 'http://cow.fi'
+    const cowSdk = new CowSdk(SupportedChainId.MAINNET, {
+      subgraphBaseUrls: {
+        [SupportedChainId.GNOSIS_CHAIN]: anotherGraphUrl,
+      },
+    })
+    mock24hVolume()
+
+    // WHEN: We query for the default chain (MAINNET)
+    await cowSdk.cowSubgraphApi.getLastHoursVolume(24)
+
+    // THEN: The URL is the original un-modified one
+    const fetchParameters = getFetchParameters(LAST_HOURS_VOLUME_QUERY, 'LastHoursVolume', { hours: 24 })
+    expect(fetchMock).toHaveBeenCalledWith(PROD_URL, fetchParameters)
   })
 })

--- a/src/api/cow-subgraph/cow-subgraph.spec.ts
+++ b/src/api/cow-subgraph/cow-subgraph.spec.ts
@@ -1,6 +1,6 @@
 import { gql } from 'graphql-request'
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
-import { getSubgraphUrl } from '.'
+import { getDefaultSubgraphUrls } from '.'
 import { SupportedChainId } from '../../constants/chains'
 import { CowSdk } from '../../CowSdk'
 import { CowError } from '../../utils/common'
@@ -9,7 +9,7 @@ import { LAST_DAYS_VOLUME_QUERY, LAST_HOURS_VOLUME_QUERY, TOTALS_QUERY } from '.
 enableFetchMocks()
 
 const cowSdk = new CowSdk(SupportedChainId.MAINNET)
-const prodUrls = getSubgraphUrl('prod')
+const prodUrls = getDefaultSubgraphUrls('prod')
 
 beforeEach(() => {
   fetchMock.resetMocks()
@@ -352,7 +352,7 @@ describe('Passing Options object', () => {
       headers,
     })
     await cowSdk.cowSubgraphApi.getLastHoursVolume(24, { chainId: SupportedChainId.GNOSIS_CHAIN, env: 'staging' })
-    const gcStagingUrl = getSubgraphUrl('staging')[SupportedChainId.GNOSIS_CHAIN]
+    const gcStagingUrl = getDefaultSubgraphUrls('staging')[SupportedChainId.GNOSIS_CHAIN]
     expect(fetchMock).toHaveBeenCalledWith(gcStagingUrl, fetchParameters)
   })
 

--- a/src/api/cow-subgraph/cow-subgraph.spec.ts
+++ b/src/api/cow-subgraph/cow-subgraph.spec.ts
@@ -355,3 +355,23 @@ describe('Passing Options object', () => {
     await expect(promise).rejects.toThrow('No network support for SubGraph in ChainId')
   })
 })
+
+describe('Override URLs', () => {
+  test('Override default chain', async () => {
+    // GIVEN: We instantiate the SDK with a different URL for Gnosis Chain
+    const anotherGraphUrl = 'http://cow.fi'
+    const cowSdk = new CowSdk(SupportedChainId.MAINNET, {
+      subgraphBaseUrls: {
+        [SupportedChainId.MAINNET]: anotherGraphUrl,
+      },
+    })
+    mock24hVolume()
+
+    // WHEN: We query this chain/env
+    await cowSdk.cowSubgraphApi.getLastHoursVolume(24)
+
+    // THEN: The API is called with the correct parameters
+    const fetchParameters = getFetchParameters(LAST_HOURS_VOLUME_QUERY, 'LastHoursVolume', { hours: 24 })
+    expect(fetchMock).toHaveBeenCalledWith(anotherGraphUrl, fetchParameters)
+  })
+})

--- a/src/api/cow-subgraph/index.ts
+++ b/src/api/cow-subgraph/index.ts
@@ -7,10 +7,11 @@ import { SupportedChainId as ChainId } from '../../constants/chains'
 import { LastDaysVolumeQuery, LastHoursVolumeQuery, TotalsQuery } from './graphql'
 import { LAST_DAYS_VOLUME_QUERY, LAST_HOURS_VOLUME_QUERY, TOTALS_QUERY } from './queries'
 
-export function getDefaultSubgraphUrls(env: Env): Partial<Record<ChainId, string>> {
+export function getDefaultSubgraphUrls(env: Env): Record<ChainId, string> {
   switch (env) {
     case 'staging':
       return {
+        [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-goerli',
         [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-staging',
         [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc-staging',
       }
@@ -31,7 +32,10 @@ export class CowSubgraphApi {
 
   constructor(context: Context) {
     this.context = context
-    this.baseUrls = context.subgraphBaseUrls ?? getDefaultSubgraphUrls(context.env)
+    this.baseUrls = {
+      ...getDefaultSubgraphUrls(context.env),
+      ...(context.subgraphBaseUrls || {}),
+    }
   }
 
   async getBaseUrl(options: SubgraphOptions = {}): Promise<string> {

--- a/src/api/cow-subgraph/index.ts
+++ b/src/api/cow-subgraph/index.ts
@@ -33,20 +33,18 @@ export function getDefaultSubgraphUrl(params: { chainId?: ChainId; env?: Env }):
 
 export class CowSubgraphApi {
   context: Context
-  baseUrls: Partial<Record<ChainId, string>>
 
   API_NAME = 'CoW Protocol Subgraph'
 
   constructor(context: Context) {
     this.context = context
-    this.baseUrls = context.subgraphBaseUrls || {}
   }
 
   async getBaseUrl(options: SubgraphOptions = {}): Promise<string> {
     const { chainId: networkId, env = DEFAULT_ENV } = options
     const chainId = networkId || (await this.context.chainId)
 
-    const baseUrl = this.baseUrls[chainId] || getDefaultSubgraphUrl({ chainId, env })
+    const baseUrl = this.context.subgraphBaseUrls[chainId] || getDefaultSubgraphUrl({ chainId, env })
     if (!baseUrl) {
       throw new CowError(`No network support for SubGraph in ChainId ${networkId} and Environment "${env}"`)
     }

--- a/src/api/cow-subgraph/index.ts
+++ b/src/api/cow-subgraph/index.ts
@@ -7,35 +7,47 @@ import { SupportedChainId as ChainId } from '../../constants/chains'
 import { LastDaysVolumeQuery, LastHoursVolumeQuery, TotalsQuery } from './graphql'
 import { LAST_DAYS_VOLUME_QUERY, LAST_HOURS_VOLUME_QUERY, TOTALS_QUERY } from './queries'
 
-export function getSubgraphUrl(env: Env): Partial<Record<ChainId, string>> {
-  switch (env) {
-    case 'staging':
-      return {
-        [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-staging',
-        [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc-staging',
-      }
-    case 'prod':
-      return {
-        [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow',
-        [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-goerli',
-        [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc',
-      }
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function getDefaultSubgraphUrls(_env: Env): Record<ChainId, string> {
+  // TODO: After evaluating Satsuma.xyz, we should re-create the staging environment
+  // switch (env) {
+  //   case 'staging':
+  //     return {
+  //       [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-staging',
+  //       [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc-staging',
+  //     }
+  //   case 'prod':
+  //     return {
+  //       [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow',
+  //       [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-goerli',
+  //       [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc',
+  //     }
+  // }
+  return {
+    [ChainId.MAINNET]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow/api',
+    [ChainId.GOERLI]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-goerli/api',
+    [ChainId.GNOSIS_CHAIN]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-gc/api',
   }
 }
 
 export class CowSubgraphApi {
   context: Context
+  baseUrls: Record<ChainId, string>
 
   API_NAME = 'CoW Protocol Subgraph'
 
   constructor(context: Context) {
     this.context = context
+    this.baseUrls = context.subgraphBaseUrls ?? getDefaultSubgraphUrls(context.env)
   }
 
   async getBaseUrl(options: SubgraphOptions = {}): Promise<string> {
     const { chainId: networkId, env = 'prod' } = options
     const chainId = networkId || (await this.context.chainId)
-    const baseUrl = getSubgraphUrl(env)[chainId]
+
+    this.context.chainId
+
+    const baseUrl = this.baseUrls[chainId]
     if (!baseUrl) {
       throw new CowError(`No network support for SubGraph in ChainId ${networkId} and Environment "${env}"`)
     }

--- a/src/api/cow-subgraph/index.ts
+++ b/src/api/cow-subgraph/index.ts
@@ -7,26 +7,19 @@ import { SupportedChainId as ChainId } from '../../constants/chains'
 import { LastDaysVolumeQuery, LastHoursVolumeQuery, TotalsQuery } from './graphql'
 import { LAST_DAYS_VOLUME_QUERY, LAST_HOURS_VOLUME_QUERY, TOTALS_QUERY } from './queries'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function getDefaultSubgraphUrls(_env: Env): Record<ChainId, string> {
-  // TODO: After evaluating Satsuma.xyz, we should re-create the staging environment
-  // switch (env) {
-  //   case 'staging':
-  //     return {
-  //       [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-staging',
-  //       [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc-staging',
-  //     }
-  //   case 'prod':
-  //     return {
-  //       [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow',
-  //       [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-goerli',
-  //       [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc',
-  //     }
-  // }
-  return {
-    [ChainId.MAINNET]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow/api',
-    [ChainId.GOERLI]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-goerli/api',
-    [ChainId.GNOSIS_CHAIN]: 'https://subgraph.satsuma-prod.com/94b7bd7c35c5/cow/cow-gc/api',
+export function getDefaultSubgraphUrls(env: Env): Partial<Record<ChainId, string>> {
+  switch (env) {
+    case 'staging':
+      return {
+        [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-staging',
+        [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc-staging',
+      }
+    case 'prod':
+      return {
+        [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow',
+        [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-goerli',
+        [ChainId.GNOSIS_CHAIN]: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc',
+      }
   }
 }
 

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -19,7 +19,7 @@ export interface CowContext {
   env?: Env
   signer?: Signer
   ipfs?: Ipfs
-  subgraphBaseUrls?: Record<ChainId, string>
+  subgraphBaseUrls?: Record<SupportedChainId, string>
 }
 
 export const DefaultCowContext: { appDataHash: string; ipfs: Ipfs; env: Env } = {
@@ -118,7 +118,7 @@ export class Context implements Partial<CowContext> {
     return this.#context.ipfs ?? DefaultCowContext.ipfs
   }
 
-  get subgraphBaseUrls(): Record<number, string> | undefined {
+  get subgraphBaseUrls(): Record<SupportedChainId, string> | undefined {
     return this.#context.subgraphBaseUrls
   }
 }

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -19,7 +19,7 @@ export interface CowContext {
   env?: Env
   signer?: Signer
   ipfs?: Ipfs
-  subgraphBaseUrls?: Record<SupportedChainId, string>
+  subgraphBaseUrls?: Partial<Record<SupportedChainId, string>>
 }
 
 export const DefaultCowContext: { appDataHash: string; ipfs: Ipfs; env: Env } = {

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -19,6 +19,7 @@ export interface CowContext {
   env?: Env
   signer?: Signer
   ipfs?: Ipfs
+  subgraphBaseUrls?: Record<ChainId, string>
 }
 
 export const DefaultCowContext: { appDataHash: string; ipfs: Ipfs; env: Env } = {
@@ -115,5 +116,9 @@ export class Context implements Partial<CowContext> {
 
   get ipfs(): Ipfs {
     return this.#context.ipfs ?? DefaultCowContext.ipfs
+  }
+
+  get subgraphBaseUrls(): Record<number, string> | undefined {
+    return this.#context.subgraphBaseUrls
   }
 }

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -118,7 +118,7 @@ export class Context implements Partial<CowContext> {
     return this.#context.ipfs ?? DefaultCowContext.ipfs
   }
 
-  get subgraphBaseUrls(): Record<SupportedChainId, string> | undefined {
-    return this.#context.subgraphBaseUrls
+  get subgraphBaseUrls(): Partial<Record<SupportedChainId, string>> {
+    return this.#context.subgraphBaseUrls || {}
   }
 }


### PR DESCRIPTION
The goal of this PR is to let an SDK client to define its own subgraph API URLs.

They will be optional parameters, and it defaults to the current URLs.

The reason I'm doing this and creating a version ASAP is to test Satsuma in the Explorer. 

Now clients will be able to instantiate the SDK like this:
```js
const cowSdk = new CowSdk(100, {
  subgraphBaseUrls: {
    1: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow',
    5: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-goerli',
    100: 'https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc',
  },
})
```

## Test

TODO: I will generate a version of explorer with the SDK including this change, and share a link.
