### PR TITLE
feat(trading-sdk): set default slippage 2% for eth selling

### DIFF
--- a/src/trading/consts.ts
+++ b/src/trading/consts.ts
@@ -10,6 +10,7 @@ log.enabled = false
 export const DEFAULT_QUOTE_VALIDITY = 60 * 30 // 30 min
 
 export const DEFAULT_SLIPPAGE_BPS = 50 // 0.5%
+export const ETH_FLOW_DEFAULT_SLIPPAGE_BPS = 200 // 2%
 
 export const SIGN_SCHEME_MAP = {
   [EcdsaSigningScheme.EIP712]: SigningScheme.EIP712,

--- a/src/trading/getEthFlowTransaction.test.ts
+++ b/src/trading/getEthFlowTransaction.test.ts
@@ -1,4 +1,13 @@
 const GAS = '0x1e848' // 125000
+const mockConnect = {
+  address: '0xaa1',
+  estimateGas: {
+    createOrder: jest.fn().mockResolvedValue({ toHexString: () => GAS }),
+  },
+  interface: {
+    encodeFunctionData: jest.fn().mockReturnValue('0x0ac'),
+  },
+}
 
 jest.mock('cross-fetch', () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -17,15 +26,7 @@ jest.mock('../common/generated', () => {
   return {
     ...original,
     EthFlow__factory: {
-      connect: jest.fn().mockReturnValue({
-        address: '0xaa1',
-        estimateGas: {
-          createOrder: jest.fn().mockResolvedValue({ toHexString: () => GAS }),
-        },
-        interface: {
-          encodeFunctionData: jest.fn().mockReturnValue('0x0ac'),
-        },
-      }),
+      connect: jest.fn().mockImplementation(() => mockConnect),
     },
   }
 })
@@ -57,6 +58,10 @@ describe('getEthFlowTransaction', () => {
   signer.getChainId = jest.fn().mockResolvedValue(chainId)
   signer.getAddress = jest.fn().mockResolvedValue(account)
 
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it('Should always override sell token with wrapped native token', async () => {
     const result = await getEthFlowTransaction(signer, appDataKeccak256, params, chainId)
     const wrappedToken = WRAPPED_NATIVE_CURRENCIES[chainId]
@@ -76,5 +81,15 @@ describe('getEthFlowTransaction', () => {
     const result = await getEthFlowTransaction(signer, appDataKeccak256, params, chainId)
 
     expect(result.transaction.value).toBe('0x' + BigInt(params.sellAmount).toString(16))
+  })
+
+  it('Default slippage must be 2%', async () => {
+    await getEthFlowTransaction(signer, appDataKeccak256, params, chainId)
+    const orderData = mockConnect.interface.encodeFunctionData.mock.calls[0][1][0]
+    const buyAmountBeforeSlippage = BigInt(params.buyAmount)
+    // 2% slippage
+    const buyAmountAfterSlippage = buyAmountBeforeSlippage - (buyAmountBeforeSlippage * BigInt(2)) / BigInt(100)
+
+    expect(orderData.buyAmount).toBe(buyAmountAfterSlippage.toString())
   })
 })

--- a/src/trading/getEthFlowTransaction.ts
+++ b/src/trading/getEthFlowTransaction.ts
@@ -3,16 +3,10 @@ import { LimitTradeParametersFromQuote, TransactionParams } from './types'
 import { calculateUniqueOrderId, EthFlowOrderExistsCallback } from './calculateUniqueOrderId'
 import { getOrderToSign } from './getOrderToSign'
 import { type EthFlow, EthFlow__factory } from '../common/generated'
-import {
-  BARN_ETH_FLOW_ADDRESSES,
-  CowEnv,
-  ETH_FLOW_ADDRESSES,
-  SupportedChainId,
-  WRAPPED_NATIVE_CURRENCIES,
-} from '../common'
+import { BARN_ETH_FLOW_ADDRESSES, CowEnv, ETH_FLOW_ADDRESSES, SupportedChainId } from '../common'
 import { GAS_LIMIT_DEFAULT } from './consts'
 import type { EthFlowOrder } from '../common/generated/EthFlow'
-import { calculateGasMargin } from './utils'
+import { adjustEthFlowOrderParams, calculateGasMargin } from './utils'
 
 export async function getEthFlowTransaction(
   signer: Signer,
@@ -26,7 +20,7 @@ export async function getEthFlowTransaction(
 
   const params = {
     ..._params,
-    sellToken: WRAPPED_NATIVE_CURRENCIES[chainId],
+    ...adjustEthFlowOrderParams(chainId, _params),
   }
   const { quoteId } = params
 

--- a/src/trading/getQuote.ts
+++ b/src/trading/getQuote.ts
@@ -19,9 +19,8 @@ import {
 } from '../order-book'
 import { buildAppData } from './appDataUtils'
 import { getOrderToSign } from './getOrderToSign'
-import { getIsEthFlowOrder, getSigner, swapParamsToLimitOrderParams } from './utils'
+import { adjustEthFlowOrderParams, getIsEthFlowOrder, getSigner, swapParamsToLimitOrderParams } from './utils'
 import { Signer } from 'ethers'
-import { WRAPPED_NATIVE_CURRENCIES } from '../common'
 import { getOrderTypedData } from './getOrderTypedData'
 
 // ETH-FLOW orders require different quote params
@@ -48,7 +47,7 @@ export async function getQuote(
   const tradeParameters = isEthFlow
     ? {
         ..._tradeParameters,
-        sellToken: WRAPPED_NATIVE_CURRENCIES[chainId],
+        ...adjustEthFlowOrderParams(chainId, _tradeParameters),
       }
     : _tradeParameters
 

--- a/src/trading/utils.ts
+++ b/src/trading/utils.ts
@@ -1,8 +1,9 @@
 import { LimitTradeParametersFromQuote, PrivateKey, TradeParameters } from './types'
 import { OrderQuoteResponse, QuoteAmountsAndCosts } from '../order-book'
-import { ETH_ADDRESS } from '../common'
+import { ETH_ADDRESS, SupportedChainId, WRAPPED_NATIVE_CURRENCIES } from '../common'
 import { ethers, Signer } from 'ethers'
 import { type ExternalProvider, Web3Provider } from '@ethersproject/providers'
+import { ETH_FLOW_DEFAULT_SLIPPAGE_BPS } from './consts'
 
 export function swapParamsToLimitOrderParams(
   params: TradeParameters,
@@ -89,4 +90,20 @@ export function getTradeParametersAfterQuote({
   orderParameters: TradeParameters
 }): TradeParameters {
   return { ...quoteParameters, sellToken: orderParameters.sellToken }
+}
+
+/**
+ * ETH-flow orders are special and need to be adjusted
+ * 1. Sell token should be the wrapped native currency
+ * 2. Default slippage is 2%
+ */
+export function adjustEthFlowOrderParams(
+  chainId: SupportedChainId,
+  params: TradeParameters | LimitTradeParametersFromQuote
+): typeof params {
+  return {
+    ...params,
+    sellToken: WRAPPED_NATIVE_CURRENCIES[chainId],
+    slippageBps: typeof params.slippageBps === 'number' ? params.slippageBps : ETH_FLOW_DEFAULT_SLIPPAGE_BPS,
+  }
 }


### PR DESCRIPTION
Eth-flow orders are special and need higher slippage (2%)