### PR TITLE
Mock contracts and test cabinet

### DIFF
--- a/src/composable/contracts.ts
+++ b/src/composable/contracts.ts
@@ -14,7 +14,7 @@ export function getComposableCowInterface(): ComposableCoWInterface {
   return composableCowInterfaceCache
 }
 
-export function getComposableCow(chain: SupportedChainId, provider: providers.Provider) {
+export function getComposableCow(chain: SupportedChainId, provider: providers.Provider): ComposableCoW {
   if (!composableCowContractCache) {
     composableCowContractCache = ComposableCoW__factory.connect(COMPOSABLE_COW_CONTRACT_ADDRESS[chain], provider)
   }

--- a/src/composable/orderTypes/test/TestConditionalOrder.ts
+++ b/src/composable/orderTypes/test/TestConditionalOrder.ts
@@ -1,0 +1,51 @@
+import { ConditionalOrder } from '../../ConditionalOrder'
+import { IsValidResult, PollResultErrors } from '../../types'
+import { encodeParams } from '../../utils'
+
+export class TestConditionalOrder extends ConditionalOrder<string, string> {
+  isSingleOrder: boolean
+
+  constructor(address: string, salt?: string, data = '0x', isSingleOrder = true) {
+    super({
+      handler: address,
+      salt,
+      data,
+    })
+    this.isSingleOrder = isSingleOrder
+  }
+
+  get orderType(): string {
+    return 'TEST'
+  }
+
+  encodeStaticInput(): string {
+    return this.staticInput
+  }
+
+  testEncodeStaticInput(): string {
+    return super.encodeStaticInputHelper(['uint256'], this.staticInput)
+  }
+
+  transformStructToData(params: string): string {
+    return params
+  }
+
+  transformDataToStruct(params: string): string {
+    return params
+  }
+
+  protected pollValidate(): Promise<PollResultErrors | undefined> {
+    throw new Error('Method not implemented.')
+  }
+
+  isValid(): IsValidResult {
+    throw new Error('Method not implemented.')
+  }
+  serialize(): string {
+    return encodeParams(this.leaf)
+  }
+
+  toString(): string {
+    throw new Error('Method not implemented.')
+  }
+}


### PR DESCRIPTION
This PR mocks the ConditionalOrders tests, so we can run some unit tests that involves calls to the contract.

The new methods, like `poll` and `cabinet` will require this mocking.

This PR also adds the unit test for the `cabinet`