### PR TITLE
fix: cow-shed types

### DIFF
--- a/src/cow-shed/CoWShedHooks.ts
+++ b/src/cow-shed/CoWShedHooks.ts
@@ -1,4 +1,13 @@
 import {
+  EcdsaSigningScheme,
+  hashTypedData,
+  isTypedDataSigner,
+  SigningScheme,
+  TypedDataTypes,
+} from '@cowprotocol/contracts'
+import type { Signer } from '@ethersproject/abstract-signer'
+import { TypedDataDomain } from 'ethers'
+import {
   arrayify,
   defaultAbiCoder,
   getCreate2Address,
@@ -6,19 +15,10 @@ import {
   solidityKeccak256,
   splitSignature,
 } from 'ethers/lib/utils'
-import { COW_SHED_FACTORY, COW_SHED_IMPLEMENTATION, SupportedChainId } from 'src/common'
-import { COW_SHED_712_TYPES, ICoWShedCall, ICoWShedOptions } from './types'
-import { COW_SHED_PROXY_INIT_CODE } from './proxyInitCode'
-import type { Signer } from '@ethersproject/abstract-signer'
+import { COW_SHED_FACTORY, COW_SHED_IMPLEMENTATION, SupportedChainId } from '../common'
 import { getCoWShedFactoryInterface } from './contracts'
-import { TypedDataDomain } from 'ethers'
-import {
-  EcdsaSigningScheme,
-  hashTypedData,
-  isTypedDataSigner,
-  SigningScheme,
-  TypedDataTypes,
-} from '@cowprotocol/contracts'
+import { COW_SHED_PROXY_INIT_CODE } from './proxyInitCode'
+import { COW_SHED_712_TYPES, ICoWShedCall, ICoWShedOptions } from './types'
 
 export class CowShedHooks {
   constructor(private chainId: SupportedChainId, private customOptions?: ICoWShedOptions) {}

--- a/src/cow-shed/contracts.ts
+++ b/src/cow-shed/contracts.ts
@@ -1,6 +1,6 @@
-import { CoWShedInterface } from 'src/common/generated/CoWShed'
-import { CoWShed__factory, CoWShedFactory__factory } from 'src/common/generated'
-import { CoWShedFactoryInterface } from 'src/common/generated/CoWShedFactory'
+import { CoWShed__factory, CoWShedFactory__factory } from '../common/generated'
+import { CoWShedInterface } from '../common/generated/CoWShed'
+import { CoWShedFactoryInterface } from '../common/generated/CoWShedFactory'
 
 let cowShedInterfaceCache: CoWShedInterface | undefined
 let cowShedFactoryInterface: CoWShedFactoryInterface | undefined


### PR DESCRIPTION
# Summary

CoW-shed was using absolute imports in some places which causes the generated types to not find the the proper imports.

Changed it to relative.

This is causing the watch-tower `tsc` command to fail: https://github.com/cowprotocol/watch-tower/actions/runs/11722358815/job/32651723873?pr=162
![image](https://github.com/user-attachments/assets/b43c4034-e57d-4bd9-9100-89ff36f4f516)

# Testing

In this lib all tests were passing as before.
The issue was when importing it on watch-tower.

I built it with `yalc`, published locally and installed onto watch-tower.

After that the build was successful.