### PR TITLE
Misc and close SDK version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "3.0.0-rc.8",
+  "version": "3.0.0-rc.9",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "3.0.0-rc.7",
+  "version": "3.0.0",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "3.0.0-rc.6",
+  "version": "3.0.0-rc.7",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "3.0.0",
+  "version": "3.0.0-rc.8",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "3.0.0-rc.5",
+  "version": "3.0.0-rc.6",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "3.0.0-rc.9",
+  "version": "3.0.0",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/composable/ConditionalOrder.spec.ts
+++ b/src/composable/ConditionalOrder.spec.ts
@@ -12,6 +12,7 @@ import { constants } from 'ethers'
 import { OwnerContext, PollParams, PollResultCode, PollResultErrors } from './types'
 import { BuyTokenDestination, OrderKind, SellTokenSource } from '../order-book/generated'
 import { computeOrderUid } from '../utils'
+import { GPv2Order } from './generated/ComposableCoW'
 
 jest.mock('./contracts')
 
@@ -45,7 +46,7 @@ const TWAP_SERIALIZED = (salt?: string, handler?: string): string => {
 const OWNER = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 const SINGLE_ORDER = createTestConditionalOrder()
 const MERKLE_ROOT_ORDER = createTestConditionalOrder({ isSingleOrder: false })
-const DISCRETE_ORDER = {
+const DISCRETE_ORDER: GPv2Order.DataStruct = {
   sellToken: '0x6810e776880c02933d47db1b9fc05908e5386b96',
   buyToken: '0x6810e776880c02933d47db1b9fc05908e5386b96',
   receiver: '0x6810e776880c02933d47db1b9fc05908e5386b96',
@@ -56,9 +57,8 @@ const DISCRETE_ORDER = {
   partiallyFillable: true,
   sellTokenBalance: SellTokenSource.ERC20,
   buyTokenBalance: BuyTokenDestination.ERC20,
-  from: '0x6810e776880c02933d47db1b9fc05908e5386b96',
   kind: OrderKind.BUY,
-  class: 'market',
+  feeAmount: '0',
 }
 const ERROR_REASON = 'Not valid, because I say so!'
 

--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -1,7 +1,7 @@
 import { BigNumber, constants, ethers, utils } from 'ethers'
 import { GPv2Order, IConditionalOrder } from './generated/ComposableCoW'
 
-import { decodeParams, encodeParams } from './utils'
+import { decodeParams, encodeParams, fromStructToOrder } from './utils'
 import {
   ConditionalOrderArguments,
   ConditionalOrderParams,
@@ -16,7 +16,6 @@ import {
 import { getComposableCow, getComposableCowInterface } from './contracts'
 import { OrderBookApi, UID } from 'src/order-book'
 import { computeOrderUid } from 'src/utils'
-import { Order } from '@cowprotocol/contracts'
 
 const orderBookCache: Record<string, OrderBookApi> = {}
 
@@ -292,7 +291,7 @@ export abstract class ConditionalOrder<D, S> {
         orderBookCache[chainId] = orderBookApi
       }
 
-      const orderUid = await computeOrderUid(chainId, owner, order as Order)
+      const orderUid = await computeOrderUid(chainId, owner, fromStructToOrder(order))
 
       // Check if the order is already in the order book
       const isOrderInOrderbook = await orderBookApi

--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -371,7 +371,7 @@ export abstract class ConditionalOrder<D, S> {
    */
   protected abstract handlePollFailedAlreadyPresent(
     orderUid: UID,
-    order: GPv2Order.DataStructOutput,
+    order: GPv2Order.DataStruct,
     params: PollParams
   ): Promise<PollResultErrors | undefined>
 

--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -14,8 +14,8 @@ import {
   PollResultErrors,
 } from './types'
 import { getComposableCow, getComposableCowInterface } from './contracts'
-import { OrderBookApi, UID } from 'src/order-book'
-import { computeOrderUid } from 'src/utils'
+import { OrderBookApi, UID } from '../order-book'
+import { computeOrderUid } from '../utils'
 
 const orderBookCache: Record<string, OrderBookApi> = {}
 

--- a/src/composable/Multiplexer.spec.ts
+++ b/src/composable/Multiplexer.spec.ts
@@ -1,3 +1,4 @@
+import 'src/order-book/__mock__/api'
 import { Multiplexer, Orders } from './Multiplexer'
 import { SupportedChainId } from '../common'
 import { ProofLocation } from './types'

--- a/src/composable/Multiplexer.ts
+++ b/src/composable/Multiplexer.ts
@@ -1,4 +1,3 @@
-import 'src/order-book/__mock__/api'
 import { StandardMerkleTree } from '@openzeppelin/merkle-tree'
 import { BigNumber, providers, utils } from 'ethers'
 

--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -361,7 +361,7 @@ describe('Current TWAP part is in the Order Book', () => {
   const numberOfParts = 10
   const totalDuration = timeBetweenParts * numberOfParts
   const orderId = '0x1'
-  const order = {} as GPv2Order.DataStructOutput
+  const order = {} as GPv2Order.DataStruct
 
   const getPollParams = ({ blockTimestamp }: { blockTimestamp: number }) =>
     ({

--- a/src/composable/orderTypes/Twap.spec.ts
+++ b/src/composable/orderTypes/Twap.spec.ts
@@ -207,20 +207,39 @@ describe('Deserialize', () => {
 })
 
 describe('To String', () => {
-  test('toString: Formats correctly', () => {
+  test('toString: Default', () => {
     expect(Twap.fromData(TWAP_PARAMS_TEST).toString()).toEqual(
-      'twap: Sell total 0x6810e776880C02933D47DB1b9fc05908e5386b96@1000000000000000000 for a minimum of 0xDAE5F1590db13E3B40423B5b5c5fbf175515910b@1000000000000000000 over 10 parts with a spacing of 3600s beginning at time of mining'
-    )
-    const startEpoch = BigNumber.from(1692876646)
-    expect(
-      Twap.fromData({
-        ...TWAP_PARAMS_TEST,
-        startTime: { startType: StartTimeValue.AT_EPOCH, epoch: startEpoch },
-      }).toString()
-    ).toEqual(
-      'twap: Sell total 0x6810e776880C02933D47DB1b9fc05908e5386b96@1000000000000000000 for a minimum of 0xDAE5F1590db13E3B40423B5b5c5fbf175515910b@1000000000000000000 over 10 parts with a spacing of 3600s beginning at epoch 1692876646'
+      'twap: {"sellAmount":"1000000000000000000","sellToken":"0x6810e776880C02933D47DB1b9fc05908e5386b96","buyAmount":"1000000000000000000","buyToken":"0xDAE5F1590db13E3B40423B5b5c5fbf175515910b","numberOfParts":"10","startTime":"AT_MINING_TIME","timeBetweenParts":3600,"durationOfPart":"AUTO","receiver":"0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF","appData":"0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5"}'
     )
   })
+})
+
+test('toString: start time at epoch', () => {
+  expect(
+    Twap.fromData({
+      ...TWAP_PARAMS_TEST,
+      startTime: {
+        startType: StartTimeValue.AT_EPOCH,
+        epoch: BigNumber.from(1692876646),
+      },
+    }).toString()
+  ).toEqual(
+    'twap: {"sellAmount":"1000000000000000000","sellToken":"0x6810e776880C02933D47DB1b9fc05908e5386b96","buyAmount":"1000000000000000000","buyToken":"0xDAE5F1590db13E3B40423B5b5c5fbf175515910b","numberOfParts":"10","startTime":1692876646,"timeBetweenParts":3600,"durationOfPart":"AUTO","receiver":"0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF","appData":"0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5"}'
+  )
+})
+
+test('toString: limit duration', () => {
+  expect(
+    Twap.fromData({
+      ...TWAP_PARAMS_TEST,
+      durationOfPart: {
+        durationType: DurationType.LIMIT_DURATION,
+        duration: BigNumber.from(1000),
+      },
+    }).toString()
+  ).toEqual(
+    'twap: {"sellAmount":"1000000000000000000","sellToken":"0x6810e776880C02933D47DB1b9fc05908e5386b96","buyAmount":"1000000000000000000","buyToken":"0xDAE5F1590db13E3B40423B5b5c5fbf175515910b","numberOfParts":"10","startTime":"AT_MINING_TIME","timeBetweenParts":3600,"durationOfPart":1000,"receiver":"0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF","appData":"0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5"}'
+  )
 })
 
 describe('Poll Validate', () => {

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -33,8 +33,6 @@ const TWAP_STRUCT_ABI = [
   'tuple(address sellToken, address buyToken, address receiver, uint256 partSellAmount, uint256 minPartLimit, uint256 t0, uint256 n, uint256 t, uint256 span, bytes32 appData)',
 ]
 
-const DEFAULT_TOKEN_FORMATTER = (address: string, amount: BigNumber) => `${address}@${amount}`
-
 /**
  * Base parameters for a TWAP order. Shared by:
  *   - TwapStruct (modelling the contract's struct used for `staticInput`).
@@ -443,26 +441,41 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
 
   /**
    * Create a human-readable string representation of the TWAP order.
-   * @param {((address: string, amount: BigNumber) => string) | undefined} tokenFormatter An optional
-   *        function that takes an address and an amount and returns a human-readable string.
    * @returns {string} A human-readable string representation of the TWAP order.
    */
-  toString(tokenFormatter = DEFAULT_TOKEN_FORMATTER): string {
+  toString(): string {
     const {
+      sellAmount,
       sellToken,
+      buyAmount,
       buyToken,
       numberOfParts,
-      timeBetweenParts = DEFAULT_DURATION_OF_PART,
       startTime = DEFAULT_START_TIME,
-      sellAmount,
-      buyAmount,
+      timeBetweenParts,
+      durationOfPart = DEFAULT_DURATION_OF_PART,
+      receiver,
+      appData,
     } = this.data
 
-    const sellAmountFormatted = tokenFormatter(sellToken, sellAmount)
-    const buyAmountFormatted = tokenFormatter(buyToken, buyAmount)
-    const t0Formatted =
-      startTime.startType === StartTimeValue.AT_MINING_TIME ? 'time of mining' : 'epoch ' + startTime.epoch.toString()
-    return `${this.orderType}: Sell total ${sellAmountFormatted} for a minimum of ${buyAmountFormatted} over ${numberOfParts} parts with a spacing of ${timeBetweenParts}s beginning at ${t0Formatted}`
+    const startTimeFormatted =
+      startTime.startType === StartTimeValue.AT_MINING_TIME ? 'AT_MINING_TIME' : startTime.epoch.toNumber()
+    const durationOfPartFormatted =
+      durationOfPart.durationType === DurationType.AUTO ? 'AUTO' : durationOfPart.duration.toNumber()
+
+    const details = {
+      sellAmount: sellAmount.toString(),
+      sellToken,
+      buyAmount: buyAmount.toString(),
+      buyToken,
+      numberOfParts: numberOfParts.toString(),
+      startTime: startTimeFormatted,
+      timeBetweenParts: timeBetweenParts.toNumber(),
+      durationOfPart: durationOfPartFormatted,
+      receiver,
+      appData,
+    }
+
+    return `${this.orderType}: ${JSON.stringify(details)}`
   }
 
   /**

--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -347,7 +347,7 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
    */
   protected async handlePollFailedAlreadyPresent(
     _orderUid: string,
-    _order: GPv2Order.DataStructOutput,
+    _order: GPv2Order.DataStruct,
     params: PollParams
   ): Promise<PollResultErrors | undefined> {
     const { blockInfo = await getBlockInfo(params.provider) } = params

--- a/src/composable/orderTypes/test/TestConditionalOrder.ts
+++ b/src/composable/orderTypes/test/TestConditionalOrder.ts
@@ -54,7 +54,7 @@ export class TestConditionalOrder extends ConditionalOrder<string, string> {
   }
   protected async handlePollFailedAlreadyPresent(
     _orderUid: string,
-    _order: GPv2Order.DataStructOutput,
+    _order: GPv2Order.DataStruct,
     _params: PollParams
   ): Promise<PollResultErrors | undefined> {
     return undefined

--- a/src/composable/utils.spec.ts
+++ b/src/composable/utils.spec.ts
@@ -1,7 +1,8 @@
 import 'src/order-book/__mock__/api'
-import { decodeParams, encodeParams, isValidAbi } from './utils'
+import { decodeParams, encodeParams, fromStructToOrder, isValidAbi } from './utils'
 import { DurationType, StartTimeValue, TwapData, TwapStruct, transformDataToStruct } from './orderTypes/Twap'
 import { BigNumber, utils } from 'ethers'
+import { GPv2Order } from './generated/ComposableCoW'
 
 export const TWAP_PARAMS_TEST: TwapData = {
   sellToken: '0x6810e776880C02933D47DB1b9fc05908e5386b96',
@@ -62,5 +63,31 @@ describe('isValidAbi', () => {
 
   test('isValidAbi: Happy path', () => {
     expect(isValidAbi(TWAP_STRUCT_ABI, [TWAP_STRUCT])).toEqual(true)
+  })
+})
+
+describe('fromStructToOrder', () => {
+  test.only('Happy path', () => {
+    const orderData: GPv2Order.DataStruct = {
+      sellToken: '0x177127622c4A00F3d409B75571e12cB3c8973d3c',
+      buyToken: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
+      receiver: '0x50736F4707eD0c7bae86bd801d65377BB3739550',
+      sellAmount: BigNumber.from('497154622979742700000'),
+      buyAmount: BigNumber.from('26618938443780026000'),
+      validTo: 1698723209,
+      appData: '0x7cc001e5e82772cf4262f2836ae90e1844d2c12ad2fbc346f27a76f5d1cc9d39',
+      feeAmount: BigNumber.from(0),
+      kind: '0xf3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee346775',
+      partiallyFillable: false,
+      sellTokenBalance: '0x5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9',
+      buyTokenBalance: '0x5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9',
+    }
+    console.log('fromStructToOrder(orderData)', fromStructToOrder(orderData))
+    expect(fromStructToOrder(orderData)).toEqual({
+      ...orderData,
+      kind: 'sell',
+      sellTokenBalance: 'erc20',
+      buyTokenBalance: 'erc20',
+    })
   })
 })

--- a/src/composable/utils.spec.ts
+++ b/src/composable/utils.spec.ts
@@ -82,7 +82,6 @@ describe('fromStructToOrder', () => {
       sellTokenBalance: '0x5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9',
       buyTokenBalance: '0x5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9',
     }
-    console.log('fromStructToOrder(orderData)', fromStructToOrder(orderData))
     expect(fromStructToOrder(orderData)).toEqual({
       ...orderData,
       kind: 'sell',

--- a/src/composable/utils.spec.ts
+++ b/src/composable/utils.spec.ts
@@ -1,3 +1,4 @@
+import 'src/order-book/__mock__/api'
 import { decodeParams, encodeParams, isValidAbi } from './utils'
 import { DurationType, StartTimeValue, TwapData, TwapStruct, transformDataToStruct } from './orderTypes/Twap'
 import { BigNumber, utils } from 'ethers'

--- a/src/composable/utils.spec.ts
+++ b/src/composable/utils.spec.ts
@@ -67,7 +67,7 @@ describe('isValidAbi', () => {
 })
 
 describe('fromStructToOrder', () => {
-  test.only('Happy path', () => {
+  test('Happy path', () => {
     const orderData: GPv2Order.DataStruct = {
       sellToken: '0x177127622c4A00F3d409B75571e12cB3c8973d3c',
       buyToken: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',

--- a/src/composable/utils.ts
+++ b/src/composable/utils.ts
@@ -6,6 +6,14 @@ import {
 } from '../common'
 import { ExtensibleFallbackHandler__factory } from './generated'
 import { BlockInfo, ConditionalOrderParams } from './types'
+import { Order, OrderBalance, OrderKind } from '@cowprotocol/contracts'
+import { GPv2Order } from './generated/ComposableCoW'
+
+const ERC20_BALANCE_VALUES = ['erc20', '0x5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9']
+const EXTERNAL_BALANCE_VALUES = ['external', '0xabee3b73373acd583a130924aad6dc38cfdc44ba0555ba94ce2ff63980ea0632']
+const INTERNAL_BALANCE_VALUES = ['internal', '0x4ac99ace14ee0a5ef932dc609df0943ab7ac16b7583634612f8dc35a4289a6ce']
+const SELL_KIND_VALUES = ['sell', '0xf3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee346775']
+const BUY_KIND_VALUES = ['buy', '0x6ed88e868af0a1983e3886d5f3e95a2fafbd6c3450bc229e27342283dc429ccc']
 
 // Define the ABI tuple for the ConditionalOrderParams struct
 export const CONDITIONAL_ORDER_PARAMS_ABI = ['tuple(address handler, bytes32 salt, bytes staticInput)']
@@ -88,4 +96,70 @@ export async function getBlockInfo(provider: providers.Provider): Promise<BlockI
 
 export function formatEpoch(epoch: number): string {
   return new Date(epoch * 1000).toISOString()
+}
+
+/**
+ * Convert a balance source/destination hash to a string
+ *
+ * @param balance balance source/destination hash
+ * @returns string representation of the balance
+ * @throws if the balance is not recognized
+ */
+function balanceToString(balance: string) {
+  if (ERC20_BALANCE_VALUES.includes(balance)) {
+    return OrderBalance.ERC20
+  } else if (EXTERNAL_BALANCE_VALUES.includes(balance)) {
+    return OrderBalance.EXTERNAL
+  } else if (INTERNAL_BALANCE_VALUES.includes(balance)) {
+    return OrderBalance.INTERNAL
+  } else {
+    throw new Error(`Unknown balance type: ${balance}`)
+  }
+}
+
+/**
+ * Convert an order kind hash to a string
+ * @param kind of order in hash format
+ * @returns string representation of the order kind
+ */
+function kindToString(kind: string) {
+  if (SELL_KIND_VALUES.includes(kind)) {
+    return OrderKind.SELL
+  } else if (BUY_KIND_VALUES.includes(kind)) {
+    return OrderKind.BUY
+  } else {
+    throw new Error(`Unknown kind: ${kind}`)
+  }
+}
+
+export function fromStructToOrder(order: GPv2Order.DataStruct): Order {
+  const {
+    sellToken,
+    sellAmount,
+    buyToken,
+    buyAmount,
+    buyTokenBalance,
+    sellTokenBalance,
+    feeAmount,
+    kind,
+    receiver,
+    validTo,
+    partiallyFillable,
+    appData,
+  } = order
+
+  return {
+    sellToken,
+    sellAmount,
+    buyToken,
+    buyAmount,
+    feeAmount,
+    receiver,
+    partiallyFillable,
+    appData,
+    validTo: Number(validTo),
+    kind: kindToString(kind.toString()),
+    sellTokenBalance: balanceToString(sellTokenBalance.toString()),
+    buyTokenBalance: balanceToString(buyTokenBalance.toString()),
+  }
 }

--- a/src/composable/utils.ts
+++ b/src/composable/utils.ts
@@ -1,4 +1,4 @@
-import { utils, providers } from 'ethers'
+import { utils, providers, BigNumber } from 'ethers'
 import {
   COMPOSABLE_COW_CONTRACT_ADDRESS,
   EXTENSIBLE_FALLBACK_HANDLER_CONTRACT_ADDRESS,
@@ -9,6 +9,8 @@ import { BlockInfo, ConditionalOrderParams } from './types'
 
 // Define the ABI tuple for the ConditionalOrderParams struct
 export const CONDITIONAL_ORDER_PARAMS_ABI = ['tuple(address handler, bytes32 salt, bytes staticInput)']
+
+export const DEFAULT_TOKEN_FORMATTER = (address: string, amount: BigNumber) => `${amount}@${address}`
 
 export function isExtensibleFallbackHandler(handler: string, chainId: SupportedChainId): boolean {
   return handler === EXTENSIBLE_FALLBACK_HANDLER_CONTRACT_ADDRESS[chainId]

--- a/src/composable/utils.ts
+++ b/src/composable/utils.ts
@@ -1,4 +1,3 @@
-import 'src/order-book/__mock__/api'
 import { utils, providers } from 'ethers'
 import {
   COMPOSABLE_COW_CONTRACT_ADDRESS,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "test/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "test/*", "src/**/__mock__/*"],
   "compilerOptions": {
     "baseUrl": "./",
     "module": "commonjs",


### PR DESCRIPTION
This PR tries to close the SDK release v3.0.0

For that, I'm ensuring the Tenderly Watch Tower project works great with this version. 

This PR does some small MISC in order to consider 3.0.0 ready!

## Fix compute UID
The compute UID was not working. 
The struct needs be converted into an order (mapping some fields). 

## From struct to order + Tests
Created some util to convert order structs to orders.

Additionally, I did some unit test for it. 

## Improves the toString
toString is traditionally used to ready in the logs the details of the object. I felt it was a bit hard to read the older version, plus logging tools have a harder time parsing the values to make it easier to search

Also, the toString was not including some fields, like the receiver or the appData.

For this reason, I modified the implementation to serialise a JSON describing the TWAP:

Before:
![image](https://github.com/cowprotocol/cow-sdk/assets/2352112/ce9d3728-f678-4d79-882a-0444ee1c05bf)

After:
![image](https://github.com/cowprotocol/cow-sdk/assets/2352112/b112e45a-ad51-485d-b624-e1974cd03782)


## Added more tests for the TWAP toString
It tests the basic default, and setting custom start time, and limiting the duration. 

## Close version v3.0.0
This PR version will be tagged as v3.0.0



# Test
I tried this PR against watch tower (this is how i found so many issues!

Now all looks SOLID ✅! 

<img width="1131" alt="image" src="https://github.com/cowprotocol/cow-sdk/assets/2352112/1872c56f-4528-4434-b1b6-8c6554c81791">
