### PR TITLE
feat: update totalFee calculation

### DIFF
--- a/src/order-book/transformOrder.test.ts
+++ b/src/order-book/transformOrder.test.ts
@@ -1,0 +1,59 @@
+import { Order, OrderClass, OrderKind, OrderStatus, SigningScheme } from './generated'
+import { transformOrder } from './transformOrder'
+
+const ORDER: Order = {
+  sellToken: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+  buyToken: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+  sellAmount: '1234567890',
+  buyAmount: '1234567890',
+  validTo: 0,
+  appData: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  partiallyFillable: true,
+  kind: OrderKind.BUY,
+  class: OrderClass.MARKET,
+  feeAmount: '1234567890',
+  signature:
+    '0x4d306ce7c770d22005bcfc00223f8d9aaa04e8a20099cc986cb9ccf60c7e876b777ceafb1e03f359ebc6d3dc84245d111a3df584212b5679cb5f9e6717b69b031b',
+  signingScheme: SigningScheme.EIP1271,
+  creationDate: '2020-12-03T18:35:18.814523Z',
+  owner: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+  uid: '0x59920c85de0162e9e55df8d396e75f3b6b7c2dfdb535f03e5c807731c31585eaff714b8b0e2700303ec912bd40496c3997ceea2b616d6710',
+  executedSellAmount: '1234567890',
+  executedSellAmountBeforeFees: '1234567890',
+  executedBuyAmount: '1234567890',
+  executedFeeAmount: '1234567890',
+  invalidated: true,
+  status: OrderStatus.FULFILLED,
+}
+
+describe('transformOrder', () => {
+  describe('addTotalFeeToOrder', () => {
+    test('should use executedFeeAmount when executedSurplusFee is 0', () => {
+      const rawOrder = { ...ORDER, executedFeeAmount: '1', executedSurplusFee: '0' }
+      const transformedOrder = transformOrder(rawOrder)
+
+      expect(transformedOrder.totalFee).toEqual(rawOrder.executedFeeAmount)
+    })
+
+    test('should use executedSurplusFee when executedFeeAmount is 0', () => {
+      const rawOrder = { ...ORDER, executedFeeAmount: '0', executedSurplusFee: '1' }
+      const transformedOrder = transformOrder(rawOrder)
+
+      expect(transformedOrder.totalFee).toEqual(rawOrder.executedSurplusFee)
+    })
+
+    test('should use sum of executedFeeAmount and executedSurplusFee', () => {
+      const rawOrder = { ...ORDER, executedFeeAmount: '1', executedSurplusFee: '1' }
+      const transformedOrder = transformOrder(rawOrder)
+
+      expect(transformedOrder.totalFee).toEqual('2')
+    })
+
+    test('should not fail when executedSurplusFee is falsy', () => {
+      const rawOrder = { ...ORDER, executedSurplusFee: null }
+      const transformedOrder = transformOrder(rawOrder)
+
+      expect(transformedOrder.totalFee).toEqual(rawOrder.executedFeeAmount)
+    })
+  })
+})

--- a/src/order-book/transformOrder.ts
+++ b/src/order-book/transformOrder.ts
@@ -16,16 +16,23 @@ export function transformOrder(order: Order): EnrichedOrder {
 /**
  * Add the total fee to the order.
  *
- * The `executedSurplusFee` represents exactly the fee that was charged (regardless of the fee
- * signed with the order). So, while the protocol currently does not allow placing a limit order
- * with any other fee than 0 - the backend is designed to support these kinds of orders for the
- * future.
+ * The total fee of the order will be represented by the `totalFee` field, which is the sum of `executedSurplusFee`
+ * and `executedFeeAmount`.
+ *
+ * Note that either `executedSurplusFee` or `executedFeeAmount` may be `0`, or both might have a non `0` value.
+ *
+ * See https://cowservices.slack.com/archives/C036G0J90BU/p1705322037866779?thread_ts=1705083817.684659&cid=C036G0J90BU
+ *
  * @param dto The order to add the total fee to.
  * @returns The order with the total fee added.
  */
 function addTotalFeeToOrder(dto: Order): EnrichedOrder {
   const { executedFeeAmount, executedSurplusFee } = dto
-  const totalFee = executedSurplusFee ?? executedFeeAmount
+
+  const _executedFeeAmount = BigInt(executedFeeAmount || '0')
+  const _executedSurplusFee = BigInt(executedSurplusFee || '0')
+
+  const totalFee = String(_executedFeeAmount + _executedSurplusFee)
 
   return {
     ...dto,


### PR DESCRIPTION
# Summary

As per [this internal discussion](https://cowservices.slack.com/archives/C036G0J90BU/p1705083817684659), the backend updated how the fees are returned by the api.

In this PR the calculation is updated to return the sum of `executedSurplusFee` and `executedFeeAmount`.

# Context

Take as example this order: https://explorer.cow.fi/orders/0xdedb65b51a6f81493f8e6e1d811b56a57297dbb6fb11716d85e646a66a5d041f85cc3c8da85612013acabe9b5d954d578860b3c165a22c43?tab=overview

Currently it shows as `0` fee, even though `executedFeeAmount` is set.

The issue is that [this order has both fields](https://api.cow.fi/mainnet/api/v1/orders/0xdedb65b51a6f81493f8e6e1d811b56a57297dbb6fb11716d85e646a66a5d041f85cc3c8da85612013acabe9b5d954d578860b3c165a22c43) `executedSurplusFee` and `executedFeeAmount` returned, but `executedSurplusFee` is set to 0.
In the current implementation, it takes precedence over `executedFeeAmount`.

https://github.com/cowprotocol/cow-sdk/blob/3abfdcfd1ab223394e43d647de07a88d06f0b30d/src/order-book/transformOrder.ts#L28

This logic was [introduced over 1y ago](https://github.com/cowprotocol/cow-sdk/pull/88/files) and according to [this comment from Nick](https://github.com/cowprotocol/cowswap/pull/1588#discussion_r1037501631):
> tl;dr: the “real” fee is executedSurplusFee ?? executedFeeAmount, and not (executedSurplusFee ?? 0) + executedFeeAmount.

According to Dusan:

 > ... probably caused by this change: https://github.com/cowprotocol/services/pull/2103
We extracted the executed_surplus_fee out of the parent struct which caused it to be always serialized (even for market orders).
Considering we will probably deliver protocol fees (which are expressed through executed_surplus_fee ) before we completely remove market orders (orders with signed fee_amount), and in that case we will have orders that have both executed_fee_amount and executed_surplus_fee different from zero => I would go with summarizing the values for UI.

# Test

Unit tests