### PR TITLE
Add global imports for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,12 @@
     ],
     "coveragePathIgnorePatterns": [
       "src/composable/generated"
+    ],
+    "moduleDirectories": [
+      "node_modules"
+    ],
+    "modulePaths": [
+      "<rootDir>/"
     ]
   },
   "keywords": [


### PR DESCRIPTION
Add global import support for jest

it was possible before to use global import (instead of relative) for any TS code, but not in tests.

This makes the test to break as soon as you use something with a global import.


This PR fixes this.