### PR TITLE
fix(OrderQuoteSide.kind): missing 'BUY' enum

### DIFF
--- a/src/order-book/generated/models/OrderQuoteSide.ts
+++ b/src/order-book/generated/models/OrderQuoteSide.ts
@@ -33,6 +33,7 @@ export namespace OrderQuoteSide {
 
     export enum kind {
         SELL = 'sell',
+        BUY = 'buy',
     }
 
 


### PR DESCRIPTION
OrderQuoteSide.kind should have `BUY` instead of having only the `SELL` option on his enum type.
I added it to `OrderQuoteSide.kind` and now it's possible to use `OrderQuoteSide.kind.BUY` on sdk.

Example:
```ts
orderBookApi.getQuote({
    kind: OrderQuoteSide.kind.BUY, // Sell order (could also be BUY)
    sellToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
    buyToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
    buyAmountAfterFee: '10000000000',
    from: '0x1811be0994930fe9480eaede25165608b093ad7a',
    validTo: 2281625458,
  })
```

this wasn't possible before this change.