### PR TITLE
Add rawApiError to native price quote

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/order-book/api.ts
+++ b/src/order-book/api.ts
@@ -174,11 +174,12 @@ export class OrderBookApi {
       })
   }
 
-  getNativePrice(
-    tokenAddress: Address,
-    contextOverride: PartialApiContext = {}
-  ): CancelablePromise<NativePriceResponse> {
-    return this.getServiceForNetwork(contextOverride).getApiV1TokenNativePrice(tokenAddress)
+  getNativePrice(tokenAddress: Address, contextOverride: PartialApiContext = {}): Promise<NativePriceResponse> {
+    return this.getServiceForNetwork(contextOverride)
+      .getApiV1TokenNativePrice(tokenAddress)
+      .catch((error) => {
+        return Promise.reject(transformError<FeeAndQuoteError>(error))
+      })
   }
 
   getOrderLink(uid: UID, contextOverride?: PartialApiContext): string {


### PR DESCRIPTION
Adds rawApiError to native price quote endpoint, to be able to backoff earlier.