### PR TITLE
feat(trading): allow changing TraderParameters in flight

### DIFF
--- a/src/trading/README.md
+++ b/src/trading/README.md
@@ -32,6 +32,7 @@ Main functions:
 - `getQuote` - Fetch a quote for a swap order.
 
 Special cases:
+- 'setTraderParams' - In case if you work with different chains and need to switch between them in runtime.
 - `postSellNativeCurrencyOrder` - Sell blockchain native tokens (e.g., ETH on Ethereum).
 - `getPreSignTransaction` - Sign an order using a smart contract wallet.
 

--- a/src/trading/tradingSdk.ts
+++ b/src/trading/tradingSdk.ts
@@ -23,12 +23,18 @@ interface TradingSdkOptions {
 
 export class TradingSdk {
   constructor(
-    public readonly traderParams: TraderParameters,
+    public traderParams: TraderParameters,
     public readonly options: Partial<TradingSdkOptions> = { enableLogging: false }
   ) {
     if (options.enableLogging) {
       log.enabled = true
     }
+  }
+
+  setTraderParams(params: Partial<TraderParameters>) {
+    this.traderParams = { ...this.traderParams, ...params }
+
+    return this
   }
 
   async getQuote(params: TradeParameters, advancedSettings?: SwapAdvancedSettings): Promise<QuoteAndPost> {


### PR DESCRIPTION
Since the SDK might be used in apps which work with different chains, we should provide a way to change network dynamically without creating another instance of the SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for updating trading parameters dynamically, enhancing flexibility in a multi-chain environment.

- **Documentation**
  - Added details about the new `setTraderParams` method in the trading guide, clarifying its functionality for managing trader parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->