### PR TITLE
fix(trading-sdk): fix order amounts calculations

### DIFF
--- a/src/trading/getQuote.ts
+++ b/src/trading/getQuote.ts
@@ -117,7 +117,7 @@ export async function getQuote(
   const orderToSign = getOrderToSign(
     { from, networkCostsAmount: quoteResponse.quote.feeAmount },
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    swapParamsToLimitOrderParams(tradeParameters, quoteResponse.id!, amountsAndCosts),
+    swapParamsToLimitOrderParams(tradeParameters, quoteResponse),
     appDataInfo.appDataKeccak256
   )
 

--- a/src/trading/postCoWProtocolTrade.test.ts
+++ b/src/trading/postCoWProtocolTrade.test.ts
@@ -57,6 +57,9 @@ signer.getChainId = jest.fn().mockResolvedValue(SupportedChainId.GNOSIS_CHAIN)
 
 const sendOrderMock = jest.fn()
 const orderBookApiMock = {
+  context: {
+    chainId: defaultOrderParams.chainId,
+  },
   sendOrder: sendOrderMock,
 } as unknown as OrderBookApi
 const appDataMock = {

--- a/src/trading/postCoWProtocolTrade.ts
+++ b/src/trading/postCoWProtocolTrade.ts
@@ -35,7 +35,7 @@ export async function postCoWProtocolTrade(
   const { quoteId = null } = params
   const { appDataKeccak256, fullAppData } = appData
 
-  const chainId = await signer.getChainId()
+  const chainId = orderBookApi.context.chainId
   const from = await signer.getAddress()
 
   const orderToSign = getOrderToSign({ from, networkCostsAmount }, params, appData.appDataKeccak256)

--- a/src/trading/postSwapOrder.test.ts
+++ b/src/trading/postSwapOrder.test.ts
@@ -1,0 +1,144 @@
+import { getQuoteWithSigner } from './getQuote'
+
+jest.mock('cross-fetch', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const fetchMock = require('jest-fetch-mock')
+  // Require the original module to not be mocked...
+  const originalFetch = jest.requireActual('cross-fetch')
+  return {
+    __esModule: true,
+    ...originalFetch,
+    default: fetchMock,
+  }
+})
+
+import { postSwapOrderFromQuote } from './postSwapOrder'
+import { SwapParameters } from './types'
+import { OrderKind } from '../order-book'
+import { parseUnits } from 'ethers/lib/utils'
+import { SupportedChainId } from '../common'
+
+const WETH_ADDRESS = '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'
+const COW_ADDRESS = '0x0625aFB445C3B6B7B929342a04A22599fd5dBB59'
+
+describe('postSwapOrder', () => {
+  it('Sell order amounts should take fees and slippage into account', async () => {
+    const parameters: SwapParameters = {
+      chainId: SupportedChainId.SEPOLIA,
+      appCode: 'test',
+      signer: '0xa43ccc40ff785560dab6cb0f13b399d050073e8a54114621362f69444e1421ca',
+      kind: OrderKind.SELL,
+      amount: parseUnits('0.1', 18).toString(), // 0.1 WETH
+      sellToken: WETH_ADDRESS,
+      sellTokenDecimals: 18,
+      buyToken: COW_ADDRESS,
+      buyTokenDecimals: 18,
+      slippageBps: 50,
+    }
+
+    const quoteResponseMock = {
+      quote: {
+        sellToken: WETH_ADDRESS.toLowerCase(),
+        buyToken: COW_ADDRESS.toLowerCase(),
+        receiver: '0xc8c753ee51e8fc80e199ab297fb575634a1ac1d3',
+        sellAmount: '98646335338956442',
+        buyAmount: '39562052700191266415',
+        validTo: 1737464594,
+        appData:
+          '{"appCode":"test","metadata":{"orderClass":{"orderClass":"market"},"quote":{"slippageBips":50}},"version":"1.3.0"}',
+        appDataHash: '0xe269b09f45b1d3c98d8e4e841b99a0779fbd3b77943d069b91ddc4fd9789e27e',
+        feeAmount: '1353664661043558',
+        kind: 'sell',
+        partiallyFillable: false,
+        sellTokenBalance: 'erc20',
+        buyTokenBalance: 'erc20',
+        signingScheme: 'eip712',
+      },
+      from: '0xc8c753ee51e8fc80e199ab297fb575634a1ac1d3',
+      expiration: '2025-01-21T12:55:14.799709609Z',
+      id: 575401,
+      verified: true,
+    }
+
+    const orderBookApi = {
+      context: {
+        chainId: parameters.chainId,
+      },
+      getQuote: jest.fn().mockResolvedValue(quoteResponseMock),
+      sendOrder: jest.fn().mockResolvedValue('0x01'),
+    }
+
+    const orderId = await postSwapOrderFromQuote(await getQuoteWithSigner(parameters, undefined, orderBookApi as any))
+
+    const call = orderBookApi.sendOrder.mock.calls[0][0]
+
+    expect(orderId).toEqual('0x01')
+    // quoteResponseMock.sellAmount + quoteResponseMock.feeAmount
+    // 98646335338956442 + 1353664661043558 = 100000000000000000
+    expect(call.sellAmount).toBe('100000000000000000')
+    // quoteResponseMock.buyAmount - 0.5%
+    // BigInt('39562052700191266415') - ((BigInt('39562052700191266415') * BigInt(50)) / 10000n) = 39364242436690310083
+    expect(call.buyAmount).toBe('39364242436690310083')
+  })
+
+  it('Buy order amounts should take fees and slippage into account', async () => {
+    const parameters: SwapParameters = {
+      chainId: SupportedChainId.SEPOLIA,
+      appCode: 'test',
+      signer: '0xa43ccc40ff785560dab6cb0f13b399d050073e8a54114621362f69444e1421ca',
+      kind: OrderKind.BUY,
+      amount: parseUnits('400', 18).toString(), // 400 COW
+      sellToken: WETH_ADDRESS,
+      sellTokenDecimals: 18,
+      buyToken: COW_ADDRESS,
+      buyTokenDecimals: 18,
+      slippageBps: 50,
+    }
+
+    const quoteResponseMock = {
+      quote: {
+        sellToken: WETH_ADDRESS.toLowerCase(),
+        buyToken: COW_ADDRESS.toLowerCase(),
+        receiver: '0xc8c753ee51e8fc80e199ab297fb575634a1ac1d3',
+        sellAmount: '1005456782512030400',
+        buyAmount: '400000000000000000000',
+        validTo: 1737468944,
+        appData:
+          '{"appCode":"test","metadata":{"orderClass":{"orderClass":"market"},"quote":{"slippageBips":50}},"version":"1.3.0"}',
+        appDataHash: '0xe269b09f45b1d3c98d8e4e841b99a0779fbd3b77943d069b91ddc4fd9789e27e',
+        feeAmount: '1112955650440102',
+        kind: 'buy',
+        partiallyFillable: false,
+        sellTokenBalance: 'erc20',
+        buyTokenBalance: 'erc20',
+        signingScheme: 'eip712',
+      },
+      from: '0xc8c753ee51e8fc80e199ab297fb575634a1ac1d3',
+      expiration: '2025-01-21T14:07:44.176194885Z',
+      id: 575498,
+      verified: true,
+    }
+
+    const orderBookApi = {
+      context: {
+        chainId: parameters.chainId,
+      },
+      getQuote: jest.fn().mockResolvedValue(quoteResponseMock),
+      sendOrder: jest.fn().mockResolvedValue('0x01'),
+    }
+
+    const orderId = await postSwapOrderFromQuote(await getQuoteWithSigner(parameters, undefined, orderBookApi as any))
+
+    const call = orderBookApi.sendOrder.mock.calls[0][0]
+
+    expect(orderId).toEqual('0x01')
+    // sellAmountAfterNetworkCosts = quoteResponseMock.sellAmount + quoteResponseMock.feeAmount
+    // sellAmountAfterNetworkCosts = BigInt('1005456782512030400') + BigInt('1112955650440102') = 1006569738162470502n
+
+    // sellAmountAfterNetworkCosts + 0.5%
+    // 1006569738162470502n + ((1006569738162470502n * BigInt(50)) / 10000n) = 1011602586853282854n
+    expect(call.sellAmount).toBe('1011602586853282854')
+    // quoteResponseMock.buyAmount
+    expect(call.buyAmount).toBe('400000000000000000000')
+  })
+})

--- a/src/trading/postSwapOrder.ts
+++ b/src/trading/postSwapOrder.ts
@@ -10,14 +10,14 @@ export async function postSwapOrder(params: SwapParameters, advancedSettings?: S
 
 export async function postSwapOrderFromQuote({
   orderBookApi,
-  result: { signer, appDataInfo, quoteResponse, tradeParameters, amountsAndCosts },
+  result: { signer, appDataInfo, quoteResponse, tradeParameters },
 }: QuoteResultsWithSigner): Promise<string> {
   return postCoWProtocolTrade(
     orderBookApi,
     signer,
     appDataInfo,
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    swapParamsToLimitOrderParams(tradeParameters, quoteResponse.id!, amountsAndCosts),
+    swapParamsToLimitOrderParams(tradeParameters, quoteResponse),
     quoteResponse.quote.feeAmount
   )
 }

--- a/src/trading/tradingSdk.ts
+++ b/src/trading/tradingSdk.ts
@@ -39,14 +39,14 @@ export class TradingSdk {
   ): Promise<ReturnType<typeof postSellNativeCurrencyOrder>> {
     const quoteResults = await getQuoteWithSigner(this.mergeParams(params), advancedSettings)
 
-    const { tradeParameters, quoteResponse, amountsAndCosts } = quoteResults.result
+    const { tradeParameters, quoteResponse } = quoteResults.result
     return postSellNativeCurrencyOrder(
       quoteResults.orderBookApi,
       quoteResults.result.signer,
       quoteResults.result.appDataInfo,
       // Quote response response always has an id
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      swapParamsToLimitOrderParams(tradeParameters, quoteResponse.id!, amountsAndCosts)
+      swapParamsToLimitOrderParams(tradeParameters, quoteResponse)
     )
   }
 

--- a/src/trading/utils.ts
+++ b/src/trading/utils.ts
@@ -1,19 +1,19 @@
 import { LimitTradeParametersFromQuote, PrivateKey, TradeParameters } from './types'
-import { QuoteAmountsAndCosts } from '../order-book'
+import { OrderQuoteResponse, QuoteAmountsAndCosts } from '../order-book'
 import { ETH_ADDRESS } from '../common'
 import { ethers, Signer } from 'ethers'
 import { type ExternalProvider, Web3Provider } from '@ethersproject/providers'
 
 export function swapParamsToLimitOrderParams(
   params: TradeParameters,
-  quoteId: number,
-  amounts: QuoteAmountsAndCosts
+  quoteResponse: OrderQuoteResponse
 ): LimitTradeParametersFromQuote {
   return {
     ...params,
-    sellAmount: amounts.afterSlippage.sellAmount.toString(),
-    buyAmount: amounts.afterSlippage.buyAmount.toString(),
-    quoteId,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    quoteId: quoteResponse.id!,
+    sellAmount: quoteResponse.quote.sellAmount,
+    buyAmount: quoteResponse.quote.buyAmount,
   }
 }
 


### PR DESCRIPTION
Fixes first issue from [the doc.](https://docs.google.com/document/d/1KvTXmYj-aCBPr-YzgHqIJfZnn6H3Q4EejVl27VdKTZs/edit?tab=t.0)

This change fixes both sell and buy orders.
It also fixes "Private Key example not working" issue.

Basically, I reverted this commit: https://github.com/cowprotocol/cow-sdk/pull/213/commits/718b2123fbb74856c3ddcecadd9ed8bbcb12b833

Unfortunately, I don't remember why I did this :( 
But obviuosly this logic is wrong, because it adds fees + slippage twice:
 - once in `swapParamsToLimitOrderParams`
 - and another one in `getOrderToSign` (getQuoteAmountsAndCosts call)

I compared the result with CoW Swap and it matches 100%.
How to test that:
1. Copy `quoteResponseMock` from unit test
2. Go to `apps/cowswap-frontend/src/api/cowProtocol/api.ts` in CoW Swap
3. Return the value of copied mock from `getQuote()` function
4. Open CoW Swap and setup a trade correspondingly to the mock
5. Init order signing
6. Compare sell and but amounts in the wallet with values in unit tests