### PR TITLE
feat: allow to specify the owner address

### DIFF
--- a/src/trading/getQuote.test.ts
+++ b/src/trading/getQuote.test.ts
@@ -5,11 +5,12 @@ import { ETH_ADDRESS, WRAPPED_NATIVE_CURRENCIES } from '../common'
 import { SupportedChainId } from '../chains'
 import { OrderBookApi, OrderKind, OrderQuoteResponse } from '../order-book'
 
+const signerAddress = '0x0236554f17Eff6F49fF7e56cF3676a2d6F2B8601'
 const quoteResponseMock = {
   quote: {
     sellToken: '0xfff9976782d46cc05630d1f6ebab18b2324d6b14',
     buyToken: '0x0625afb445c3b6b7b929342a04a22599fd5dbb59',
-    receiver: '0xfb3c7eb936caa12b5a884d612393969a557d4307',
+    receiver: signerAddress,
     sellAmount: '98115217044683860',
     buyAmount: '984440000000',
     validTo: 1731059375,
@@ -23,7 +24,7 @@ const quoteResponseMock = {
     buyTokenBalance: 'erc20',
     signingScheme: 'eip712',
   },
-  from: '0xfb3c7eb936caa12b5a884d612393969a557d4307',
+  from: signerAddress,
   expiration: '2024-11-08T09:21:35.442772888Z',
   id: 486289,
   verified: true,
@@ -50,7 +51,12 @@ const orderBookApiMock = {
 describe('getQuoteToSign', () => {
   beforeEach(() => {
     getQuoteMock.mockReset()
-    getQuoteMock.mockResolvedValue(quoteResponseMock)
+    getQuoteMock.mockImplementation((params) => {
+      return {
+        ...quoteResponseMock,
+        from: params.from,
+      }
+    })
   })
 
   describe('App data', () => {
@@ -147,6 +153,36 @@ describe('getQuoteToSign', () => {
       const call = getQuoteMock.mock.calls[0][0]
 
       expect(call.onchainOrder).toEqual({ foo: 'bar' })
+    })
+
+    it.only('should use the signer as the default owner', async () => {
+      const quoteRequest: SwapParameters = {
+        ...defaultOrderParams,
+        owner: undefined,
+      }
+
+      // Call getQuote with the request
+      const result = await getQuoteWithSigner(quoteRequest, {}, orderBookApiMock)
+
+      // Verify the owner is undefined, and therefore the quote response has the signer address
+      expect(result.result.tradeParameters.owner).toBe(undefined)
+      expect(result.result.quoteResponse.from).toBe(signerAddress)
+    })
+
+    it('should allow to override the owner', async () => {
+      const ownerAddress = '0x1234567890123456789012345678901234567890'
+      const quoteRequest: SwapParameters = {
+        ...defaultOrderParams,
+        owner: ownerAddress,
+      }
+
+      // Call getQuote with the request
+      const result = await getQuoteWithSigner(quoteRequest, {}, orderBookApiMock)
+
+      // Verify the owner in the quote response is the expected owner
+      expect(result.result.tradeParameters.owner).toBe(ownerAddress)
+      expect(result.result.quoteResponse.from).toBe(ownerAddress)
+      expect(result.result.quoteResponse.from).not.toBe(signerAddress)
     })
   })
 

--- a/src/trading/getQuote.test.ts
+++ b/src/trading/getQuote.test.ts
@@ -5,12 +5,11 @@ import { ETH_ADDRESS, WRAPPED_NATIVE_CURRENCIES } from '../common'
 import { SupportedChainId } from '../chains'
 import { OrderBookApi, OrderKind, OrderQuoteResponse } from '../order-book'
 
-const signerAddress = '0x0236554f17Eff6F49fF7e56cF3676a2d6F2B8601'
 const quoteResponseMock = {
   quote: {
     sellToken: '0xfff9976782d46cc05630d1f6ebab18b2324d6b14',
     buyToken: '0x0625afb445c3b6b7b929342a04a22599fd5dbb59',
-    receiver: signerAddress,
+    receiver: '0xfb3c7eb936caa12b5a884d612393969a557d4307',
     sellAmount: '98115217044683860',
     buyAmount: '984440000000',
     validTo: 1731059375,
@@ -24,7 +23,7 @@ const quoteResponseMock = {
     buyTokenBalance: 'erc20',
     signingScheme: 'eip712',
   },
-  from: signerAddress,
+  from: '0xfb3c7eb936caa12b5a884d612393969a557d4307',
   expiration: '2024-11-08T09:21:35.442772888Z',
   id: 486289,
   verified: true,
@@ -51,12 +50,7 @@ const orderBookApiMock = {
 describe('getQuoteToSign', () => {
   beforeEach(() => {
     getQuoteMock.mockReset()
-    getQuoteMock.mockImplementation((params) => {
-      return {
-        ...quoteResponseMock,
-        from: params.from,
-      }
-    })
+    getQuoteMock.mockResolvedValue(quoteResponseMock)
   })
 
   describe('App data', () => {
@@ -153,36 +147,6 @@ describe('getQuoteToSign', () => {
       const call = getQuoteMock.mock.calls[0][0]
 
       expect(call.onchainOrder).toEqual({ foo: 'bar' })
-    })
-
-    it.only('should use the signer as the default owner', async () => {
-      const quoteRequest: SwapParameters = {
-        ...defaultOrderParams,
-        owner: undefined,
-      }
-
-      // Call getQuote with the request
-      const result = await getQuoteWithSigner(quoteRequest, {}, orderBookApiMock)
-
-      // Verify the owner is undefined, and therefore the quote response has the signer address
-      expect(result.result.tradeParameters.owner).toBe(undefined)
-      expect(result.result.quoteResponse.from).toBe(signerAddress)
-    })
-
-    it('should allow to override the owner', async () => {
-      const ownerAddress = '0x1234567890123456789012345678901234567890'
-      const quoteRequest: SwapParameters = {
-        ...defaultOrderParams,
-        owner: ownerAddress,
-      }
-
-      // Call getQuote with the request
-      const result = await getQuoteWithSigner(quoteRequest, {}, orderBookApiMock)
-
-      // Verify the owner in the quote response is the expected owner
-      expect(result.result.tradeParameters.owner).toBe(ownerAddress)
-      expect(result.result.quoteResponse.from).toBe(ownerAddress)
-      expect(result.result.quoteResponse.from).not.toBe(signerAddress)
     })
   })
 

--- a/src/trading/getQuote.ts
+++ b/src/trading/getQuote.ts
@@ -137,11 +137,12 @@ export async function getQuoteWithSigner(
   orderBookApi?: OrderBookApi
 ): Promise<QuoteResultsWithSigner> {
   const signer = getSigner(swapParameters.signer)
+  const account = swapParameters.owner || ((await getSigner(swapParameters.signer).getAddress()) as AccountAddress)
 
   const trader = {
     chainId: swapParameters.chainId,
     appCode: swapParameters.appCode,
-    account: (await signer.getAddress()) as AccountAddress,
+    account,
   }
 
   const result = await getQuote(swapParameters, trader, advancedSettings, orderBookApi)

--- a/src/trading/getQuote.ts
+++ b/src/trading/getQuote.ts
@@ -14,9 +14,9 @@ import { buildAppData } from './appDataUtils'
 import { getOrderToSign } from './getOrderToSign'
 import { adjustEthFlowOrderParams, getIsEthFlowOrder, swapParamsToLimitOrderParams } from './utils'
 import { Signer } from 'ethers'
-import { AccountAddress } from '../common'
 import { getOrderTypedData } from './getOrderTypedData'
 import { getSigner } from '../common/utils/wallet'
+import { AccountAddress } from 'src/common'
 
 // ETH-FLOW orders require different quote params
 // check the isEthFlow flag and set in quote req obj
@@ -137,9 +137,9 @@ export async function getQuoteWithSigner(
   orderBookApi?: OrderBookApi
 ): Promise<QuoteResultsWithSigner> {
   const signer = getSigner(swapParameters.signer)
-  const account = swapParameters.owner || ((await getSigner(swapParameters.signer).getAddress()) as AccountAddress)
+  const account = swapParameters.owner || ((await signer.getAddress()) as AccountAddress)
 
-  const trader = {
+  const trader: QuoterParameters = {
     chainId: swapParameters.chainId,
     appCode: swapParameters.appCode,
     account,

--- a/src/trading/postCoWProtocolTrade.test.ts
+++ b/src/trading/postCoWProtocolTrade.test.ts
@@ -116,4 +116,22 @@ describe('postCoWProtocolTrade', () => {
       validTo: 1487078508,
     })
   })
+
+  it('should use owner address as "from" parameter in sendOrder', async () => {
+    const ownerAddress = '0x1234567890123456789012345678901234567890'
+    const order: LimitOrderParameters = {
+      ...defaultOrderParams,
+      owner: ownerAddress,
+    }
+
+    await postCoWProtocolTrade(orderBookApiMock, signer, appDataMock, order)
+
+    // Verify the from parameter matches the owner address
+    expect(sendOrderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: ownerAddress,
+        receiver: ownerAddress,
+      })
+    )
+  })
 })

--- a/src/trading/postCoWProtocolTrade.ts
+++ b/src/trading/postCoWProtocolTrade.ts
@@ -33,11 +33,11 @@ export async function postCoWProtocolTrade(
     }
   }
 
-  const { quoteId = null } = params
+  const { quoteId = null, owner } = params
   const { appDataKeccak256, fullAppData } = appData
 
   const chainId = orderBookApi.context.chainId
-  const from = await signer.getAddress()
+  const from = owner || (await signer.getAddress())
   const orderToSign = getOrderToSign({ from, networkCostsAmount }, params, appData.appDataKeccak256)
 
   log('Signing order...')

--- a/src/trading/types.ts
+++ b/src/trading/types.ts
@@ -48,6 +48,7 @@ export interface OrderTypedData {
  */
 export interface TradeBaseParameters {
   kind: OrderKind
+  owner?: AccountAddress
   sellToken: OrderParameters['sellToken']
   sellTokenDecimals: number
   buyToken: OrderParameters['buyToken']


### PR DESCRIPTION
This PR adds an additional parameter to specify the owner of the order. 

Before, the owner would be implicitly using the signer account. The owner is not necessarily the signer, for example, in a multisig transaction.

To be fair, the SDK did allow to pass the owner, although it was not very intuitive how to pass it, and wouldn't allow to pass it in all methods. 

Before you could pass the owner in the override of the quoteRequest:
```
const quote = await sdk.getQuote(parameters, {
    quoteRequest: {
      from: "0x79063d9173C09887d536924E2F6eADbaBAc099f5",
      signingScheme: SigningScheme.PRESIGN,      
    },
  });
```

Now is an optional parameter of the trade parameters, which should be more intuitive.
```
const quote = await sdk.getQuote({
   owner: "0x79063d9173C09887d536924E2F6eADbaBAc099f5"
}});
```

# Test
You can run the tests. I added a few tests to assert the if you specify the owner, its used and that the change is backwards compatible (it defaults to use the signer address)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Trades now support an optional owner address, allowing orders to use a designated owner if provided; otherwise, they default to the standard signer.
  
- **Tests**
	- Enhanced test coverage confirms that orders correctly use the owner address when specified and fallback appropriately when not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->