### PR TITLE
Check existence of the order in the orderbook, and add polledOrderInOrderbook

### DIFF
--- a/src/composable/ConditionalOrder.spec.ts
+++ b/src/composable/ConditionalOrder.spec.ts
@@ -16,7 +16,7 @@ jest.mock('./contracts')
 jest.mock('../order-book/api', () => {
   return {
     OrderBookApi: class MockedOrderBookApi {
-      getOrder = mockGetOrder //jest.fn(),
+      getOrder = mockGetOrder
     },
   }
 })

--- a/src/composable/ConditionalOrder.spec.ts
+++ b/src/composable/ConditionalOrder.spec.ts
@@ -1,3 +1,4 @@
+import { mockGetOrder } from '../order-book/__mock__/api'
 import {
   DEFAULT_ORDER_PARAMS,
   TestConditionalOrder,
@@ -13,18 +14,11 @@ import { BuyTokenDestination, OrderKind, SellTokenSource } from '../order-book/g
 import { computeOrderUid } from '../utils'
 
 jest.mock('./contracts')
-jest.mock('../order-book/api', () => {
-  return {
-    OrderBookApi: class MockedOrderBookApi {
-      getOrder = mockGetOrder
-    },
-  }
-})
+
 jest.mock('../utils')
 
 const mockGetComposableCow = getComposableCow as jest.MockedFunction<typeof getComposableCow>
 const mockComputeOrderUid = computeOrderUid as jest.MockedFunction<typeof computeOrderUid>
-const mockGetOrder = jest.fn()
 
 const TWAP_SERIALIZED = (salt?: string, handler?: string): string => {
   return (

--- a/src/composable/ConditionalOrder.spec.ts
+++ b/src/composable/ConditionalOrder.spec.ts
@@ -10,9 +10,21 @@ import { getComposableCow } from './contracts'
 import { constants } from 'ethers'
 import { OwnerContext, PollParams, PollResultCode, PollResultErrors } from './types'
 import { BuyTokenDestination, OrderKind, SellTokenSource } from '../order-book/generated'
+import { computeOrderUid } from '../utils'
 
 jest.mock('./contracts')
+jest.mock('../order-book/api', () => {
+  return {
+    OrderBookApi: class MockedOrderBookApi {
+      getOrder = mockGetOrder //jest.fn(),
+    },
+  }
+})
+jest.mock('../utils')
+
 const mockGetComposableCow = getComposableCow as jest.MockedFunction<typeof getComposableCow>
+const mockComputeOrderUid = computeOrderUid as jest.MockedFunction<typeof computeOrderUid>
+const mockGetOrder = jest.fn()
 
 const TWAP_SERIALIZED = (salt?: string, handler?: string): string => {
   return (
@@ -187,6 +199,9 @@ describe('Poll Single Orders', () => {
       getTradeableOrderWithSignature: mockGetTradeableOrderWithSignature,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)
+
+    mockComputeOrderUid.mockReturnValue(Promise.resolve(SINGLE_ORDER.id))
+    mockGetOrder.mockImplementation(() => Promise.reject('Pretend the order does not exist'))
   })
 
   test('[SUCCESS] Happy path', async () => {

--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -292,16 +292,6 @@ export abstract class ConditionalOrder<D, S> {
         orderBookCache[chainId] = orderBookApi
       }
 
-      // TODO: Derive orderId from the order data
-      /*
-      {
-        name: "Gnosis Protocol",
-        version: "v2",
-        chainId: chainId,
-        verifyingContract: GPV2SETTLEMENT,
-      }
-      */
-
       const orderUid = await computeOrderUid(chainId, owner, order as Order)
 
       // Check if the order is already in the order book

--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -302,7 +302,7 @@ export abstract class ConditionalOrder<D, S> {
 
       // Let the concrete Conditional Order decide about the poll result (in the case the order is already in the orderbook)
       if (isOrderInOrderbook) {
-        const pollResult = await this.polledOrderInOrderbook(orderUid, order, params)
+        const pollResult = await this.handlePollFailedAlreadyPresent(orderUid, order, params)
         if (pollResult) {
           return pollResult
         }
@@ -363,14 +363,14 @@ export abstract class ConditionalOrder<D, S> {
   protected abstract pollValidate(params: PollParams): Promise<PollResultErrors | undefined>
 
   /**
-   * This method lets the concrete conditional order decide what to do if the order yielded in the polling has been already created.
+   * This method lets the concrete conditional order decide what to do if the order yielded in the polling is already present in the Orderbook API.
    *
    * The concrete conditional order will have a chance to schedule the next poll.
-   * For example, a TWAP order that has the current part already in the orderbook, can signal that the next poll should be done at the time of the next part.
+   * For example, a TWAP order that has the current part already in the orderbook, can signal that the next poll should be done at the start time of the next part.
    *
    * @param params
    */
-  protected abstract polledOrderInOrderbook(
+  protected abstract handlePollFailedAlreadyPresent(
     orderUid: UID,
     order: GPv2Order.DataStructOutput,
     params: PollParams

--- a/src/composable/Multiplexer.ts
+++ b/src/composable/Multiplexer.ts
@@ -1,3 +1,4 @@
+import 'src/order-book/__mock__/api'
 import { StandardMerkleTree } from '@openzeppelin/merkle-tree'
 import { BigNumber, providers, utils } from 'ethers'
 
@@ -434,7 +435,7 @@ export class Multiplexer {
    */
   public static registerOrderType(
     orderType: string,
-    conditionalOrderClass: new (...args: unknown[]) => ConditionalOrder<unknown, unknown>
+    conditionalOrderClass: new (...args: any[]) => ConditionalOrder<unknown, unknown>
   ) {
     Multiplexer.orderTypeRegistry[orderType] = conditionalOrderClass
   }

--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -1,3 +1,4 @@
+import '../../order-book/__mock__/api'
 import { DurationType, StartTimeValue, Twap, TWAP_ADDRESS, TwapData } from './Twap'
 import { BigNumber, utils, constants } from 'ethers'
 

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -12,6 +12,7 @@ import {
   PollResultErrors,
 } from '../types'
 import { encodeParams, formatEpoch, getBlockInfo, isValidAbi } from '../utils'
+import { GPv2Order } from '../generated/ComposableCoW'
 
 // The type of Conditional Order
 const TWAP_ORDER_TYPE = 'twap'
@@ -347,6 +348,14 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
     // // Get current part number
     // const partNumber = Math.floor(blockTimestamp - startTimestamp / timeBetweenParts.toNumber())
 
+    return undefined
+  }
+
+  protected async polledOrderInOrderbook(
+    _orderUid: string,
+    _order: GPv2Order.DataStructOutput,
+    _params: PollParams
+  ): Promise<PollResultErrors | undefined> {
     return undefined
   }
 

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -351,7 +351,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
     return undefined
   }
 
-  protected async polledOrderInOrderbook(
+  protected async handlePollFailedAlreadyPresent(
     _orderUid: string,
     _order: GPv2Order.DataStructOutput,
     _params: PollParams

--- a/src/composable/orderTypes/test/TestConditionalOrder.ts
+++ b/src/composable/orderTypes/test/TestConditionalOrder.ts
@@ -1,4 +1,4 @@
-import { GPv2Order } from 'src/composable/generated/ComposableCoW'
+import { GPv2Order } from '../../generated/ComposableCoW'
 import { ConditionalOrder } from '../../ConditionalOrder'
 import { IsValidResult, PollParams, PollResultErrors } from '../../types'
 import { encodeParams } from '../../utils'
@@ -49,7 +49,7 @@ export class TestConditionalOrder extends ConditionalOrder<string, string> {
     return params
   }
 
-  protected async pollValidate(): Promise<PollResultErrors | undefined> {
+  protected async pollValidate(_params: PollParams): Promise<PollResultErrors | undefined> {
     return undefined
   }
   protected async polledOrderInOrderbook(

--- a/src/composable/orderTypes/test/TestConditionalOrder.ts
+++ b/src/composable/orderTypes/test/TestConditionalOrder.ts
@@ -52,7 +52,7 @@ export class TestConditionalOrder extends ConditionalOrder<string, string> {
   protected async pollValidate(_params: PollParams): Promise<PollResultErrors | undefined> {
     return undefined
   }
-  protected async polledOrderInOrderbook(
+  protected async handlePollFailedAlreadyPresent(
     _orderUid: string,
     _order: GPv2Order.DataStructOutput,
     _params: PollParams

--- a/src/composable/orderTypes/test/TestConditionalOrder.ts
+++ b/src/composable/orderTypes/test/TestConditionalOrder.ts
@@ -1,5 +1,6 @@
+import { GPv2Order } from 'src/composable/generated/ComposableCoW'
 import { ConditionalOrder } from '../../ConditionalOrder'
-import { IsValidResult, PollResultErrors } from '../../types'
+import { IsValidResult, PollParams, PollResultErrors } from '../../types'
 import { encodeParams } from '../../utils'
 
 export const DEFAULT_ORDER_PARAMS: TestConditionalOrderParams = {
@@ -49,6 +50,13 @@ export class TestConditionalOrder extends ConditionalOrder<string, string> {
   }
 
   protected async pollValidate(): Promise<PollResultErrors | undefined> {
+    return undefined
+  }
+  protected async polledOrderInOrderbook(
+    _orderUid: string,
+    _order: GPv2Order.DataStructOutput,
+    _params: PollParams
+  ): Promise<PollResultErrors | undefined> {
     return undefined
   }
 

--- a/src/composable/utils.ts
+++ b/src/composable/utils.ts
@@ -1,3 +1,4 @@
+import 'src/order-book/__mock__/api'
 import { utils, providers } from 'ethers'
 import {
   COMPOSABLE_COW_CONTRACT_ADDRESS,

--- a/src/order-book/__mock__/api.ts
+++ b/src/order-book/__mock__/api.ts
@@ -1,0 +1,9 @@
+jest.mock('../api', () => {
+  return {
+    OrderBookApi: class MockedOrderBookApi {
+      getOrder = mockGetOrder
+    },
+  }
+})
+
+export const mockGetOrder = jest.fn()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,10 @@
+import type { Order } from '@cowprotocol/contracts'
+import type { SupportedChainId } from './common'
+import { OrderSigningUtils } from './order-signing'
+
+export async function computeOrderUid(chainId: SupportedChainId, owner: string, order: Order): Promise<string> {
+  const { computeOrderUid: _computeOrderUid } = await import('@cowprotocol/contracts')
+  const domain = await OrderSigningUtils.getDomain(chainId)
+
+  return _computeOrderUid(domain, order, owner)
+}


### PR DESCRIPTION
This PR adds a 2 things:

1) A new check, after we get the order that "should" be created, we double-check if it was already created or not by quering the orderbook.

2) After we verify the existence of the order, the polling will return by default `TRY_NEXT_BLOCK`, but at the same time it will give the concrete order to give a different result. This will allow orders like Twap to say: "Ok, so if current part is already created, next part should be starting by this exact time, therefore it will return a `TRY_AT_EPOCH` overriding `TRY_NEXT_BLOCK` default). 


This will allow orders to be polled much more efficiently, for example, DCA that trades once a month, you will not need to check every block between two months.

Also, another efficiency, is that watch towers will not need to post the orders if someone else already posted it, reducing drastically the errors of `DuplicatedOrder`.



## Not included
Next PRs I plan to add:
- Unit testing for all these 2 new additions
- TWAP: Schedule next part