### PR TITLE
Add error transformer to add rawApiError to quote rejection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/order-book/api.ts
+++ b/src/order-book/api.ts
@@ -32,6 +32,7 @@ import { EnrichedOrder } from './types'
 import { ApiRequestOptions } from './generated/core/ApiRequestOptions'
 import { request as __request } from './generated/core/request'
 import { SupportedChainId } from '../common/chains'
+import { transformError } from './transformError'
 
 export const ORDER_BOOK_PROD_CONFIG: ApiBaseUrls = {
   [SupportedChainId.MAINNET]: 'https://api.cow.fi/mainnet',
@@ -147,8 +148,8 @@ export class OrderBookApi {
   getQuote(requestBody: OrderQuoteRequest, contextOverride: PartialApiContext = {}): Promise<OrderQuoteResponse> {
     return this.getServiceForNetwork(contextOverride)
       .postApiV1Quote(requestBody)
-      .catch((error: { body: FeeAndQuoteError }) => {
-        return Promise.reject(error.body || error)
+      .catch((error) => {
+        return Promise.reject(transformError<FeeAndQuoteError>(error))
       })
   }
 

--- a/src/order-book/transformError.ts
+++ b/src/order-book/transformError.ts
@@ -1,0 +1,20 @@
+import { ApiError } from './generated'
+
+type TransformedError<T> = T & {
+  rawApiError: ApiError
+}
+
+function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError
+}
+
+export function transformError<T>(error: ApiError): TransformedError<T> | Error {
+  if (isApiError(error)) {
+    return {
+      ...error.body,
+      rawApiError: error,
+    }
+  }
+
+  return error
+}


### PR DESCRIPTION
In exponential backoff, not having the raw error body limits us in terms of determining when to retry or not (i.e. not knowing the status).

This change adds a transformation function and applies it to getQuote as a PoC. (And to fix https://github.com/cowprotocol/cowswap/issues/2311)