### PR TITLE
Test twap poll validate

### DIFF
--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -222,7 +222,7 @@ describe('To String', () => {
   })
 })
 
-describe('Poll', () => {
+describe('Poll Validate', () => {
   const blockNumber = 123456
   const blockTimestamp = 1700000000
   const mockStartTimestamp: jest.MockedFunction<(params: OwnerContext) => Promise<number>> = jest.fn()

--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -235,7 +235,7 @@ describe('Poll Validate', () => {
 
   const provider = {
     getBlock: mockGetBlock,
-  } as any as providers.Provider
+  } as unknown as providers.Provider
 
   const pollParams = {
     owner: OWNER,

--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -275,7 +275,7 @@ describe('Poll Validate', () => {
   })
 
   test(`[TRY_AT_EPOCH] TWAP has not started`, async () => {
-    // GIVEN: A TWAP that hasn't started (should start in 1 second ago, should finish in 2 second)
+    // GIVEN: A TWAP that hasn't started (should start in 1 second, should finish in 2 second)
     const startTime = blockTimestamp + 1
     mockStartTimestamp.mockReturnValue(Promise.resolve(startTime))
     mockEndTimestamp.mockReturnValue(blockTimestamp + 2)
@@ -325,7 +325,7 @@ describe('Poll Validate', () => {
     // WHEN: We poll
     const result = await twap.pollValidate({ ...pollParams, blockInfo })
 
-    // THEN: Then, we can see that uses the right block timestamp to validate the order
+    // THEN: Then, we can see that it uses the right block timestamp to validate the order
     expect(result).toEqual({
       result: PollResultCode.TRY_AT_EPOCH,
       epoch: startTime,

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -267,7 +267,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
     return error ? { isValid: false, reason: error } : { isValid: true }
   }
 
-  private async startTimestamp(params: OwnerContext): Promise<number> {
+  protected async startTimestamp(params: OwnerContext): Promise<number> {
     const { startTime } = this.data
 
     if (startTime?.startType === StartTimeValue.AT_EPOCH) {
@@ -293,7 +293,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
    * @param startTimestamp The start timestamp of the TWAP.
    * @returns The timestamp at which the TWAP will end.
    */
-  private endTimestamp(startTimestamp: number): number {
+  protected endTimestamp(startTimestamp: number): number {
     const { numberOfParts, timeBetweenParts, durationOfPart } = this.data
 
     if (durationOfPart && durationOfPart.durationType === DurationType.LIMIT_DURATION) {


### PR DESCRIPTION
![image](https://github.com/cowprotocol/cow-sdk/assets/2352112/803109e7-a939-4f01-aa76-875a9d4e5087)

This PR test the “poll validate” logic, which is how the abstract order asks the concrete order to validate.
The tests will cover the cases where:
- The order has not started: It will instruct Watch Tower to wait until the correct start time
- The order has expired: It will instruct the Watch Tower to not poll again this order. Expired orders, won’t yield a valid order since it is a final state
- It also asserts the logic of not passing the blockInfo, so it uses the latest block info

## Test
`yarn test`