### PR TITLE
fix(trading-sdk): hardcode has limit for setPreSignature

### DIFF
--- a/src/trading/getPreSignTransaction.test.ts
+++ b/src/trading/getPreSignTransaction.test.ts
@@ -45,11 +45,10 @@ describe('getPreSignTransaction', () => {
   signer.getChainId = jest.fn().mockResolvedValue(chainId)
   signer.getAddress = jest.fn().mockResolvedValue(account)
 
-  it('Should call gas estimation and return estimated value + 20%', async () => {
+  it('Gas limit should always be 50k', async () => {
     const result = await getPreSignTransaction(signer, chainId, account, orderId)
-    const gasNum = +GAS
 
-    expect(+result.gas).toBe(gasNum * 1.2)
+    expect(+result.gas).toBe(50_000)
   })
 
   it('Tx value should always be zero', async () => {


### PR DESCRIPTION
For presign transactions it is not necessary to use a wallet provider.
Because of that, provider might not support estimateGas method.
setPreSignature() call is static enough, and we can expect the same gas spending.
It usually takes 25700 gas, just in case I doubled it.

Example of gas usage: https://dashboard.tenderly.co/tx/sepolia/0x9ab158dcdb42f572f5bd829a1005547eb69bfd8fae8b1a2ecd910a9f78d2883d/gas-usage

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/e3ec4fdb-1f5d-48b8-b594-4c225af3a67a" />
