### PR TITLE
feat(subgraph): explicitly define which networks are supported for Subgraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/subgraph/api.ts
+++ b/src/subgraph/api.ts
@@ -8,17 +8,19 @@ import { SupportedChainId } from '../common/chains'
 
 const SUBGRAPH_BASE_URL = 'https://api.thegraph.com/subgraphs/name/cowprotocol'
 
+type SubgraphApiBaseUrls = Record<SupportedChainId, string | undefined>
+
 /**
  * CoW Protocol Production Subgraph API configuration.
  * @see {@link https://api.thegraph.com/subgraphs/name/cowprotocol/cow}
  * @see {@link https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc}
  * @see {@link https://api.thegraph.com/subgraphs/name/cowprotocol/cow-goerli}
  */
-export const SUBGRAPH_PROD_CONFIG: ApiBaseUrls = {
+export const SUBGRAPH_PROD_CONFIG: SubgraphApiBaseUrls = {
   [SupportedChainId.MAINNET]: SUBGRAPH_BASE_URL + '/cow',
   [SupportedChainId.GNOSIS_CHAIN]: SUBGRAPH_BASE_URL + '/cow-gc',
   [SupportedChainId.GOERLI]: SUBGRAPH_BASE_URL + '/cow-goerli',
-  [SupportedChainId.SEPOLIA]: '',
+  [SupportedChainId.SEPOLIA]: undefined,
 }
 
 /**
@@ -27,11 +29,11 @@ export const SUBGRAPH_PROD_CONFIG: ApiBaseUrls = {
  * @see {@link https://api.thegraph.com/subgraphs/name/cowprotocol/cow-staging}
  * @see {@link https://api.thegraph.com/subgraphs/name/cowprotocol/cow-gc-staging}
  */
-export const SUBGRAPH_STAGING_CONFIG: ApiBaseUrls = {
+export const SUBGRAPH_STAGING_CONFIG: SubgraphApiBaseUrls = {
   [SupportedChainId.MAINNET]: SUBGRAPH_BASE_URL + '/cow-staging',
   [SupportedChainId.GNOSIS_CHAIN]: SUBGRAPH_BASE_URL + '/cow-gc-staging',
-  [SupportedChainId.GOERLI]: '',
-  [SupportedChainId.SEPOLIA]: '',
+  [SupportedChainId.GOERLI]: undefined,
+  [SupportedChainId.SEPOLIA]: undefined,
 }
 
 /**
@@ -99,6 +101,10 @@ export class SubgraphApi {
     const { chainId, env } = this.getContextWithOverride(contextOverride)
     const baseUrl = this.getEnvConfigs(env)[chainId]
 
+    if (baseUrl === undefined) {
+      throw new Error('Unsupported Network. The subgraph API is not available in the Network ' + chainId)
+    }
+
     try {
       return await request(baseUrl, query, variables)
     } catch (error) {
@@ -123,7 +129,7 @@ export class SubgraphApi {
    * @param {CowEnv} env The environment to get the base URLs for.
    * @returns {ApiBaseUrls} The base URLs for the given environment.
    */
-  private getEnvConfigs(env: CowEnv): ApiBaseUrls {
+  private getEnvConfigs(env: CowEnv): SubgraphApiBaseUrls {
     if (this.context.baseUrls) return this.context.baseUrls
 
     return env === 'prod' ? SUBGRAPH_PROD_CONFIG : SUBGRAPH_STAGING_CONFIG

--- a/src/subgraph/api.ts
+++ b/src/subgraph/api.ts
@@ -3,7 +3,7 @@ import { LastDaysVolumeQuery, LastHoursVolumeQuery, TotalsQuery } from './graphq
 import { LAST_DAYS_VOLUME_QUERY, LAST_HOURS_VOLUME_QUERY, TOTALS_QUERY } from './queries'
 import { DocumentNode } from 'graphql/index'
 import { request, Variables } from 'graphql-request'
-import { ApiContext, CowEnv, DEFAULT_COW_API_CONTEXT, ApiBaseUrls, PartialApiContext } from '../common/configs'
+import { ApiContext, CowEnv, DEFAULT_COW_API_CONTEXT, PartialApiContext } from '../common/configs'
 import { SupportedChainId } from '../common/chains'
 
 const SUBGRAPH_BASE_URL = 'https://api.thegraph.com/subgraphs/name/cowprotocol'

--- a/src/subgraph/api.ts
+++ b/src/subgraph/api.ts
@@ -8,7 +8,7 @@ import { SupportedChainId } from '../common/chains'
 
 const SUBGRAPH_BASE_URL = 'https://api.thegraph.com/subgraphs/name/cowprotocol'
 
-type SubgraphApiBaseUrls = Record<SupportedChainId, string | undefined>
+type SubgraphApiBaseUrls = Record<SupportedChainId, string | null>
 
 /**
  * CoW Protocol Production Subgraph API configuration.
@@ -20,7 +20,7 @@ export const SUBGRAPH_PROD_CONFIG: SubgraphApiBaseUrls = {
   [SupportedChainId.MAINNET]: SUBGRAPH_BASE_URL + '/cow',
   [SupportedChainId.GNOSIS_CHAIN]: SUBGRAPH_BASE_URL + '/cow-gc',
   [SupportedChainId.GOERLI]: SUBGRAPH_BASE_URL + '/cow-goerli',
-  [SupportedChainId.SEPOLIA]: undefined,
+  [SupportedChainId.SEPOLIA]: null,
 }
 
 /**
@@ -32,8 +32,8 @@ export const SUBGRAPH_PROD_CONFIG: SubgraphApiBaseUrls = {
 export const SUBGRAPH_STAGING_CONFIG: SubgraphApiBaseUrls = {
   [SupportedChainId.MAINNET]: SUBGRAPH_BASE_URL + '/cow-staging',
   [SupportedChainId.GNOSIS_CHAIN]: SUBGRAPH_BASE_URL + '/cow-gc-staging',
-  [SupportedChainId.GOERLI]: undefined,
-  [SupportedChainId.SEPOLIA]: undefined,
+  [SupportedChainId.GOERLI]: null,
+  [SupportedChainId.SEPOLIA]: null,
 }
 
 /**
@@ -101,7 +101,7 @@ export class SubgraphApi {
     const { chainId, env } = this.getContextWithOverride(contextOverride)
     const baseUrl = this.getEnvConfigs(env)[chainId]
 
-    if (baseUrl === undefined) {
+    if (baseUrl === null) {
       throw new Error('Unsupported Network. The subgraph API is not available in the Network ' + chainId)
     }
 


### PR DESCRIPTION
Since not all networks have Subgraph support we need to explicitly define which networks have support.
To do this, I've changed type of `SUBGRAPH_PROD_CONFIG` and `SUBGRAPH_STAGING_CONFIG`.
Now the type is `string | undefined`, `undefined` means that Subgraph is not supported for the network.