### PR TITLE
fix(trading-sdk): chane default order validity to 30min

### DIFF
--- a/src/trading/consts.ts
+++ b/src/trading/consts.ts
@@ -7,7 +7,7 @@ export function log(text: string) {
 
 log.enabled = false
 
-export const DEFAULT_QUOTE_VALIDITY = 60 * 10 // 10 min
+export const DEFAULT_QUOTE_VALIDITY = 60 * 30 // 30 min
 
 export const DEFAULT_SLIPPAGE_BPS = 50 // 0.5%
 

--- a/src/trading/postCoWProtocolTrade.test.ts
+++ b/src/trading/postCoWProtocolTrade.test.ts
@@ -124,7 +124,7 @@ describe('postCoWProtocolTrade', () => {
       receiver: '0x21c3de23d98caddc406e3d31b25e807addf33333',
       signature: '0x000a1',
       signingScheme: 'eip712',
-      validTo: 1487077308,
+      validTo: 1487078508,
     })
   })
 })


### PR DESCRIPTION
https://docs.google.com/document/d/1KvTXmYj-aCBPr-YzgHqIJfZnn6H3Q4EejVl27VdKTZs/edit?tab=t.0#heading=h.m2n3ppp9tinj

<img width="741" alt="image" src="https://github.com/user-attachments/assets/4b70102e-fe31-4a8c-a3b7-12d248b019a3" />
