### PR TITLE
Mock class and implement custom polling test

### DIFF
--- a/src/composable/orderTypes/test/TestConditionalOrder.ts
+++ b/src/composable/orderTypes/test/TestConditionalOrder.ts
@@ -1,5 +1,5 @@
 import { ConditionalOrder } from '../../ConditionalOrder'
-import { IsValidResult, PollParams, PollResultErrors } from '../../types'
+import { IsValidResult, PollResultErrors } from '../../types'
 import { encodeParams } from '../../utils'
 
 export const DEFAULT_ORDER_PARAMS: TestConditionalOrderParams = {
@@ -48,7 +48,7 @@ export class TestConditionalOrder extends ConditionalOrder<string, string> {
     return params
   }
 
-  protected async pollValidate(_params: PollParams): Promise<PollResultErrors | undefined> {
+  protected async pollValidate(): Promise<PollResultErrors | undefined> {
     return undefined
   }
 

--- a/src/composable/orderTypes/test/TestConditionalOrder.ts
+++ b/src/composable/orderTypes/test/TestConditionalOrder.ts
@@ -1,13 +1,27 @@
 import { ConditionalOrder } from '../../ConditionalOrder'
-import { IsValidResult, PollResultErrors } from '../../types'
+import { IsValidResult, PollParams, PollResultErrors } from '../../types'
 import { encodeParams } from '../../utils'
 
+export const DEFAULT_ORDER_PARAMS: TestConditionalOrderParams = {
+  handler: '0x910d00a310f7Dc5B29FE73458F47f519be547D3d',
+  salt: '0x9379a0bf532ff9a66ffde940f94b1a025d6f18803054c1aef52dc94b15255bbe',
+  data: '0x',
+  isSingleOrder: true,
+}
+
+export type TestConditionalOrderParams = {
+  handler: string
+  salt?: string
+  data: string
+  isSingleOrder: boolean
+}
 export class TestConditionalOrder extends ConditionalOrder<string, string> {
   isSingleOrder: boolean
 
-  constructor(address: string, salt?: string, data = '0x', isSingleOrder = true) {
+  constructor(params: TestConditionalOrderParams) {
+    const { handler, salt, data = '0x', isSingleOrder = true } = params
     super({
-      handler: address,
+      handler,
       salt,
       data,
     })
@@ -34,7 +48,7 @@ export class TestConditionalOrder extends ConditionalOrder<string, string> {
     return params
   }
 
-  protected async pollValidate(): Promise<PollResultErrors | undefined> {
+  protected async pollValidate(_params: PollParams): Promise<PollResultErrors | undefined> {
     return undefined
   }
 
@@ -49,3 +63,9 @@ export class TestConditionalOrder extends ConditionalOrder<string, string> {
     throw new Error('Method not implemented.')
   }
 }
+
+export const createTestConditionalOrder = (params?: Partial<TestConditionalOrderParams>) =>
+  new TestConditionalOrder({
+    ...DEFAULT_ORDER_PARAMS,
+    ...params,
+  })


### PR DESCRIPTION
This PR verifies that the child class always have the last word when we are polling, and can signal what should be the result.

It adds 6 new tests for the different outcomes of `pollValidate`:

![image](https://github.com/cowprotocol/cow-sdk/assets/2352112/51b305ea-3651-43bc-814b-0e25dac63cfb)

The tests were a bit repetitive, so for this one i created a shared function. After all, i just want to test for all case, the `poll` will respect what the `pollValidate` says, so i just want to see it handles expectations, and all the result codes.

Note that I had to extend the test order class to be able to override and mock `pollValidate` (its protected, which makes it harder to mock)