### PR TITLE
chore: preconfigured orderbook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/composable/ConditionalOrder.spec.ts
+++ b/src/composable/ConditionalOrder.spec.ts
@@ -13,6 +13,7 @@ import { OwnerContext, PollParams, PollResultCode, PollResultErrors } from './ty
 import { BuyTokenDestination, OrderKind, SellTokenSource } from '../order-book/generated'
 import { computeOrderUid } from '../utils'
 import { GPv2Order } from './generated/ComposableCoW'
+import { OrderBookApi } from '../order-book'
 
 jest.mock('./contracts')
 
@@ -172,7 +173,9 @@ describe('Cabinet', () => {
 describe('Poll Single Orders', () => {
   const mockSingleOrders = jest.fn()
   const mockGetTradeableOrderWithSignature = jest.fn()
-  const param = { owner: OWNER, chainId: 1, provider: {} } as PollParams
+  const chainId = 1
+  const orderBookApi = new OrderBookApi({ chainId })
+  const param = { owner: OWNER, chainId, provider: {}, orderBookApi } as PollParams
 
   const mockPollValidate = jest.fn<Promise<PollResultErrors | undefined>, [params: PollParams], any>()
 

--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -14,10 +14,8 @@ import {
   PollResultErrors,
 } from './types'
 import { getComposableCow, getComposableCowInterface } from './contracts'
-import { OrderBookApi, UID } from '../order-book'
+import { UID } from '../order-book'
 import { computeOrderUid } from '../utils'
-
-const orderBookCache: Record<string, OrderBookApi> = {}
 
 /**
  * An abstract base class from which all conditional orders should inherit.
@@ -249,7 +247,7 @@ export abstract class ConditionalOrder<D, S> {
    * @returns The tradeable `GPv2Order.Data` struct and the `signature` for the conditional order.
    */
   async poll(params: PollParams): Promise<PollResult> {
-    const { chainId, owner, provider, orderbookApiConfig } = params
+    const { chainId, owner, provider, orderBookApi } = params
     const composableCow = getComposableCow(chainId, provider)
 
     try {
@@ -284,12 +282,6 @@ export abstract class ConditionalOrder<D, S> {
         this.offChainInput,
         []
       )
-
-      let orderBookApi = orderBookCache[chainId]
-      if (!orderBookApi) {
-        orderBookApi = new OrderBookApi({ ...orderbookApiConfig, chainId })
-        orderBookCache[chainId] = orderBookApi
-      }
 
       const orderUid = await computeOrderUid(chainId, owner, fromStructToOrder(order))
 

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -89,6 +89,7 @@ export type OwnerContext = {
 }
 
 export type PollParams = OwnerContext & {
+  orderBookApi: OrderBookApi
   offchainInput?: string
   proof?: string[]
 
@@ -96,14 +97,7 @@ export type PollParams = OwnerContext & {
    * If present, it can be used for custom conditional order validations. If not present, the orders will need to get the block info themselves
    */
   blockInfo?: BlockInfo
-
-  /**
-   * Allows to optional pass the config of the orderbook API
-   */
-  orderbookApiConfig?: OrderBookApiConfig
 }
-
-export type OrderBookApiConfig = Omit<ConstructorParameters<typeof OrderBookApi>[0], 'chainId'>
 
 export type BlockInfo = {
   blockNumber: number


### PR DESCRIPTION
This PR:

1. Modifies the `PollParams` type to take an already-instantiated `OrderBookApi`.

**NOTES:** As this is a change to the type, this is a breaking change and is accompanied by a major version bump.