### PR TITLE
fix(trading-sdk): fix eth-flow

### DIFF
--- a/src/composable/ConditionalOrder.ts
+++ b/src/composable/ConditionalOrder.ts
@@ -1,7 +1,7 @@
 import { BigNumber, constants, ethers, utils } from 'ethers'
 import { GPv2Order, IConditionalOrder } from '../common/generated/ComposableCoW'
 
-import { decodeParams, encodeParams, fromStructToOrder } from './utils'
+import { decodeParams, encodeParams, fromStructToOrder, getIsValidResult } from './utils'
 import {
   ConditionalOrderArguments,
   ConditionalOrderParams,
@@ -94,7 +94,7 @@ export abstract class ConditionalOrder<D, S> {
 
   assertIsValid(): void {
     const isValidResult = this.isValid()
-    if (!isValidResult.isValid) {
+    if (!getIsValidResult(isValidResult)) {
       throw new Error(`Invalid order: ${isValidResult.reason}`)
     }
   }
@@ -253,7 +253,7 @@ export abstract class ConditionalOrder<D, S> {
     try {
       const isValid = this.isValid()
       // Do a validation first
-      if (!isValid.isValid) {
+      if (!getIsValidResult(isValid)) {
         return {
           result: PollResultCode.DONT_TRY_AGAIN,
           reason: `InvalidConditionalOrder. Reason: ${isValid.reason}`,

--- a/src/composable/utils.ts
+++ b/src/composable/utils.ts
@@ -5,7 +5,7 @@ import {
   SupportedChainId,
 } from '../common'
 import { ExtensibleFallbackHandler__factory } from '../common/generated'
-import { BlockInfo, ConditionalOrderParams } from './types'
+import { BlockInfo, ConditionalOrderParams, IsValid, IsValidResult } from './types'
 import { Order, OrderBalance, OrderKind } from '@cowprotocol/contracts'
 import { GPv2Order } from '../common/generated/ComposableCoW'
 
@@ -162,4 +162,8 @@ export function fromStructToOrder(order: GPv2Order.DataStruct): Order {
     sellTokenBalance: balanceToString(sellTokenBalance.toString()),
     buyTokenBalance: balanceToString(buyTokenBalance.toString()),
   }
+}
+
+export function getIsValidResult(result: IsValidResult): result is IsValid {
+  return result.isValid
 }

--- a/src/trading/getEthFlowTransaction.test.ts
+++ b/src/trading/getEthFlowTransaction.test.ts
@@ -33,12 +33,12 @@ jest.mock('../common/generated', () => {
 import { getEthFlowTransaction } from './getEthFlowTransaction'
 import { VoidSigner } from '@ethersproject/abstract-signer'
 import { SupportedChainId, WRAPPED_NATIVE_CURRENCIES } from '../common'
-import { LimitTradeParameters } from './types'
+import { LimitTradeParametersFromQuote } from './types'
 import { OrderKind } from '../order-book'
 
 const appDataKeccak256 = '0x578c975b1cfd3e24c21fb599076c4f7879c4268efd33eed3eb9efa5e30efac21'
 
-const params: LimitTradeParameters = {
+const params: LimitTradeParametersFromQuote = {
   kind: OrderKind.SELL,
   sellToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   buyToken: '0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab',
@@ -58,7 +58,7 @@ describe('getEthFlowTransaction', () => {
   signer.getAddress = jest.fn().mockResolvedValue(account)
 
   it('Should always override sell token with wrapped native token', async () => {
-    const result = await getEthFlowTransaction(signer, appDataKeccak256, params)
+    const result = await getEthFlowTransaction(signer, appDataKeccak256, params, chainId)
     const wrappedToken = WRAPPED_NATIVE_CURRENCIES[chainId]
 
     expect(result.transaction.data.includes(params.sellToken.slice(2))).toBe(false)
@@ -66,14 +66,14 @@ describe('getEthFlowTransaction', () => {
   })
 
   it('Should call gas estimation and return estimated value + 20%', async () => {
-    const result = await getEthFlowTransaction(signer, appDataKeccak256, params)
+    const result = await getEthFlowTransaction(signer, appDataKeccak256, params, chainId)
     const gasNum = +GAS
 
-    expect(+result.transaction.gas).toBe(gasNum + gasNum * 0.2)
+    expect(+result.transaction.gasLimit).toBe(gasNum + gasNum * 0.2)
   })
 
   it('Transaction value should be equal to sell amount', async () => {
-    const result = await getEthFlowTransaction(signer, appDataKeccak256, params)
+    const result = await getEthFlowTransaction(signer, appDataKeccak256, params, chainId)
 
     expect(result.transaction.value).toBe('0x' + BigInt(params.sellAmount).toString(16))
   })

--- a/src/trading/getEthFlowTransaction.ts
+++ b/src/trading/getEthFlowTransaction.ts
@@ -18,10 +18,10 @@ export async function getEthFlowTransaction(
   signer: Signer,
   appDataKeccak256: string,
   _params: LimitTradeParametersFromQuote,
+  chainId: SupportedChainId,
   networkCostsAmount = '0',
   checkEthFlowOrderExists?: EthFlowOrderExistsCallback
 ): Promise<{ orderId: string; transaction: TransactionParams }> {
-  const chainId = (await signer.getChainId()) as SupportedChainId
   const from = await signer.getAddress()
 
   const params = {
@@ -56,7 +56,7 @@ export async function getEthFlowTransaction(
     orderId,
     transaction: {
       data,
-      gas: '0x' + calculateGasMargin(estimatedGas).toString(16),
+      gasLimit: '0x' + calculateGasMargin(estimatedGas).toString(16),
       to: contract.address,
       value: '0x' + BigInt(orderToSign.sellAmount).toString(16),
     },

--- a/src/trading/getPreSignTransaction.test.ts
+++ b/src/trading/getPreSignTransaction.test.ts
@@ -49,7 +49,7 @@ describe('getPreSignTransaction', () => {
     const result = await getPreSignTransaction(signer, chainId, account, orderId)
     const gasNum = +GAS
 
-    expect(+result.gas).toBe(gasNum * 1.2)
+    expect(+result.gasLimit).toBe(gasNum * 1.2)
   })
 
   it('Tx value should always be zero', async () => {

--- a/src/trading/getPreSignTransaction.ts
+++ b/src/trading/getPreSignTransaction.ts
@@ -28,7 +28,7 @@ export async function getPreSignTransaction(
 
   return {
     data: preSignatureCall,
-    gas: '0x' + calculateGasMargin(gas).toString(16),
+    gasLimit: '0x' + calculateGasMargin(gas).toString(16),
     to: settlementContractAddress,
     value: '0',
   }

--- a/src/trading/postSellNativeCurrencyOrder.test.ts
+++ b/src/trading/postSellNativeCurrencyOrder.test.ts
@@ -122,7 +122,7 @@ describe('postSellNativeCurrencyTrade', () => {
 
     const call = (signer.sendTransaction as jest.Mock).mock.calls[0][0]
 
-    expect(+call.gas).toBe(180000) // 150000 by default + 20%
+    expect(+call.gasLimit).toBe(180000) // 150000 by default + 20%
   })
 
   it('Should create an on-chain transaction with all specified parameters', async () => {

--- a/src/trading/postSellNativeCurrencyOrder.test.ts
+++ b/src/trading/postSellNativeCurrencyOrder.test.ts
@@ -53,7 +53,10 @@ const callData = '0x123456'
 const currentTimestamp = 1487076708000
 
 const uploadAppDataMock = jest.fn()
-const orderBookApiMock = { uploadAppData: uploadAppDataMock } as unknown as OrderBookApi
+const orderBookApiMock = {
+  uploadAppData: uploadAppDataMock,
+  context: { chainId: SupportedChainId.GNOSIS_CHAIN },
+} as unknown as OrderBookApi
 const appDataMock = {
   appDataKeccak256: '0xaf1908d8e30f63bf4a6dbd41d2191eb092ac0af626b37c720596426130717658',
   fullAppData:

--- a/src/trading/postSellNativeCurrencyOrder.ts
+++ b/src/trading/postSellNativeCurrencyOrder.ts
@@ -20,6 +20,7 @@ export async function postSellNativeCurrencyOrder(
     signer,
     appDataKeccak256,
     _params,
+    orderBookApi.context.chainId,
     networkCostsAmount,
     checkEthFlowOrderExists
   )

--- a/src/trading/tradingSdk.ts
+++ b/src/trading/tradingSdk.ts
@@ -10,7 +10,7 @@ import { postSwapOrder, postSwapOrderFromQuote } from './postSwapOrder'
 import { postLimitOrder } from './postLimitOrder'
 import { getQuoteWithSigner } from './getQuote'
 import { postSellNativeCurrencyOrder } from './postSellNativeCurrencyOrder'
-import { getSigner, swapParamsToLimitOrderParams } from './utils'
+import { getSigner, getTradeParametersAfterQuote, swapParamsToLimitOrderParams } from './utils'
 import { getPreSignTransaction } from './getPreSignTransaction'
 import { log } from './consts'
 import { OrderBookApi } from '../order-book'
@@ -35,7 +35,17 @@ export class TradingSdk {
 
     return {
       quoteResults: quoteResults.result,
-      postSwapOrderFromQuote: () => postSwapOrderFromQuote(quoteResults),
+      postSwapOrderFromQuote: () =>
+        postSwapOrderFromQuote({
+          ...quoteResults,
+          result: {
+            ...quoteResults.result,
+            tradeParameters: getTradeParametersAfterQuote({
+              quoteParameters: quoteResults.result.tradeParameters,
+              orderParameters: params,
+            }),
+          },
+        }),
     }
   }
 
@@ -60,7 +70,10 @@ export class TradingSdk {
       quoteResults.result.appDataInfo,
       // Quote response response always has an id
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      swapParamsToLimitOrderParams(tradeParameters, quoteResponse)
+      swapParamsToLimitOrderParams(
+        getTradeParametersAfterQuote({ quoteParameters: tradeParameters, orderParameters: params }),
+        quoteResponse
+      )
     )
   }
 

--- a/src/trading/types.ts
+++ b/src/trading/types.ts
@@ -160,7 +160,7 @@ export interface AppDataInfo {
  */
 export interface TransactionParams {
   data: string
-  gas: string
+  gasLimit: string
   to: string
   value: string
 }

--- a/src/trading/utils.ts
+++ b/src/trading/utils.ts
@@ -76,3 +76,17 @@ export function mapQuoteAmountsAndCosts<T, R>(
     afterSlippage: serializeAmounts(value.afterSlippage),
   }
 }
+
+/**
+ * Set sell token to the initial one
+ * Because for ETH-flow orders we do quote requests with wrapped token
+ */
+export function getTradeParametersAfterQuote({
+  quoteParameters,
+  orderParameters,
+}: {
+  quoteParameters: TradeParameters
+  orderParameters: TradeParameters
+}): TradeParameters {
+  return { ...quoteParameters, sellToken: orderParameters.sellToken }
+}


### PR DESCRIPTION
Fixes https://docs.google.com/document/d/1KvTXmYj-aCBPr-YzgHqIJfZnn6H3Q4EejVl27VdKTZs/edit?tab=t.0#heading=h.e68ykbfkaz2q

Three problems were fixed:
1. `sellToken` parameter needs to be replaced by wrapped ETH when we make a quote request for eth-flow. But after getting a quote it must be put back to ETH address. Because of that I've added `getTradeParametersAfterQuote()` function
2. `gas` -> `gasLimit` renaming
3. Added `chainId` parameter to `getEthFlowTransaction` function because a signer might be just a private key, which doesn't provide `getChainId()` method

# Testing
1. Go to `examples/vanilla` and run `yarn start`
2. Connect a wallet and setup a trade like on the picture bellow
3. Click "Get quote"
4. Click "Send order"
- [ ] eth-flow order must be created corresponding to input

<img width="1069" alt="image" src="https://github.com/user-attachments/assets/010625bb-82c7-481d-8584-78b470d984bd" />
