### PR TITLE
fix: typos and nomenclature

### DIFF
--- a/src/composable/ConditionalOrder.spec.ts
+++ b/src/composable/ConditionalOrder.spec.ts
@@ -25,7 +25,7 @@ const TWAP_SERIALIZED = (salt?: string, handler?: string): string => {
   )
 }
 
-describe('Constuctor', () => {
+describe('Constructor', () => {
   test('Create TestConditionalOrder', () => {
     // bad address
     expect(() => new TestConditionalOrder('0xdeadbeef')).toThrow('Invalid handler: 0xdeadbeef')

--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -295,10 +295,10 @@ export abstract class ConditionalOrder<D, S> {
   }
 
   /**
-   * Checks if the owner authorized the conditional order.
+   * Checks if the owner authorised the conditional order.
    *
-   * @param params owner context, to be able to check if the order is authorized
-   * @returns true if the owner authorized the order, false otherwise.
+   * @param params owner context, to be able to check if the order is authorised
+   * @returns true if the owner authorised the order, false otherwise.
    */
   public isAuthorized(params: OwnerContext): Promise<boolean> {
     const { chainId, owner, provider } = params
@@ -331,7 +331,7 @@ export abstract class ConditionalOrder<D, S> {
   protected abstract pollValidate(params: PollParams): Promise<PollResultErrors | undefined>
 
   /**
-   * Convert the struct that the contract expect as an encoded `staticInput` into a friendly data object modeling the smart order.
+   * Convert the struct that the contract expect as an encoded `staticInput` into a friendly data object modelling the smart order.
    *
    * **NOTE**: This should be overridden by any conditional order that requires transformations.
    * This implementation is a no-op if you use the same type for both.
@@ -342,7 +342,7 @@ export abstract class ConditionalOrder<D, S> {
   abstract transformStructToData(params: S): D
 
   /**
-   * Converts a friendly data object modeling the smart order into the struct that the contract expect as an encoded `staticInput`.
+   * Converts a friendly data object modelling the smart order into the struct that the contract expect as an encoded `staticInput`.
    *
    * **NOTE**: This should be overridden by any conditional order that requires transformations.
    * This implementation is a no-op if you use the same type for both.

--- a/src/composable/contracts.ts
+++ b/src/composable/contracts.ts
@@ -3,21 +3,21 @@ import { COMPOSABLE_COW_CONTRACT_ADDRESS, SupportedChainId } from '../common'
 import { ComposableCoW, ComposableCoW__factory } from './generated'
 import { ComposableCoWInterface } from './generated/ComposableCoW'
 
-let iCcomposableCow: ComposableCoWInterface | undefined
-let composableCow: ComposableCoW | undefined
+let composableCowInterfaceCache: ComposableCoWInterface | undefined
+let composableCowContractCache: ComposableCoW | undefined
 
 export function getComposableCowInterface(): ComposableCoWInterface {
-  if (!iCcomposableCow) {
-    iCcomposableCow = ComposableCoW__factory.createInterface()
+  if (!composableCowInterfaceCache) {
+    composableCowInterfaceCache = ComposableCoW__factory.createInterface()
   }
 
-  return iCcomposableCow
+  return composableCowInterfaceCache
 }
 
 export function getComposableCow(chain: SupportedChainId, provider: providers.Provider) {
-  if (!composableCow) {
-    composableCow = ComposableCoW__factory.connect(COMPOSABLE_COW_CONTRACT_ADDRESS[chain], provider)
+  if (!composableCowContractCache) {
+    composableCowContractCache = ComposableCoW__factory.connect(COMPOSABLE_COW_CONTRACT_ADDRESS[chain], provider)
   }
 
-  return composableCow
+  return composableCowContractCache
 }

--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -87,7 +87,7 @@ describe('Twap.fromData', () => {
   test('Creates valid TWAP: Start at epoch', () => {
     const twap = Twap.fromData({
       ...TWAP_PARAMS_TEST,
-      startTime: { startType: StartTimeValue.AT_EPOC, epoch: BigNumber.from(1) },
+      startTime: { startType: StartTimeValue.AT_EPOCH, epoch: BigNumber.from(1) },
     })
     expect(twap.context).toBeUndefined()
   })
@@ -137,7 +137,7 @@ describe('Validate', () => {
     expect(
       Twap.fromData({
         ...TWAP_PARAMS_TEST,
-        startTime: { startType: StartTimeValue.AT_EPOC, epoch: BigNumber.from(-1) },
+        startTime: { startType: StartTimeValue.AT_EPOCH, epoch: BigNumber.from(-1) },
       }).isValid()
     ).toEqual({
       isValid: false,
@@ -211,7 +211,7 @@ describe('To String', () => {
     expect(
       Twap.fromData({
         ...TWAP_PARAMS_TEST,
-        startTime: { startType: StartTimeValue.AT_EPOC, epoch: startEpoch },
+        startTime: { startType: StartTimeValue.AT_EPOCH, epoch: startEpoch },
       }).toString()
     ).toEqual(
       'twap: Sell total 0x6810e776880C02933D47DB1b9fc05908e5386b96@1000000000000000000 for a minimum of 0xDAE5F1590db13E3B40423B5b5c5fbf175515910b@1000000000000000000 over 10 parts with a spacing of 3600s beginning at epoch 1692876646'

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -36,8 +36,8 @@ const DEFAULT_TOKEN_FORMATTER = (address: string, amount: BigNumber) => `${addre
 
 /**
  * Base parameters for a TWAP order. Shared by:
- *   - TwapStruct (modeling the contract's struct used for `staticInput`).
- *   - TwapData (modeling the friendly SDK interface).
+ *   - TwapStruct (modelling the contract's struct used for `staticInput`).
+ *   - TwapData (modelling the friendly SDK interface).
  */
 export type TwapDataBase = {
   /**
@@ -147,11 +147,11 @@ export enum DurationType {
 
 export type StartTime =
   | { startType: StartTimeValue.AT_MINING_TIME }
-  | { startType: StartTimeValue.AT_EPOC; epoch: BigNumber }
+  | { startType: StartTimeValue.AT_EPOCH; epoch: BigNumber }
 
 export enum StartTimeValue {
   AT_MINING_TIME = 'AT_MINING_TIME',
-  AT_EPOC = 'AT_EPOC',
+  AT_EPOCH = 'AT_EPOCH',
 }
 
 const DEFAULT_START_TIME: StartTime = { startType: StartTimeValue.AT_MINING_TIME }
@@ -246,7 +246,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
       if (!(sellToken != constants.AddressZero && buyToken != constants.AddressZero)) return 'InvalidToken'
       if (!sellAmount.gt(constants.Zero)) return 'InvalidSellAmount'
       if (!buyAmount.gt(constants.Zero)) return 'InvalidMinBuyAmount'
-      if (startTime.startType === StartTimeValue.AT_EPOC) {
+      if (startTime.startType === StartTimeValue.AT_EPOCH) {
         const t0 = startTime.epoch
         if (!(t0.gte(constants.Zero) && t0.lt(MAX_UINT32))) return 'InvalidStartTime'
       }
@@ -269,14 +269,14 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
   private async startTimestamp(params: OwnerContext): Promise<number> {
     const { startTime } = this.data
 
-    if (startTime?.startType === StartTimeValue.AT_EPOC) {
+    if (startTime?.startType === StartTimeValue.AT_EPOCH) {
       return startTime.epoch.toNumber()
     }
 
     const cabinet = await this.cabinet(params)
-    const cabinetEpoc = utils.defaultAbiCoder.decode(['uint256'], cabinet)[0]
+    const cabinetEpoch = utils.defaultAbiCoder.decode(['uint256'], cabinet)[0]
 
-    if (cabinetEpoc === 0) {
+    if (cabinetEpoch === 0) {
       throw new Error('Cabinet is not set. Required for TWAP orders that start at mining time.')
     }
 
@@ -284,12 +284,12 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
   }
 
   /**
-   * Checks if the owner authorized the conditional order.
+   * Checks if the owner authorised the conditional order.
    *
    * @param owner The owner of the conditional order.
    * @param chain Which chain to use for the ComposableCoW contract.
    * @param provider An RPC provider for the chain.
-   * @returns true if the owner authorized the order, false otherwise.
+   * @returns true if the owner authorised the order, false otherwise.
    */
   protected async pollValidate(params: PollParams): Promise<PollResultErrors | undefined> {
     const { blockInfo = await getBlockInfo(params.provider) } = params
@@ -469,7 +469,7 @@ export function transformStructToData(struct: TwapStruct): TwapData {
 
   const startTime: StartTime = span.isZero()
     ? { startType: StartTimeValue.AT_MINING_TIME }
-    : { startType: StartTimeValue.AT_EPOC, epoch: startEpoch }
+    : { startType: StartTimeValue.AT_EPOCH, epoch: startEpoch }
 
   return {
     sellAmount: partSellAmount.mul(numberOfParts),

--- a/src/composable/orderTypes/index.ts
+++ b/src/composable/orderTypes/index.ts
@@ -2,7 +2,7 @@ import { ConditionalOrderRegistry } from '../ConditionalOrderFactory'
 import { TWAP_ADDRESS, Twap } from './Twap'
 export * from './Twap'
 
-export const DEFAULT_CONDITIONAL_ORDER_REGSTRY: ConditionalOrderRegistry = {
+export const DEFAULT_CONDITIONAL_ORDER_REGISTRY: ConditionalOrderRegistry = {
   // Registry of all known order types
   [TWAP_ADDRESS]: (params) => Twap.fromParams(params),
 }

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -145,10 +145,10 @@ export interface PollResultTryOnBlock {
 export interface PollResultTryAtEpoch {
   readonly result: PollResultCode.TRY_AT_EPOCH
   /**
-   * The epoch after which it is ok to re-try to to poll this order.
+   * The epoch after which it is ok to retry to to poll this order.
    * The value is expressed as a Unix timestamp (in seconds).
    *
-   * This epoch will be inclusive, meaning that it is ok to re-try at the block mined pricesely at this epoch or later.
+   * This epoch will be inclusive, meaning that it is ok to retry at the block mined precisely at this epoch or later.
    */
   readonly epoch: number
   reason?: string


### PR DESCRIPTION
This PR:

1. Fixes various typos in the composable section of the code base.
2. Adjusts some nomenclature for non-exported variables.
3. Fixes a typo in an exported const that affects downstream consumers (comments inline in code).