### PR TITLE
[Polling tests] Add Handle unexpected errors

### DIFF
--- a/src/composable/ConditionalOrder.spec.ts
+++ b/src/composable/ConditionalOrder.spec.ts
@@ -270,7 +270,7 @@ describe('Poll Single Orders', () => {
     // WHEN: we poll
     const pollResult = await order.poll(param)
 
-    // THEN: we expect no CALLs to the
+    // THEN: we expect 1 CALL to the
     expect(mockGetTradeableOrderWithSignature).toBeCalledTimes(1)
 
     // THEN: We receive an unexpected error

--- a/src/composable/ConditionalOrder.spec.ts
+++ b/src/composable/ConditionalOrder.spec.ts
@@ -253,4 +253,30 @@ describe('Poll Single Orders', () => {
       reason: 'InvalidConditionalOrder. Reason: ' + validationError,
     })
   })
+
+  test('[UNEXPECTED_ERROR] getTradeableOrderWithSignature throws an error', async () => {
+    // GIVEN: getTradeableOrderWithSignature throws
+    const error = new Error(`I'm sorry, but is not a good time to trade`)
+    mockGetTradeableOrderWithSignature.mockImplementation(() => {
+      throw error
+    })
+
+    // GIVEN: Every validation is OK (auth + contract returns an order + order is valid)
+    const order = createOrder()
+    const mockIsValid = jest.fn(order.isValid).mockReturnValue({ isValid: true })
+    order.isValid = mockIsValid
+    mockSingleOrders.mockReturnValue(true)
+
+    // WHEN: we poll
+    const pollResult = await order.poll(param)
+
+    // THEN: we expect no CALLs to the
+    expect(mockGetTradeableOrderWithSignature).toBeCalledTimes(1)
+
+    // THEN: We expect a SUCCESS result, which returns the order and the signature
+    expect(pollResult).toEqual({
+      result: PollResultCode.UNEXPECTED_ERROR,
+      error,
+    })
+  })
 })

--- a/src/composable/ConditionalOrder.spec.ts
+++ b/src/composable/ConditionalOrder.spec.ts
@@ -273,7 +273,7 @@ describe('Poll Single Orders', () => {
     // THEN: we expect no CALLs to the
     expect(mockGetTradeableOrderWithSignature).toBeCalledTimes(1)
 
-    // THEN: We expect a SUCCESS result, which returns the order and the signature
+    // THEN: We receive an unexpected error
     expect(pollResult).toEqual({
       result: PollResultCode.UNEXPECTED_ERROR,
       error,


### PR DESCRIPTION
Normally, validations, if done right, will catch all errors and return a comprehensive error.

This is why, by the time we do the call to `getTradeableOrderWithSignature` we will have quite some certainty the call will succeed. If it doesn't we will consider it an `UNEXPECTED_ERROR` and will return the original error with the result. 

This PR adds a unit test to validate we get this result in this situation. 