### PR TITLE
feat: replace the usage of `executedSurplusFee` with `executedFee`

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,7 +111,7 @@ class OrderMetaData {
   + fullFeeAmount?: TokenAmount;
   + isLiquidityOrder?: boolean;
   + onchainUser?: Address;
-  + executedSurplusFee?: BigUint | null;
+  + executedFee?: BigUint | null;
 }
 
 class OrderStatus {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "5.9.0",
+  "version": "5.10.0-RC.0",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "graphql:codegen": "graphql-codegen --config graphql-codegen.yml",
-    "swagger:codegen": " openapi --input https://raw.githubusercontent.com/cowprotocol/services/v2.285.0/crates/orderbook/openapi.yml --output src/order-book/generated --exportServices false --exportCore false",
+    "swagger:codegen": " openapi --input https://raw.githubusercontent.com/cowprotocol/services/v2.291.0/crates/orderbook/openapi.yml --output src/order-book/generated --exportServices false --exportCore false",
     "typechain:codegen": "typechain --target ethers-v5 --out-dir ./src/common/generated './abi/*.json'",
     "trading:generateSchemas": "ts-node scripts/generateTradingSchemas.ts"
   },

--- a/src/order-book/generated/index.ts
+++ b/src/order-book/generated/index.ts
@@ -44,7 +44,6 @@ export type { PreSignature } from './models/PreSignature';
 export { PriceEstimationError } from './models/PriceEstimationError';
 export type { PriceImprovement } from './models/PriceImprovement';
 export { PriceQuality } from './models/PriceQuality';
-export type { ProtocolAppData } from './models/ProtocolAppData';
 export type { Quote } from './models/Quote';
 export { SellTokenSource } from './models/SellTokenSource';
 export type { Signature } from './models/Signature';

--- a/src/order-book/generated/models/Auction.ts
+++ b/src/order-book/generated/models/Auction.ts
@@ -17,19 +17,10 @@ export type Auction = {
      */
     id?: number;
     /**
-     * The block number for the auction. Orders and prices are guaranteed to be valid on this
-     * block. Proposed settlements should be valid for this block as well.
+     * The block number for the auction. Orders and prices are guaranteed to be valid on this block. Proposed settlements should be valid for this block as well.
      *
      */
     block?: number;
-    /**
-     * The latest block on which a settlement has been processed.
-     *
-     * **NOTE**: Under certain conditions it is possible for a settlement to have been mined as
-     * part of `block` but not have yet been processed.
-     *
-     */
-    latestSettlementBlock?: number;
     /**
      * The solvable orders included in the auction.
      *

--- a/src/order-book/generated/models/AuctionPrices.ts
+++ b/src/order-book/generated/models/AuctionPrices.ts
@@ -5,10 +5,7 @@
 import type { BigUint } from './BigUint';
 
 /**
- * The reference prices for all traded tokens in the auction as a mapping from token
- * addresses to a price denominated in native token (i.e. 1e18 represents a token that
- * trades one to one with the native token). These prices are used for solution competition
- * for computing surplus and converting fees to native token.
+ * The reference prices for all traded tokens in the auction as a mapping from token addresses to a price denominated in native token (i.e. 1e18 represents a token that trades one to one with the native token). These prices are used for solution competition for computing surplus and converting fees to native token.
  *
  */
 export type AuctionPrices = Record<string, BigUint>;

--- a/src/order-book/generated/models/CompetitionOrderStatus.ts
+++ b/src/order-book/generated/models/CompetitionOrderStatus.ts
@@ -7,9 +7,11 @@ import type { ExecutedAmounts } from './ExecutedAmounts';
 export type CompetitionOrderStatus = {
     type: CompetitionOrderStatus.type;
     /**
-     * A list of solvers who participated in the latest competition, sorted by score in ascending order, where the last element is the winner.
-     * The presence of executed amounts defines whether the solver provided a solution for the desired order.
+     * A list of solvers who participated in the latest competition, sorted
+     * by score in ascending order, where the last element is the winner.
      *
+     * The presence of executed amounts defines whether the solver provided
+     * a solution for the desired order.
      */
     value?: Array<{
         /**

--- a/src/order-book/generated/models/ExecutedProtocolFee.ts
+++ b/src/order-book/generated/models/ExecutedProtocolFee.ts
@@ -8,13 +8,7 @@ import type { TokenAmount } from './TokenAmount';
 
 export type ExecutedProtocolFee = {
     policy?: FeePolicy;
-    /**
-     * Fee amount taken
-     */
     amount?: TokenAmount;
-    /**
-     * The token in which the fee is taken
-     */
     token?: Address;
 };
 

--- a/src/order-book/generated/models/OnchainOrderData.ts
+++ b/src/order-book/generated/models/OnchainOrderData.ts
@@ -6,16 +6,12 @@ import type { Address } from './Address';
 
 export type OnchainOrderData = {
     /**
-     * If orders are placed as on-chain orders, the owner of the order might
-     * be a smart contract, but not the user placing the order. The
-     * actual user will be provided in this field.
+     * If orders are placed as on-chain orders, the owner of the order might be a smart contract, but not the user placing the order. The actual user will be provided in this field.
      *
      */
     sender: Address;
     /**
-     * Describes the error, if the order placement was not successful. This could
-     * happen, for example, if the `validTo` is too high, or no valid quote was
-     * found or generated.
+     * Describes the error, if the order placement was not successful. This could happen, for example, if the `validTo` is too high, or no valid quote was found or generated.
      *
      */
     placementError?: OnchainOrderData.placementError;
@@ -24,9 +20,7 @@ export type OnchainOrderData = {
 export namespace OnchainOrderData {
 
     /**
-     * Describes the error, if the order placement was not successful. This could
-     * happen, for example, if the `validTo` is too high, or no valid quote was
-     * found or generated.
+     * Describes the error, if the order placement was not successful. This could happen, for example, if the `validTo` is too high, or no valid quote was found or generated.
      *
      */
     export enum placementError {

--- a/src/order-book/generated/models/OrderCreation.ts
+++ b/src/order-book/generated/models/OrderCreation.ts
@@ -63,30 +63,22 @@ export type OrderCreation = {
     signingScheme: SigningScheme;
     signature: Signature;
     /**
-     * If set, the backend enforces that this address matches what is decoded as the *signer* of
-     * the signature. This helps catch errors with invalid signature encodings as the backend
-     * might otherwise silently work with an unexpected address that for example does not have
-     * any balance.
+     * If set, the backend enforces that this address matches what is decoded as the *signer* of the signature. This helps catch errors with invalid signature encodings as the backend might otherwise silently work with an unexpected address that for example does not have any balance.
      *
      */
     from?: Address | null;
     /**
-     * Orders can optionally include a quote ID. This way the order can be linked to a quote
-     * and enable providing more metadata when analysing order slippage.
+     * Orders can optionally include a quote ID. This way the order can be linked to a quote and enable providing more metadata when analysing order slippage.
      *
      */
     quoteId?: number | null;
     /**
-     * This field comes in two forms for backward compatibility. The hash form will eventually
-     * stop being accepted.
+     * This field comes in two forms for backward compatibility. The hash form will eventually stop being accepted.
      *
      */
     appData: (AppData | AppDataHash);
     /**
-     * May be set for debugging purposes. If set, this field is compared to what the backend
-     * internally calculates as the app data hash based on the contents of `appData`. If the
-     * hash does not match, an error is returned. If this field is set, then `appData` **MUST** be
-     * a string encoding of a JSON object.
+     * May be set for debugging purposes. If set, this field is compared to what the backend internally calculates as the app data hash based on the contents of `appData`. If the hash does not match, an error is returned. If this field is set, then `appData` **MUST** be a string encoding of a JSON object.
      *
      */
     appDataHash?: AppDataHash | null;

--- a/src/order-book/generated/models/OrderMetaData.ts
+++ b/src/order-book/generated/models/OrderMetaData.ts
@@ -12,8 +12,7 @@ import type { TokenAmount } from './TokenAmount';
 import type { UID } from './UID';
 
 /**
- * Extra order data that is returned to users when querying orders but not provided by users
- * when creating orders.
+ * Extra order data that is returned to users when querying orders but not provided by users when creating orders.
  *
  */
 export type OrderMetaData = {
@@ -62,40 +61,44 @@ export type OrderMetaData = {
      */
     fullFeeAmount?: TokenAmount;
     /**
-     * Liquidity orders are functionally the same as normal smart contract orders but are not
-     * placed with the intent of actively getting traded. Instead they facilitate the
-     * trade of normal orders by allowing them to be matched against liquidity orders which
-     * uses less gas and can have better prices than external liquidity.
+     * Liquidity orders are functionally the same as normal smart contract
+     * orders but are not placed with the intent of actively getting
+     * traded. Instead they facilitate the trade of normal orders by
+     * allowing them to be matched against liquidity orders which uses less
+     * gas and can have better prices than external liquidity.
      *
-     * As such liquidity orders will only be used in order to improve settlement of normal
-     * orders. They should not be expected to be traded otherwise and should not expect to get
-     * surplus.
-     *
+     * As such liquidity orders will only be used in order to improve
+     * settlement of normal orders. They should not be expected to be
+     * traded otherwise and should not expect to get surplus.
      */
     isLiquidityOrder?: boolean;
     ethflowData?: EthflowData;
     /**
      * This represents the actual trader of an on-chain order.
-     *
      * ### ethflow orders
-     *
      * In this case, the `owner` would be the `EthFlow` contract and *not* the actual trader.
      *
      */
     onchainUser?: Address;
     /**
-     * There is some data only available for orders that are placed on-chain. This data
-     * can be found in this object.
+     * There is some data only available for orders that are placed on-chain. This data can be found in this object.
      *
      */
     onchainOrderData?: OnchainOrderData;
     /**
      * Surplus fee that the limit order was executed with.
      */
-    executedSurplusFee?: BigUint | null;
+    executedSurplusFee?: BigUint;
     /**
-     * Full `appData`, which the contract-level `appData` is a hash of. See `OrderCreation`
-     * for more information.
+     * Total fee charged for execution of the order. Contains network fee and protocol fees.
+     */
+    executedFee?: BigUint;
+    /**
+     * Token the executed fee was captured in.
+     */
+    executedFeeToken?: Address;
+    /**
+     * Full `appData`, which the contract-level `appData` is a hash of. See `OrderCreation` for more information.
      *
      */
     fullAppData?: string | null;

--- a/src/order-book/generated/models/OrderParameters.ts
+++ b/src/order-book/generated/models/OrderParameters.ts
@@ -23,8 +23,7 @@ export type OrderParameters = {
      */
     buyToken: Address;
     /**
-     * An optional Ethereum address to receive the proceeds of the trade instead
-     * of the owner (i.e. the order signer).
+     * An optional Ethereum address to receive the proceeds of the trade instead of the owner (i.e. the order signer).
      *
      */
     receiver?: Address | null;

--- a/src/order-book/generated/models/OrderQuoteRequest.ts
+++ b/src/order-book/generated/models/OrderQuoteRequest.ts
@@ -32,17 +32,22 @@ export type OrderQuoteRequest = (OrderQuoteSide & OrderQuoteValidity & {
     receiver?: Address | null;
     /**
      * AppData which will be assigned to the order.
-     * Expects either a string JSON doc as defined on [AppData](https://github.com/cowprotocol/app-data) or a
-     * hex encoded string for backwards compatibility.
-     * When the first format is used, it's possible to provide the derived appDataHash field.
      *
+     * Expects either a string JSON doc as defined on
+     * [AppData](https://github.com/cowprotocol/app-data) or a hex
+     * encoded string for backwards compatibility.
+     *
+     * When the first format is used, it's possible to provide the
+     * derived appDataHash field.
      */
     appData?: (AppData | AppDataHash);
     /**
      * The hash of the stringified JSON appData doc.
-     * If present, `appData` field must be set with the aforementioned data where this hash is derived from.
-     * In case they differ, the call will fail.
      *
+     * If present, `appData` field must be set with the aforementioned
+     * data where this hash is derived from.
+     *
+     * In case they differ, the call will fail.
      */
     appDataHash?: AppDataHash;
     sellTokenBalance?: SellTokenSource;
@@ -51,8 +56,7 @@ export type OrderQuoteRequest = (OrderQuoteSide & OrderQuoteValidity & {
     priceQuality?: PriceQuality;
     signingScheme?: SigningScheme;
     /**
-     * Flag to signal whether the order is intended for on-chain order placement. Only valid
-     * for non ECDSA-signed orders."
+     * Flag to signal whether the order is intended for on-chain order placement. Only valid for non ECDSA-signed orders."
      *
      */
     onchainOrder?: any;

--- a/src/order-book/generated/models/OrderQuoteResponse.ts
+++ b/src/order-book/generated/models/OrderQuoteResponse.ts
@@ -20,8 +20,7 @@ export type OrderQuoteResponse = {
      */
     expiration: string;
     /**
-     * Quote ID linked to a quote to enable providing more metadata when analysing
-     * order slippage.
+     * Quote ID linked to a quote to enable providing more metadata when analysing order slippage.
      *
      */
     id?: number;

--- a/src/order-book/generated/models/OrderQuoteSide.ts
+++ b/src/order-book/generated/models/OrderQuoteSide.ts
@@ -12,8 +12,7 @@ import type { TokenAmount } from './TokenAmount';
 export type OrderQuoteSide = ({
     kind: OrderQuoteSideKindSell;
     /**
-     * The total amount that is available for the order. From this value, the fee
-     * is deducted and the buy amount is calculated.
+     * The total amount that is available for the order. From this value, the fee is deducted and the buy amount is calculated.
      *
      */
     sellAmountBeforeFee: TokenAmount;

--- a/src/order-book/generated/models/PriceQuality.ts
+++ b/src/order-book/generated/models/PriceQuality.ts
@@ -7,10 +7,11 @@
  *
  * Fast: The price estimate is chosen among the fastest N price estimates.
  * Optimal: The price estimate is chosen among all price estimates.
- * Verified: The price estimate is chosen among all verified/simulated price estimates.
+ * Verified: The price estimate is chosen among all verified/simulated
+ * price estimates.
  *
- * **NOTE**: Orders are supposed to be created from `verified` or `optimal` price estimates.
- *
+ * **NOTE**: Orders are supposed to be created from `verified` or `optimal`
+ * price estimates.
  */
 export enum PriceQuality {
     FAST = 'fast',

--- a/src/order-book/generated/models/ProtocolAppData.ts
+++ b/src/order-book/generated/models/ProtocolAppData.ts
@@ -1,7 +1,0 @@
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
-
-export type ProtocolAppData = {
-};
-

--- a/src/order-book/generated/models/SolverSettlement.ts
+++ b/src/order-book/generated/models/SolverSettlement.ts
@@ -12,8 +12,9 @@ export type SolverSettlement = {
     solver?: string;
     /**
      * The address used by the solver to execute the settlement on-chain.
-     * This field is missing for old settlements, the zero address has been used instead.
      *
+     * This field is missing for old settlements, the zero address has been
+     * used instead.
      */
     solverAddress?: string;
     objective?: {
@@ -44,5 +45,9 @@ export type SolverSettlement = {
         id?: UID;
         executedAmount?: BigUint;
     }>;
+    /**
+     * whether the solution is a winner (received the right to get executed) or not
+     */
+    isWinner?: boolean;
 };
 

--- a/src/order-book/generated/models/UID.ts
+++ b/src/order-book/generated/models/UID.ts
@@ -3,9 +3,10 @@
 /* eslint-disable */
 
 /**
- * Unique identifier for the order: 56 bytes encoded as hex with `0x` prefix.
- * Bytes 0..32 are the order digest, bytes 30..52 the owner address and bytes
- * 52..56 the expiry (`validTo`) as a `uint32` unix epoch timestamp.
+ * Unique identifier for the order: 56 bytes encoded as hex with `0x`
+ * prefix.
  *
+ * Bytes 0..32 are the order digest, bytes 30..52 the owner address and
+ * bytes 52..56 the expiry (`validTo`) as a `uint32` unix epoch timestamp.
  */
 export type UID = string;

--- a/src/order-book/transformOrder.test.ts
+++ b/src/order-book/transformOrder.test.ts
@@ -28,29 +28,29 @@ const ORDER: Order = {
 
 describe('transformOrder', () => {
   describe('addTotalFeeToOrder', () => {
-    test('should use executedFeeAmount when executedSurplusFee is 0', () => {
-      const rawOrder = { ...ORDER, executedFeeAmount: '1', executedSurplusFee: '0' }
+    test('should use executedFeeAmount when executedFee is 0', () => {
+      const rawOrder = { ...ORDER, executedFeeAmount: '1', executedFee: '0' }
       const transformedOrder = transformOrder(rawOrder)
 
       expect(transformedOrder.totalFee).toEqual('1')
     })
 
-    test('should use executedSurplusFee when executedFeeAmount is 0', () => {
-      const rawOrder = { ...ORDER, executedFeeAmount: '0', executedSurplusFee: '1' }
+    test('should use executedFee when executedFeeAmount is 0', () => {
+      const rawOrder = { ...ORDER, executedFeeAmount: '0', executedFee: '1' }
       const transformedOrder = transformOrder(rawOrder)
 
       expect(transformedOrder.totalFee).toEqual('1')
     })
 
-    test('should use sum of executedFeeAmount and executedSurplusFee', () => {
-      const rawOrder = { ...ORDER, executedFeeAmount: '1', executedSurplusFee: '1' }
+    test('should use sum of executedFeeAmount and executedFee', () => {
+      const rawOrder = { ...ORDER, executedFeeAmount: '1', executedFee: '1' }
       const transformedOrder = transformOrder(rawOrder)
 
       expect(transformedOrder.totalFee).toEqual('2')
     })
 
-    test('should not fail when executedSurplusFee is falsy', () => {
-      const rawOrder = { ...ORDER, executedSurplusFee: null }
+    test('should not fail when executedFee is falsy', () => {
+      const rawOrder = { ...ORDER, executedFee: undefined }
       const transformedOrder = transformOrder(rawOrder)
 
       expect(transformedOrder.totalFee).toEqual('1234567890')

--- a/src/order-book/transformOrder.ts
+++ b/src/order-book/transformOrder.ts
@@ -16,10 +16,10 @@ export function transformOrder(order: Order): EnrichedOrder {
 /**
  * Add the total fee to the order.
  *
- * The total fee of the order will be represented by the `totalFee` field, which is the sum of `executedSurplusFee`
+ * The total fee of the order will be represented by the `totalFee` field, which is the sum of `executedFee`
  * and `executedFeeAmount`.
  *
- * Note that either `executedSurplusFee` or `executedFeeAmount` may be `0`, or both might have a non `0` value.
+ * Note that either `executedFee` or `executedFeeAmount` may be `0`, or both might have a non `0` value.
  *
  * See https://cowservices.slack.com/archives/C036G0J90BU/p1705322037866779?thread_ts=1705083817.684659&cid=C036G0J90BU
  *
@@ -27,12 +27,12 @@ export function transformOrder(order: Order): EnrichedOrder {
  * @returns The order with the total fee added.
  */
 function addTotalFeeToOrder(dto: Order): EnrichedOrder {
-  const { executedFeeAmount, executedSurplusFee } = dto
+  const { executedFeeAmount, executedFee } = dto
 
   const _executedFeeAmount = BigInt(executedFeeAmount || '0')
-  const _executedSurplusFee = BigInt(executedSurplusFee || '0')
+  const _executedFee = BigInt(executedFee || '0')
 
-  const totalFee = String(_executedFeeAmount + _executedSurplusFee)
+  const totalFee = String(_executedFeeAmount + _executedFee)
 
   return {
     ...dto,


### PR DESCRIPTION
# Summary

As part of backend's fee overhaul, `executedSurplusFee` is deprecated in favor of `executedFee`.

This change replaces it where applicable, as well as building the types based on the latest backend release that includes such changes https://github.com/cowprotocol/services/releases/tag/v2.291.0

# Testing

- Unit tests
- Locally loaded it via `yalc` on CoW Swap/Explorer