### PR TITLE
refactor: remove duplication for mocking fetch

### DIFF
--- a/setupTests.js
+++ b/setupTests.js
@@ -1,7 +1,15 @@
-import fetchMock from 'jest-fetch-mock'
+jest.mock('cross-fetch', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const fetchMock = require('jest-fetch-mock')
 
-fetchMock.enableMocks()
+  // Require the original module to not be mocked...
+  const originalFetch = jest.requireActual('cross-fetch')
 
-jest.setMock('cross-fetch', fetchMock)
+  return {
+    __esModule: true,
+    ...originalFetch,
+    default: fetchMock,
+  }
+})
 
 global.window = global

--- a/src/order-book/api.spec.ts
+++ b/src/order-book/api.spec.ts
@@ -1,15 +1,3 @@
-jest.mock('cross-fetch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fetchMock = require('jest-fetch-mock')
-  // Require the original module to not be mocked...
-  const originalFetch = jest.requireActual('cross-fetch')
-  return {
-    __esModule: true,
-    ...originalFetch,
-    default: fetchMock,
-  }
-})
-
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 import { CowError } from '../common/types/cow-error'
 import { OrderBookApi } from './api'

--- a/src/order-signing/orderSigningUtils.spec.ts
+++ b/src/order-signing/orderSigningUtils.spec.ts
@@ -1,15 +1,3 @@
-jest.mock('cross-fetch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fetchMock = require('jest-fetch-mock')
-  // Require the original module to not be mocked...
-  const originalFetch = jest.requireActual('cross-fetch')
-  return {
-    __esModule: true,
-    ...originalFetch,
-    default: fetchMock,
-  }
-})
-
 import { OrderSigningUtils } from './orderSigningUtils'
 import { SupportedChainId } from '../common'
 import { UnsignedOrder } from './types'

--- a/src/trading/getEthFlowTransaction.test.ts
+++ b/src/trading/getEthFlowTransaction.test.ts
@@ -9,17 +9,6 @@ const mockConnect = {
   },
 }
 
-jest.mock('cross-fetch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fetchMock = require('jest-fetch-mock')
-  // Require the original module to not be mocked...
-  const originalFetch = jest.requireActual('cross-fetch')
-  return {
-    __esModule: true,
-    ...originalFetch,
-    default: fetchMock,
-  }
-})
 jest.mock('../common/generated', () => {
   const original = jest.requireActual('../common/generated')
 

--- a/src/trading/getOrderToSign.test.ts
+++ b/src/trading/getOrderToSign.test.ts
@@ -1,15 +1,3 @@
-jest.mock('cross-fetch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fetchMock = require('jest-fetch-mock')
-  // Require the original module to not be mocked...
-  const originalFetch = jest.requireActual('cross-fetch')
-  return {
-    __esModule: true,
-    ...originalFetch,
-    default: fetchMock,
-  }
-})
-
 import { getOrderToSign } from './getOrderToSign'
 import { LimitOrderParameters } from './types'
 import { SupportedChainId } from '../common'

--- a/src/trading/getPreSignTransaction.test.ts
+++ b/src/trading/getPreSignTransaction.test.ts
@@ -1,16 +1,5 @@
 const GAS = '0x1e848' // 125000
 
-jest.mock('cross-fetch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fetchMock = require('jest-fetch-mock')
-  // Require the original module to not be mocked...
-  const originalFetch = jest.requireActual('cross-fetch')
-  return {
-    __esModule: true,
-    ...originalFetch,
-    default: fetchMock,
-  }
-})
 jest.mock('../common/generated', () => {
   const original = jest.requireActual('../common/generated')
 

--- a/src/trading/getQuote.test.ts
+++ b/src/trading/getQuote.test.ts
@@ -4,18 +4,6 @@ import { SwapParameters } from './types'
 import { ETH_ADDRESS, SupportedChainId, WRAPPED_NATIVE_CURRENCIES } from '../common'
 import { OrderBookApi, OrderKind, OrderQuoteResponse } from '../order-book'
 
-jest.mock('cross-fetch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fetchMock = require('jest-fetch-mock')
-  // Require the original module to not be mocked...
-  const originalFetch = jest.requireActual('cross-fetch')
-  return {
-    __esModule: true,
-    ...originalFetch,
-    default: fetchMock,
-  }
-})
-
 const quoteResponseMock = {
   quote: {
     sellToken: '0xfff9976782d46cc05630d1f6ebab18b2324d6b14',

--- a/src/trading/postCoWProtocolTrade.test.ts
+++ b/src/trading/postCoWProtocolTrade.test.ts
@@ -1,15 +1,3 @@
-jest.mock('cross-fetch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fetchMock = require('jest-fetch-mock')
-  // Require the original module to not be mocked...
-  const originalFetch = jest.requireActual('cross-fetch')
-  return {
-    __esModule: true,
-    ...originalFetch,
-    default: fetchMock,
-  }
-})
-
 jest.mock('../order-signing', () => {
   return {
     OrderSigningUtils: {

--- a/src/trading/postLimitOrder.test.ts
+++ b/src/trading/postLimitOrder.test.ts
@@ -1,15 +1,3 @@
-jest.mock('cross-fetch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fetchMock = require('jest-fetch-mock')
-  // Require the original module to not be mocked...
-  const originalFetch = jest.requireActual('cross-fetch')
-  return {
-    __esModule: true,
-    ...originalFetch,
-    default: fetchMock,
-  }
-})
-
 jest.mock('./postCoWProtocolTrade', () => {
   return {
     postCoWProtocolTrade: jest.fn(),

--- a/src/trading/postSellNativeCurrencyOrder.test.ts
+++ b/src/trading/postSellNativeCurrencyOrder.test.ts
@@ -6,18 +6,6 @@ import { OrderBookApi, OrderKind } from '../order-book'
 import { postSellNativeCurrencyOrder } from './postSellNativeCurrencyOrder'
 import { WRAPPED_NATIVE_CURRENCIES } from '../common'
 
-jest.mock('cross-fetch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fetchMock = require('jest-fetch-mock')
-  // Require the original module to not be mocked...
-  const originalFetch = jest.requireActual('cross-fetch')
-  return {
-    __esModule: true,
-    ...originalFetch,
-    default: fetchMock,
-  }
-})
-
 jest.mock('../common/generated', () => {
   const original = jest.requireActual('../common/generated')
 

--- a/src/trading/postSwapOrder.test.ts
+++ b/src/trading/postSwapOrder.test.ts
@@ -1,17 +1,5 @@
 import { getQuoteWithSigner } from './getQuote'
 
-jest.mock('cross-fetch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fetchMock = require('jest-fetch-mock')
-  // Require the original module to not be mocked...
-  const originalFetch = jest.requireActual('cross-fetch')
-  return {
-    __esModule: true,
-    ...originalFetch,
-    default: fetchMock,
-  }
-})
-
 import { postSwapOrderFromQuote } from './postSwapOrder'
 import { SwapParameters } from './types'
 import { OrderKind } from '../order-book'

--- a/src/trading/tradingSdk.test.ts
+++ b/src/trading/tradingSdk.test.ts
@@ -1,14 +1,3 @@
-jest.mock('cross-fetch', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fetchMock = require('jest-fetch-mock')
-  // Require the original module to not be mocked...
-  const originalFetch = jest.requireActual('cross-fetch')
-  return {
-    __esModule: true,
-    ...originalFetch,
-    default: fetchMock,
-  }
-})
 import { TradingSdk } from './tradingSdk'
 import { SupportedChainId } from '../common'
 import { TradeBaseParameters } from './types'


### PR DESCRIPTION
This PR tries to reduce the duplication on the mocking of `cross-fetch` library, that is done in  many unit tests.

This moves the mocking to the global setup of the tests, and removes the previous setup.

# Test
test should pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test configurations for network requests by removing redundant custom mocks.
  - Streamlined the test environment to rely on default behaviors, enhancing consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->