### PR TITLE
feat: make the conditional order factory case insensitive

### DIFF
--- a/src/composable/ConditionalOrderFactory.ts
+++ b/src/composable/ConditionalOrderFactory.ts
@@ -4,17 +4,31 @@ import { ConditionalOrderParams } from './types'
 export type FromParams<D, S> = (params: ConditionalOrderParams) => ConditionalOrder<D, S>
 export type ConditionalOrderRegistry = Record<string, FromParams<unknown, unknown>>
 
+/**
+ * Factory for conditional orders.
+ *
+ * It uses a registry to instantiate the correct conditional order based on the handler.
+ *
+ * Knowing the handler, the factory will instantiate the correct conditional order using the staticInput data.
+ */
 export class ConditionalOrderFactory {
   public knownOrderTypes
 
   constructor(registry: ConditionalOrderRegistry) {
-    this.knownOrderTypes = registry
+    // Normalize the keys to lowercase
+    this.knownOrderTypes = Object.entries(registry).reduce<ConditionalOrderRegistry>((acc, [key, value]) => {
+      acc[key.toLowerCase()] = value
+      return acc
+    }, {})
   }
 
+  /**
+   * Get the conditional order factory from the conditional order parameters
+   */
   public fromParams(params: ConditionalOrderParams): ConditionalOrder<unknown, unknown> | undefined {
     const { handler } = params
 
-    const factory = this.knownOrderTypes[handler]
+    const factory = this.knownOrderTypes[handler.toLocaleLowerCase()]
     if (!factory) {
       return undefined
     }


### PR DESCRIPTION
We are observing some issues handling some TWAP orders in the logs.

<img width="1330" alt="image" src="https://github.com/user-attachments/assets/5e93c099-a17d-40e3-b3e8-4fa21860a4de">

According to the log, this message should only be shown for legacy polling, meaning that the order was not recognised as a known one, and instead of using the SDK polling for Conditional Orders, its using the generic polling of the Watch Tower.

The check if the order is a known one is based on the `ConditionalOrderFactory` who instanciates conditional orders based on their handler. 

I can see in the error the handler is TWAP, but it was not instantiated using the SDK which I believe it means the handler was not recognised. 

This PR makes the `ConditionalOrderFactory` to not be case sensitive, because otherwise it depends on the casing of the handler if its recognised or not. With this, the legacy polling should not be used for TWAP.

## After this PR
After this PR we need to generate a new SDK version and make use of it in Watch Tower