### PR TITLE
fix: rename chain id from ARBITRUM to ARBITRUM_ONE

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Since the API supports different networks and environments, there are some optio
 
 #### Environment configuration
 
-`chainId` - can be one of `SupportedChainId.MAINNET`, `SupportedChainId.GNOSIS_CHAIN`, `SupportedChainId.ARBITRUM` or `SupportedChainId.SEPOLIA`
+`chainId` - can be one of `SupportedChainId.MAINNET`, `SupportedChainId.GNOSIS_CHAIN`, `SupportedChainId.ARBITRUM_ONE` or `SupportedChainId.SEPOLIA`
 
 `env` - this parameter affects which environment will be used:
 

--- a/src/common/chains.ts
+++ b/src/common/chains.ts
@@ -5,6 +5,6 @@
 export enum SupportedChainId {
   MAINNET = 1,
   GNOSIS_CHAIN = 100,
-  ARBITRUM = 42161,
+  ARBITRUM_ONE = 42161,
   SEPOLIA = 11155111,
 }

--- a/src/order-book/api.ts
+++ b/src/order-book/api.ts
@@ -38,7 +38,7 @@ import { EnrichedOrder } from './types'
 export const ORDER_BOOK_PROD_CONFIG: ApiBaseUrls = {
   [SupportedChainId.MAINNET]: 'https://api.cow.fi/mainnet',
   [SupportedChainId.GNOSIS_CHAIN]: 'https://api.cow.fi/xdai',
-  [SupportedChainId.ARBITRUM]: 'https://api.cow.fi/arbitrum_one',
+  [SupportedChainId.ARBITRUM_ONE]: 'https://api.cow.fi/arbitrum_one',
   [SupportedChainId.SEPOLIA]: 'https://api.cow.fi/sepolia',
 }
 
@@ -48,7 +48,7 @@ export const ORDER_BOOK_PROD_CONFIG: ApiBaseUrls = {
 export const ORDER_BOOK_STAGING_CONFIG: ApiBaseUrls = {
   [SupportedChainId.MAINNET]: 'https://barn.api.cow.fi/mainnet',
   [SupportedChainId.GNOSIS_CHAIN]: 'https://barn.api.cow.fi/xdai',
-  [SupportedChainId.ARBITRUM]: 'https://barn.api.cow.fi/arbitrum_one',
+  [SupportedChainId.ARBITRUM_ONE]: 'https://barn.api.cow.fi/arbitrum_one',
   [SupportedChainId.SEPOLIA]: 'https://barn.api.cow.fi/sepolia',
 }
 

--- a/src/subgraph/api.ts
+++ b/src/subgraph/api.ts
@@ -24,7 +24,7 @@ type PartialSubgraphApiContext = Partial<SubgraphApiContext>
 export const SUBGRAPH_PROD_CONFIG: SubgraphApiBaseUrls = {
   [SupportedChainId.MAINNET]: SUBGRAPH_BASE_URL + '/cow',
   [SupportedChainId.GNOSIS_CHAIN]: SUBGRAPH_BASE_URL + '/cow-gc',
-  [SupportedChainId.ARBITRUM]: null,
+  [SupportedChainId.ARBITRUM_ONE]: null,
   [SupportedChainId.SEPOLIA]: null,
 }
 
@@ -37,7 +37,7 @@ export const SUBGRAPH_PROD_CONFIG: SubgraphApiBaseUrls = {
 export const SUBGRAPH_STAGING_CONFIG: SubgraphApiBaseUrls = {
   [SupportedChainId.MAINNET]: SUBGRAPH_BASE_URL + '/cow-staging',
   [SupportedChainId.GNOSIS_CHAIN]: SUBGRAPH_BASE_URL + '/cow-gc-staging',
-  [SupportedChainId.ARBITRUM]: null,
+  [SupportedChainId.ARBITRUM_ONE]: null,
   [SupportedChainId.SEPOLIA]: null,
 }
 


### PR DESCRIPTION
# Summary

Rename chain id from `ARBITRUM` to `ARBITRUM_ONE`

I did not follow the new recommendations and did not use the proper chain name format.