### PR TITLE
Handle twap in orderbook

### DIFF
--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -484,4 +484,22 @@ describe('Current TWAP part is in the Order Book', () => {
       epoch: 1700000200,
     })
   })
+
+  test(`We are in the last second of part 9/10`, async () => {
+    // GIVEN: Part 9 is about to end
+    const pollParams = getPollParams({
+      blockTimestamp: startTimestamp + 9 * timeBetweenParts - 1,
+    })
+
+    // WHEN: We invoke handlePollFailedAlreadyPresent
+    const result = await twap.handlePollFailedAlreadyPresent(orderId, order, pollParams)
+
+    // THEN: It should instruct we should wait for part 2 to start
+    expect(result).toEqual({
+      result: PollResultCode.TRY_AT_EPOCH,
+      reason:
+        "Current active TWAP part (9/10) is already in the Order Book. TWAP part 10 doesn't start until 1700000900 (2023-11-14T22:28:20.000Z)",
+      epoch: 1700000900,
+    })
+  })
 })

--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -415,7 +415,7 @@ describe('Current TWAP part is in the Order Book', () => {
     })
   })
 
-  test.only(`TWAP just started`, async () => {
+  test(`TWAP just started`, async () => {
     // GIVEN: The order starts precisely at the current block time
     const twap = new MockTwap({
       handler: TWAP_ADDRESS,
@@ -426,6 +426,33 @@ describe('Current TWAP part is in the Order Book', () => {
         startTime: {
           startType: StartTimeValue.AT_EPOCH,
           epoch: BigNumber.from(blockTimestamp),
+        },
+      },
+    })
+
+    // WHEN: We invoke handlePollFailedAlreadyPresent
+    const result = await twap.handlePollFailedAlreadyPresent(orderId, order, pollParams)
+
+    // THEN: It should raise an Unhandled error (it should never happen). This function should be invoked only if "pollValidate" who should already make sure the polling fails if it hasn't started the TWAP
+    expect(result).toEqual({
+      result: PollResultCode.TRY_AT_EPOCH,
+      reason:
+        "Current active TWAP part (1/10) is already in the Order Book. TWAP part 2 doesn't start until 1700000100 (2023-11-14T22:15:00.000Z)",
+      epoch: 1700000100,
+    })
+  })
+
+  test(`We are in the middle of part 1/10`, async () => {
+    // GIVEN: We are in the middle of the first part
+    const twap = new MockTwap({
+      handler: TWAP_ADDRESS,
+      data: {
+        ...TWAP_PARAMS_TEST,
+        timeBetweenParts: BigNumber.from(100),
+        numberOfParts: BigNumber.from(10),
+        startTime: {
+          startType: StartTimeValue.AT_EPOCH,
+          epoch: BigNumber.from(blockTimestamp).sub(50),
         },
       },
     })

--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -414,4 +414,31 @@ describe('Current TWAP part is in the Order Book', () => {
       error: undefined,
     })
   })
+
+  test.only(`TWAP just started`, async () => {
+    // GIVEN: The order starts precisely at the current block time
+    const twap = new MockTwap({
+      handler: TWAP_ADDRESS,
+      data: {
+        ...TWAP_PARAMS_TEST,
+        timeBetweenParts: BigNumber.from(100),
+        numberOfParts: BigNumber.from(10),
+        startTime: {
+          startType: StartTimeValue.AT_EPOCH,
+          epoch: BigNumber.from(blockTimestamp),
+        },
+      },
+    })
+
+    // WHEN: We invoke handlePollFailedAlreadyPresent
+    const result = await twap.handlePollFailedAlreadyPresent(orderId, order, pollParams)
+
+    // THEN: It should raise an Unhandled error (it should never happen). This function should be invoked only if "pollValidate" who should already make sure the polling fails if it hasn't started the TWAP
+    expect(result).toEqual({
+      result: PollResultCode.TRY_AT_EPOCH,
+      reason:
+        "Current active TWAP part (1/10) is already in the Order Book. TWAP part 2 doesn't start until 1700000100 (2023-11-14T22:15:00.000Z)",
+      epoch: 1700000100,
+    })
+  })
 })

--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -442,7 +442,7 @@ describe('Current TWAP part is in the Order Book', () => {
     // WHEN: We invoke handlePollFailedAlreadyPresent
     const result = await twap.handlePollFailedAlreadyPresent(orderId, order, pollParams)
 
-    // THEN: It should instruct we should wait for part 2 to start
+    // THEN: It should instruct we should wait for part 3 to start
     expect(result).toEqual({
       result: PollResultCode.TRY_AT_EPOCH,
       reason:
@@ -460,7 +460,7 @@ describe('Current TWAP part is in the Order Book', () => {
     // WHEN: We invoke handlePollFailedAlreadyPresent
     const result = await twap.handlePollFailedAlreadyPresent(orderId, order, pollParams)
 
-    // THEN: It should instruct we should wait for part 2 to start
+    // THEN: It should instruct we should wait for part 10 to start
     expect(result).toEqual({
       result: PollResultCode.TRY_AT_EPOCH,
       reason:
@@ -470,7 +470,7 @@ describe('Current TWAP part is in the Order Book', () => {
   })
 
   test(`Polling at the first second of part 10/10`, async () => {
-    // GIVEN: Part 10 is about to end
+    // GIVEN: Part 10 has just started
     const pollParams = getPollParams({
       blockTimestamp: startTimestamp + 9 * timeBetweenParts,
     })
@@ -478,7 +478,7 @@ describe('Current TWAP part is in the Order Book', () => {
     // WHEN: We invoke handlePollFailedAlreadyPresent
     const result = await twap.handlePollFailedAlreadyPresent(orderId, order, pollParams)
 
-    // THEN: It should instruct we should wait for part 2 to start
+    // THEN: It should instruct that this was the last TWAP part.
     expect(result).toEqual({
       result: PollResultCode.DONT_TRY_AGAIN,
       reason:

--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -482,7 +482,7 @@ describe('Current TWAP part is in the Order Book', () => {
     expect(result).toEqual({
       result: PollResultCode.DONT_TRY_AGAIN,
       reason:
-        'Current active TWAP part (10/10) is already in the Order Book. This was the last TWAP part, nor more orders need to be placed',
+        'Current active TWAP part (10/10) is already in the Order Book. This was the last TWAP part, no more orders need to be placed',
     })
   })
 

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -350,6 +350,14 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
     const { numberOfParts } = this.data
     const startTimestamp = await this.startTimestamp(params)
 
+    if (blockTimestamp < startTimestamp) {
+      return {
+        result: PollResultCode.UNEXPECTED_ERROR,
+        reason: `TWAP part hash't started. First TWAP part start at ${startTimestamp} (${formatEpoch(startTimestamp)})`,
+        error: undefined,
+      }
+    }
+
     // Get current part number
     const currentPartNumber = Math.floor(blockTimestamp - startTimestamp / timeBetweenParts)
 

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -375,7 +375,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
         result: PollResultCode.DONT_TRY_AGAIN,
         reason: `Current active TWAP part (${
           currentPartNumber + 1
-        }/${numberOfParts}) is already in the Order Book. This was the last TWAP part, nor more orders need to be placed`,
+        }/${numberOfParts}) is already in the Order Book. This was the last TWAP part, no more orders need to be placed`,
       }
     }
 

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -370,7 +370,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
     const currentPartNumber = Math.floor((blockTimestamp - startTimestamp) / timeBetweenParts)
 
     // Next part start time
-    const nextPartStartTime = blockTimestamp + (currentPartNumber + 1) * timeBetweenParts
+    const nextPartStartTime = startTimestamp + (currentPartNumber + 1) * timeBetweenParts
 
     /**
      * Given we know, that TWAP part that is due in the current block is already in the Orderbook,

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -369,6 +369,16 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
     // Get current part number
     const currentPartNumber = Math.floor((blockTimestamp - startTimestamp) / timeBetweenParts)
 
+    // If current part is the last one
+    if (currentPartNumber === numberOfParts.toNumber() - 1) {
+      return {
+        result: PollResultCode.DONT_TRY_AGAIN,
+        reason: `Current active TWAP part (${
+          currentPartNumber + 1
+        }/${numberOfParts}) is already in the Order Book. This was the last TWAP part, nor more orders need to be placed`,
+      }
+    }
+
     // Next part start time
     const nextPartStartTime = startTimestamp + (currentPartNumber + 1) * timeBetweenParts
 

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -338,6 +338,15 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
     return undefined
   }
 
+  /**
+   * Handles the error when the order is already present in the orderbook.
+   *
+   * Given the current part is in the book, it will signal to Watch Tower what to do:
+   *   - Wait until the next part starts
+   *   - Don't try again if current part is the last one
+   *
+   * NOTE: The error messages will refer to the parts 1-indexed, so first part is 1, second part is 2, etc.
+   */
   protected async handlePollFailedAlreadyPresent(
     _orderUid: string,
     _order: GPv2Order.DataStructOutput,

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -357,6 +357,14 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
         error: undefined,
       }
     }
+    const expireTime = numberOfParts.mul(timeBetweenParts).add(startTimestamp).toNumber()
+    if (blockTimestamp >= expireTime) {
+      return {
+        result: PollResultCode.UNEXPECTED_ERROR,
+        reason: `TWAP is expired. Expired at ${expireTime} (${formatEpoch(expireTime)})`,
+        error: undefined,
+      }
+    }
 
     // Get current part number
     const currentPartNumber = Math.floor(blockTimestamp - startTimestamp / timeBetweenParts)

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -367,10 +367,10 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
     }
 
     // Get current part number
-    const currentPartNumber = Math.floor(blockTimestamp - startTimestamp / timeBetweenParts)
+    const currentPartNumber = Math.floor((blockTimestamp - startTimestamp) / timeBetweenParts)
 
     // Next part start time
-    const nextPartStartTime = (currentPartNumber + 1) * timeBetweenParts
+    const nextPartStartTime = blockTimestamp + (currentPartNumber + 1) * timeBetweenParts
 
     /**
      * Given we know, that TWAP part that is due in the current block is already in the Orderbook,
@@ -379,9 +379,11 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
     return {
       result: PollResultCode.TRY_AT_EPOCH,
       epoch: nextPartStartTime,
-      reason: `Current active TWAP part (${currentPartNumber}/${numberOfParts}) is already in the Order Book. TWAP part ${currentPartNumber} doesn't start until ${nextPartStartTime} (${formatEpoch(
-        nextPartStartTime
-      )})`,
+      reason: `Current active TWAP part (${
+        currentPartNumber + 1
+      }/${numberOfParts}) is already in the Order Book. TWAP part ${
+        currentPartNumber + 2
+      } doesn't start until ${nextPartStartTime} (${formatEpoch(nextPartStartTime)})`,
     }
   }
 


### PR DESCRIPTION

![image](https://github.com/cowprotocol/cow-sdk/assets/2352112/ac5ca8c1-bc69-425a-a64f-801b67d69698)


This PR implements and test the logic in TWAP that instructs the watch-towers what is the next polling time for the case, the current part is already in the order book. 

This is very important for the scalability of watch towers, since otherwise they would need to check on every block.
This PR will allow a DCA that executes once a month, to be polled only once a month (two at most, since first polling returns the current part, and next polling for the same period will instruct to wait for approximately one month )

The test will cover various edge cases in the execution of a 10 parts TWAP order. Read the tests for more details. As a summary:
- Will verify that when is the time of part N, it instructs watch tower to wait until N+1 starts
- Will verify that if we are in the last part, then it will instructs watch tower to not poll again this order
- It also tests some edge-cases that should not happen, but formalises the assumption of the responsibility of this function. This function is supposed to be called only if the current part is yielding an order that is already in the orderboook, so it shouldn’t be possible that the TWAP is expired or that is hasn’t started. However, the implementation handles these cases, and the test also covers them


## Test
`yarn test`