### PR TITLE
chore: allow to override orderbook API config for polling

### DIFF
--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -249,7 +249,7 @@ export abstract class ConditionalOrder<D, S> {
    * @returns The tradeable `GPv2Order.Data` struct and the `signature` for the conditional order.
    */
   async poll(params: PollParams): Promise<PollResult> {
-    const { chainId, owner, provider } = params
+    const { chainId, owner, provider, orderbookApiConfig } = params
     const composableCow = getComposableCow(chainId, provider)
 
     try {
@@ -287,7 +287,7 @@ export abstract class ConditionalOrder<D, S> {
 
       let orderBookApi = orderBookCache[chainId]
       if (!orderBookApi) {
-        orderBookApi = new OrderBookApi({ chainId })
+        orderBookApi = new OrderBookApi({ ...orderbookApiConfig, chainId })
         orderBookCache[chainId] = orderBookApi
       }
 

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -1,3 +1,4 @@
+import { OrderBookApi } from '../order-book'
 import { SupportedChainId } from '../common'
 import { GPv2Order } from './generated/ComposableCoW'
 import { providers } from 'ethers'
@@ -95,7 +96,14 @@ export type PollParams = OwnerContext & {
    * If present, it can be used for custom conditional order validations. If not present, the orders will need to get the block info themselves
    */
   blockInfo?: BlockInfo
+
+  /**
+   * Allows to optional pass the config of the orderbook API
+   */
+  orderbookApiConfig?: OrderBookApiConfig
 }
+
+export type OrderBookApiConfig = Omit<ConstructorParameters<typeof OrderBookApi>[0], 'chainId'>
 
 export type BlockInfo = {
   blockNumber: number


### PR DESCRIPTION
This PR will allow us to override any config param of the orderbook API for polling.

This will allow us to set our own endpoints