### PR TITLE
Handle Expired TWAP and not started TWAP

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "cross-fetch": "^3.1.5",
     "exponential-backoff": "^3.1.1",
     "graphql-request": "^4.3.0",
+    "graphql": "^16.3.0",
     "limiter": "^2.1.0"
   },
   "peerDependencies": {
@@ -62,7 +63,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-unused-imports": "^3.0.0",
     "ethers": "^5.7.2",
-    "graphql": "^16.3.0",
     "jest": "^29.4.2",
     "jest-fetch-mock": "^3.0.3",
     "microbundle": "^0.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.5",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/composable/ConditionalOrder.spec.ts
+++ b/src/composable/ConditionalOrder.spec.ts
@@ -79,6 +79,8 @@ describe('ConditionalOrder', () => {
 })
 
 class TestConditionalOrder extends ConditionalOrder<string, string> {
+  isSingleOrder = true
+
   constructor(address: string, salt?: string, data = '0x') {
     super({
       handler: address,

--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ethers, utils, providers } from 'ethers'
+import { BigNumber, ethers, utils } from 'ethers'
 import { IConditionalOrder } from './generated/ComposableCoW'
 
 import { decodeParams, encodeParams } from './utils'
@@ -7,12 +7,12 @@ import {
   ConditionalOrderParams,
   ContextFactory,
   IsValidResult,
+  OwnerContext,
   PollParams,
   PollResult,
   PollResultCode,
   PollResultErrors,
 } from './types'
-import { SupportedChainId } from '../common'
 import { getComposableCow, getComposableCowInterface } from './contracts'
 
 /**
@@ -253,7 +253,7 @@ export abstract class ConditionalOrder<D, S> {
       }
 
       // Check if the owner authorised the order
-      const isAuthorized = await this.isAuthorized(owner, chainId, provider)
+      const isAuthorized = await this.isAuthorized(params)
       if (!isAuthorized) {
         return {
           result: PollResultCode.DONT_TRY_AGAIN,
@@ -290,8 +290,9 @@ export abstract class ConditionalOrder<D, S> {
    * @param provider An RPC provider for the chain.
    * @returns true if the owner authorized the order, false otherwise.
    */
-  public isAuthorized(owner: string, chain: SupportedChainId, provider: providers.Provider): Promise<boolean> {
-    const composableCow = getComposableCow(chain, provider)
+  public isAuthorized(params: OwnerContext): Promise<boolean> {
+    const { chainId, owner, provider } = params
+    const composableCow = getComposableCow(chainId, provider)
     return composableCow.callStatic.singleOrders(owner, this.id)
   }
 
@@ -303,8 +304,10 @@ export abstract class ConditionalOrder<D, S> {
    * @param provider An RPC provider for the chain.
    * @returns true if the owner authorized the order, false otherwise.
    */
-  public cabinet(owner: string, chain: SupportedChainId, provider: providers.Provider): Promise<string> {
-    const composableCow = getComposableCow(chain, provider)
+  public cabinet(params: OwnerContext): Promise<string> {
+    const { chainId, owner, provider } = params
+
+    const composableCow = getComposableCow(chainId, provider)
     return composableCow.callStatic.cabinet(owner, this.id)
   }
 

--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ethers, utils } from 'ethers'
+import { BigNumber, constants, ethers, utils } from 'ethers'
 import { IConditionalOrder } from './generated/ComposableCoW'
 
 import { decodeParams, encodeParams } from './utils'
@@ -304,8 +304,10 @@ export abstract class ConditionalOrder<D, S> {
   public cabinet(params: OwnerContext): Promise<string> {
     const { chainId, owner, provider } = params
 
+    const slotId = this.isSingleOrder ? this.id : constants.HashZero
+
     const composableCow = getComposableCow(chainId, provider)
-    return composableCow.callStatic.cabinet(owner, this.id)
+    return composableCow.callStatic.cabinet(owner, slotId)
   }
 
   /**

--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -70,6 +70,8 @@ export abstract class ConditionalOrder<D, S> {
     this.hasOffChainInput = hasOffChainInput
   }
 
+  abstract get isSingleOrder(): boolean
+
   /**
    * Get a descriptive name for the type of the conditional order (i.e twap, dca, etc).
    *
@@ -285,9 +287,7 @@ export abstract class ConditionalOrder<D, S> {
   /**
    * Checks if the owner authorized the conditional order.
    *
-   * @param owner The owner of the conditional order.
-   * @param chain Which chain to use for the ComposableCoW contract.
-   * @param provider An RPC provider for the chain.
+   * @param params owner context, to be able to check if the order is authorized
    * @returns true if the owner authorized the order, false otherwise.
    */
   public isAuthorized(params: OwnerContext): Promise<boolean> {
@@ -299,10 +299,7 @@ export abstract class ConditionalOrder<D, S> {
   /**
    * Checks the value in the cabinet for a given owner and chain
    *
-   * @param owner The owner of the conditional order.
-   * @param chain Which chain to use for the ComposableCoW contract.
-   * @param provider An RPC provider for the chain.
-   * @returns true if the owner authorized the order, false otherwise.
+   * @param params owner context, to be able to check the cabinet
    */
   public cabinet(params: OwnerContext): Promise<string> {
     const { chainId, owner, provider } = params

--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -233,8 +233,8 @@ export abstract class ConditionalOrder<D, S> {
    * @returns The tradeable `GPv2Order.Data` struct and the `signature` for the conditional order.
    */
   async poll(params: PollParams): Promise<PollResult> {
-    const { chain, owner, provider } = params
-    const composableCow = getComposableCow(chain, provider)
+    const { chainId, owner, provider } = params
+    const composableCow = getComposableCow(chainId, provider)
 
     try {
       const isValid = this.isValid()
@@ -253,11 +253,11 @@ export abstract class ConditionalOrder<D, S> {
       }
 
       // Check if the owner authorised the order
-      const isAuthorized = await this.isAuthorized(owner, chain, provider)
+      const isAuthorized = await this.isAuthorized(owner, chainId, provider)
       if (!isAuthorized) {
         return {
           result: PollResultCode.DONT_TRY_AGAIN,
-          reason: `NotAuthorised: Order ${this.id} is not authorised for ${owner} on chain ${chain}`,
+          reason: `NotAuthorised: Order ${this.id} is not authorised for ${owner} on chain ${chainId}`,
         }
       }
 
@@ -296,7 +296,7 @@ export abstract class ConditionalOrder<D, S> {
   }
 
   /**
-   * Checks if the owner authorized the conditional order.
+   * Checks the value in the cabinet for a given owner and chain
    *
    * @param owner The owner of the conditional order.
    * @param chain Which chain to use for the ComposableCoW contract.

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -287,7 +287,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
   protected async pollValidate(params: PollParams): Promise<PollResultErrors | undefined> {
     const { blockInfo = await getBlockInfo(params.provider), owner, chain, provider } = params
     const { blockTimestamp } = blockInfo
-    const { numberOfParts, timeBetweenParts } = this.data
+    const { numberOfParts, timeBetweenParts, durationOfPart } = this.data
 
     const startTimestamp = await this.startTimestamp(owner, chain, provider)
 
@@ -309,8 +309,19 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
       }
     }
 
-    // TODO: Do not check again expired order
-    // TODO: Calculate the next part start time, signal to not check again until then
+    // TODO: Do not check between parts
+    //    - 1. Check whats the order parameters for the current partNumber
+    //    - 2. Derive discrete orderUid
+    //    - 3. Verify if this is already created in the API
+    //    - 4. If so, we know we should return
+    //   return {
+    //     result: PollResultCode.TRY_AT_EPOCH,
+    //     epoch: nextPartStartTime,
+    //     reason: `Current active TWAP part is already created. The next one doesn't start until ${nextPartStartTime} (${formatEpoc(nextPartStartTime)})`,
+    //   }
+    // // Get current part number
+    // const partNumber = Math.floor(blockTimestamp - startTimestamp / timeBetweenParts.toNumber())
+
     return undefined
   }
 

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -163,6 +163,8 @@ const DEFAULT_DURATION_OF_PART: DurationOfPart = { durationType: DurationType.AU
  * @author mfw78 <mfw78@rndlabs.xyz>
  */
 export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
+  isSingleOrder = true
+
   /**
    * @see {@link ConditionalOrder.constructor}
    * @throws If the TWAP order is invalid.

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -1,4 +1,4 @@
-import { BigNumber, constants } from 'ethers'
+import { BigNumber, constants, utils } from 'ethers'
 
 import { ConditionalOrder } from '../ConditionalOrder'
 import {
@@ -275,6 +275,12 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
     }
 
     const cabinet = await this.cabinet(params)
+    const cabinetEpoc = utils.defaultAbiCoder.decode(['uint256'], cabinet)[0]
+
+    if (cabinetEpoc === 0) {
+      throw new Error('Cabinet is not set. Required for TWAP orders that start at mining time.')
+    }
+
     return parseInt(cabinet, 16)
   }
 

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -285,11 +285,11 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
    * @returns true if the owner authorized the order, false otherwise.
    */
   protected async pollValidate(params: PollParams): Promise<PollResultErrors | undefined> {
-    const { blockInfo = await getBlockInfo(params.provider), owner, chain, provider } = params
+    const { blockInfo = await getBlockInfo(params.provider), owner, chainId, provider } = params
     const { blockTimestamp } = blockInfo
-    const { numberOfParts, timeBetweenParts, durationOfPart } = this.data
+    const { numberOfParts, timeBetweenParts } = this.data
 
-    const startTimestamp = await this.startTimestamp(owner, chain, provider)
+    const startTimestamp = await this.startTimestamp(owner, chainId, provider)
 
     if (startTimestamp > blockTimestamp) {
       // The start time hasn't started

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -293,7 +293,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
 
     if (startTimestamp <= blockTimestamp) {
       // The start time hasn't started
-      return { result: PollResultCode.TRY_AT_EPOCH, epoch: startTimestamp }
+      return { result: PollResultCode.TRY_AT_EPOCH, epoch: startTimestamp, reason: "TWAP hasn't started yet" }
     }
 
     // TODO: Do not check again expired order

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -291,7 +291,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
 
     const startTimestamp = await this.startTimestamp(owner, chain, provider)
 
-    if (startTimestamp <= blockTimestamp) {
+    if (startTimestamp > blockTimestamp) {
       // The start time hasn't started
       return { result: PollResultCode.TRY_AT_EPOCH, epoch: startTimestamp, reason: "TWAP hasn't started yet" }
     }

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -11,7 +11,7 @@ import {
   PollResultCode,
   PollResultErrors,
 } from '../types'
-import { encodeParams, formatEpoc, getBlockInfo, isValidAbi } from '../utils'
+import { encodeParams, formatEpoch, getBlockInfo, isValidAbi } from '../utils'
 import { SupportedChainId } from '../../common'
 
 // The type of Conditional Order
@@ -296,7 +296,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
       return {
         result: PollResultCode.TRY_AT_EPOCH,
         epoch: startTimestamp,
-        reason: `TWAP hasn't started yet. Starts at ${startTimestamp} (${formatEpoc(startTimestamp)})`,
+        reason: `TWAP hasn't started yet. Starts at ${startTimestamp} (${formatEpoch(startTimestamp)})`,
       }
     }
 
@@ -305,7 +305,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
       // The order has expired
       return {
         result: PollResultCode.DONT_TRY_AGAIN,
-        reason: `TWAP has expired. Expired at ${expirationTimestamp} (${formatEpoc(expirationTimestamp)})`,
+        reason: `TWAP has expired. Expired at ${expirationTimestamp} (${formatEpoch(expirationTimestamp)})`,
       }
     }
 
@@ -317,7 +317,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
     //   return {
     //     result: PollResultCode.TRY_AT_EPOCH,
     //     epoch: nextPartStartTime,
-    //     reason: `Current active TWAP part is already created. The next one doesn't start until ${nextPartStartTime} (${formatEpoc(nextPartStartTime)})`,
+    //     reason: `Current active TWAP part is already created. The next one doesn't start until ${nextPartStartTime} (${formatEpoch(nextPartStartTime)})`,
     //   }
     // // Get current part number
     // const partNumber = Math.floor(blockTimestamp - startTimestamp / timeBetweenParts.toNumber())

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -1,4 +1,6 @@
+import { SupportedChainId } from '../common'
 import { GPv2Order } from './generated/ComposableCoW'
+import { providers } from 'ethers'
 
 export interface ConditionalOrderArguments<T> {
   handler: string
@@ -79,6 +81,22 @@ export type ProofWithParams = {
   params: ConditionalOrderParams
 }
 
+export type PollParams = {
+  owner: string
+  chain: SupportedChainId
+  provider: providers.Provider
+
+  /**
+   * If present, it can be used for custom conditional order validations. If not present, the orders will need to get the block info themselves using the provider
+   */
+  blockInfo?: BlockInfo
+}
+
+export type BlockInfo = {
+  blockNumber: number
+  blockTimestamp: number
+}
+
 export type PollResult = PollResultSuccess | PollResultErrors
 
 export type PollResultErrors =
@@ -105,6 +123,7 @@ export interface PollResultSuccess {
 export interface PollResultUnexpectedError {
   readonly result: PollResultCode.UNEXPECTED_ERROR
   readonly error: unknown
+  reason?: string
 }
 
 export interface PollResultTryNextBlock {

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -111,7 +111,7 @@ export enum PollResultCode {
   UNEXPECTED_ERROR = 'UNEXPECTED_ERROR',
   TRY_NEXT_BLOCK = 'TRY_NEXT_BLOCK',
   TRY_ON_BLOCK = 'TRY_ON_BLOCK',
-  TRY_AT_EPOCH = 'TRY_AT_DATE',
+  TRY_AT_EPOCH = 'TRY_AT_EPOCH',
   DONT_TRY_AGAIN = 'DONT_TRY_AGAIN',
 }
 export interface PollResultSuccess {

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -88,6 +88,9 @@ export type OwnerContext = {
 }
 
 export type PollParams = OwnerContext & {
+  offchainInput: string
+  proof: string[]
+
   /**
    * If present, it can be used for custom conditional order validations. If not present, the orders will need to get the block info themselves
    */

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -81,11 +81,13 @@ export type ProofWithParams = {
   params: ConditionalOrderParams
 }
 
-export type PollParams = {
+export type OwnerContext = {
   owner: string
   chainId: SupportedChainId
   provider: providers.Provider
+}
 
+export type PollParams = OwnerContext & {
   /**
    * If present, it can be used for custom conditional order validations. If not present, the orders will need to get the block info themselves
    */

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -83,11 +83,11 @@ export type ProofWithParams = {
 
 export type PollParams = {
   owner: string
-  chain: SupportedChainId
+  chainId: SupportedChainId
   provider: providers.Provider
 
   /**
-   * If present, it can be used for custom conditional order validations. If not present, the orders will need to get the block info themselves using the provider
+   * If present, it can be used for custom conditional order validations. If not present, the orders will need to get the block info themselves
    */
   blockInfo?: BlockInfo
 }

--- a/src/composable/utils.ts
+++ b/src/composable/utils.ts
@@ -83,3 +83,7 @@ export async function getBlockInfo(provider: providers.Provider): Promise<BlockI
     blockTimestamp: block.timestamp,
   }
 }
+
+export function formatEpoc(epoch: number): string {
+  return new Date(epoch * 1000).toISOString()
+}

--- a/src/composable/utils.ts
+++ b/src/composable/utils.ts
@@ -5,7 +5,7 @@ import {
   SupportedChainId,
 } from '../common'
 import { ExtensibleFallbackHandler__factory } from './generated'
-import { ConditionalOrderParams } from './types'
+import { BlockInfo, ConditionalOrderParams } from './types'
 
 // Define the ABI tuple for the ConditionalOrderParams struct
 export const CONDITIONAL_ORDER_PARAMS_ABI = ['tuple(address handler, bytes32 salt, bytes staticInput)']
@@ -73,4 +73,13 @@ export function isValidAbi(types: readonly (string | utils.ParamType)[], values:
     return false
   }
   return true
+}
+
+export async function getBlockInfo(provider: providers.Provider): Promise<BlockInfo> {
+  const block = await provider.getBlock('latest')
+
+  return {
+    blockNumber: block.number,
+    blockTimestamp: block.timestamp,
+  }
 }

--- a/src/composable/utils.ts
+++ b/src/composable/utils.ts
@@ -84,6 +84,6 @@ export async function getBlockInfo(provider: providers.Provider): Promise<BlockI
   }
 }
 
-export function formatEpoc(epoch: number): string {
+export function formatEpoch(epoch: number): string {
   return new Date(epoch * 1000).toISOString()
 }


### PR DESCRIPTION
This PR 

## Includes some optional blockInfo params
This params allow the `poll` method to use either the `blockNumber` or the `blockTimestamp` to validate the concrete Conditional Order.

![image](https://github.com/cowprotocol/cow-sdk/assets/2352112/016d79c0-ace9-4b00-b3bb-6642fa4da062)

## Validate start time
It will check if the order started. If it haven't then we can signal we don't want to re-check until the start time


## Handle Expired TWAPs
This is causing a lot of noise in the logs. Expired TWAP orders are never deleted. Now they are
![image](https://github.com/cowprotocol/cow-sdk/assets/2352112/e8e4582c-a86b-4041-b3a3-3e88ff35bab6)

Tried it in WatchTower (adapted it in https://github.com/cowprotocol/tenderly-watch-tower/pull/16)

![image](https://github.com/cowprotocol/cow-sdk/assets/2352112/d49e9f91-22eb-4239-8ad9-3f8dea82aafb)


## Don't fail to handle errors
Handled errors should not show as errors

![image](https://github.com/cowprotocol/cow-sdk/assets/2352112/aaa6dac7-aa35-4a88-bfe3-a081cf123b63)



## Not included
Left some notes for a future PR on something that will help to reduce significantly the number of checks we need to do.
It's out of scope cause is not a trivial change. It will need a model update in watch tower
![image](https://github.com/cowprotocol/cow-sdk/assets/2352112/aaa6dac7-aa35-4a88-bfe3-a081cf123b63)

