### PR TITLE
feat(trading): optimize posting order additional parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "5.10.1",
+  "version": "5.10.2-RC.0",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/trading/appDataUtils.ts
+++ b/src/trading/appDataUtils.ts
@@ -2,16 +2,16 @@ import { AppDataInfo, AppDataRootSchema, BuildAppDataParams } from './types'
 import { AppDataParams, MetadataApi, stringifyDeterministic } from '@cowprotocol/app-data'
 import { keccak256, toUtf8Bytes } from 'ethers/lib/utils'
 
+const metadataApiSdk = new MetadataApi()
+
 export async function buildAppData(
   { slippageBps, appCode, orderClass: orderClassName, partnerFee }: BuildAppDataParams,
   advancedParams?: AppDataParams
 ): Promise<AppDataInfo> {
-  const metadataApiSDK = new MetadataApi()
-
   const quoteParams = { slippageBips: slippageBps }
   const orderClass = { orderClass: orderClassName }
 
-  const doc = await metadataApiSDK.generateAppDataDoc({
+  const doc = await metadataApiSdk.generateAppDataDoc({
     appCode,
     metadata: {
       quote: quoteParams,

--- a/src/trading/calculateUniqueOrderId.ts
+++ b/src/trading/calculateUniqueOrderId.ts
@@ -8,10 +8,7 @@ import {
 } from '../common'
 import { SupportedChainId } from '../chains'
 import type { Order, OrderBalance } from '@cowprotocol/contracts'
-
-export interface EthFlowOrderExistsCallback {
-  (orderId: string, orderDigest: string): Promise<boolean>
-}
+import { EthFlowOrderExistsCallback } from './types'
 
 export async function calculateUniqueOrderId(
   chainId: SupportedChainId,

--- a/src/trading/getEthFlowTransaction.ts
+++ b/src/trading/getEthFlowTransaction.ts
@@ -1,6 +1,6 @@
 import { Signer } from 'ethers'
-import { LimitTradeParametersFromQuote, TransactionParams } from './types'
-import { calculateUniqueOrderId, EthFlowOrderExistsCallback } from './calculateUniqueOrderId'
+import { LimitTradeParametersFromQuote, PostTradeAdditionalParams, TransactionParams } from './types'
+import { calculateUniqueOrderId } from './calculateUniqueOrderId'
 import { getOrderToSign } from './getOrderToSign'
 import { type EthFlow, EthFlow__factory } from '../common/generated'
 import { BARN_ETH_FLOW_ADDRESS, CowEnv, ETH_FLOW_ADDRESS } from '../common'
@@ -14,9 +14,9 @@ export async function getEthFlowTransaction(
   appDataKeccak256: string,
   _params: LimitTradeParametersFromQuote,
   chainId: SupportedChainId,
-  networkCostsAmount = '0',
-  checkEthFlowOrderExists?: EthFlowOrderExistsCallback
+  additionalParams: PostTradeAdditionalParams = {}
 ): Promise<{ orderId: string; transaction: TransactionParams }> {
+  const { networkCostsAmount = '0', checkEthFlowOrderExists } = additionalParams
   const from = await signer.getAddress()
 
   const params = {

--- a/src/trading/postCoWProtocolTrade.test.ts
+++ b/src/trading/postCoWProtocolTrade.test.ts
@@ -85,7 +85,7 @@ describe('postCoWProtocolTrade', () => {
     await postCoWProtocolTrade(orderBookApiMock, signer, appDataMock, order)
 
     expect(postSellNativeCurrencyOrderMock).toHaveBeenCalledTimes(1)
-    expect(postSellNativeCurrencyOrderMock).toHaveBeenCalledWith(orderBookApiMock, signer, appDataMock, order, '0')
+    expect(postSellNativeCurrencyOrderMock).toHaveBeenCalledWith(orderBookApiMock, signer, appDataMock, order, {})
   })
 
   it('API request should contain all specified parameters', async () => {

--- a/src/trading/postCoWProtocolTrade.ts
+++ b/src/trading/postCoWProtocolTrade.ts
@@ -1,6 +1,6 @@
 import { OrderBookApi, OrderCreation, SigningScheme } from '../order-book'
 import type { Signer } from 'ethers'
-import { AppDataInfo, LimitTradeParameters } from './types'
+import { AppDataInfo, LimitTradeParameters, PostTradeAdditionalParams } from './types'
 import { log, SIGN_SCHEME_MAP } from './consts'
 import { OrderSigningUtils } from '../order-signing'
 import { getOrderToSign } from './getOrderToSign'
@@ -12,9 +12,10 @@ export async function postCoWProtocolTrade(
   signer: Signer,
   appData: AppDataInfo,
   params: LimitTradeParameters,
-  networkCostsAmount = '0',
-  _signingScheme: SigningScheme = SigningScheme.EIP712
+  additionalParams: PostTradeAdditionalParams = {}
 ): Promise<string> {
+  const { networkCostsAmount = '0', signingScheme: _signingScheme = SigningScheme.EIP712 } = additionalParams
+
   if (getIsEthFlowOrder(params)) {
     const quoteId = params.quoteId
 
@@ -24,7 +25,7 @@ export async function postCoWProtocolTrade(
         signer,
         appData,
         { ...params, quoteId },
-        networkCostsAmount
+        additionalParams
       )
 
       return orderId

--- a/src/trading/postLimitOrder.test.ts
+++ b/src/trading/postLimitOrder.test.ts
@@ -61,7 +61,7 @@ describe('postLimitOrder', () => {
   it('Should add advanced appData parameters', async () => {
     const advancedData = { appData: { environment: 'sandbox' } }
 
-    await postLimitOrder(defaultOrderParams, advancedData, orderBookApiMock)
+    await postLimitOrder(defaultOrderParams, advancedData, undefined, orderBookApiMock)
 
     const call = buildAppDataMock.mock.calls[0][1]
 
@@ -69,14 +69,15 @@ describe('postLimitOrder', () => {
   })
 
   it('Should call order posting with all specified parameters', async () => {
-    await postLimitOrder(defaultOrderParams, {}, orderBookApiMock)
+    await postLimitOrder(defaultOrderParams, {}, undefined, orderBookApiMock)
 
     expect(postCoWProtocolTradeMock).toHaveBeenCalledTimes(1)
     expect(postCoWProtocolTradeMock).toHaveBeenCalledWith(
       orderBookApiMock,
       expect.anything(),
       appDataMock,
-      defaultOrderParams
+      defaultOrderParams,
+      undefined
     )
   })
 })

--- a/src/trading/postLimitOrder.test.ts
+++ b/src/trading/postLimitOrder.test.ts
@@ -61,7 +61,7 @@ describe('postLimitOrder', () => {
   it('Should add advanced appData parameters', async () => {
     const advancedData = { appData: { environment: 'sandbox' } }
 
-    await postLimitOrder(defaultOrderParams, advancedData, undefined, orderBookApiMock)
+    await postLimitOrder(defaultOrderParams, advancedData, orderBookApiMock)
 
     const call = buildAppDataMock.mock.calls[0][1]
 
@@ -69,7 +69,7 @@ describe('postLimitOrder', () => {
   })
 
   it('Should call order posting with all specified parameters', async () => {
-    await postLimitOrder(defaultOrderParams, {}, undefined, orderBookApiMock)
+    await postLimitOrder(defaultOrderParams, {}, orderBookApiMock)
 
     expect(postCoWProtocolTradeMock).toHaveBeenCalledTimes(1)
     expect(postCoWProtocolTradeMock).toHaveBeenCalledWith(

--- a/src/trading/postLimitOrder.ts
+++ b/src/trading/postLimitOrder.ts
@@ -1,4 +1,4 @@
-import { LimitOrderAdvancedSettings, LimitOrderParameters } from './types'
+import { LimitOrderAdvancedSettings, LimitOrderParameters, PostTradeAdditionalParams } from './types'
 import { log } from './consts'
 import { OrderBookApi } from '../order-book'
 import { buildAppData } from './appDataUtils'
@@ -8,6 +8,7 @@ import { getSigner } from '../common/utils/wallet'
 export async function postLimitOrder(
   params: LimitOrderParameters,
   advancedSettings?: LimitOrderAdvancedSettings,
+  additionalParams?: PostTradeAdditionalParams,
   _orderBookApi?: OrderBookApi
 ): Promise<string> {
   const {
@@ -39,5 +40,5 @@ export async function postLimitOrder(
     advancedSettings?.appData
   )
 
-  return postCoWProtocolTrade(orderBookApi, signer, appDataInfo, params)
+  return postCoWProtocolTrade(orderBookApi, signer, appDataInfo, params, additionalParams)
 }

--- a/src/trading/postLimitOrder.ts
+++ b/src/trading/postLimitOrder.ts
@@ -1,4 +1,4 @@
-import { LimitOrderAdvancedSettings, LimitOrderParameters, PostTradeAdditionalParams } from './types'
+import { LimitOrderAdvancedSettings, LimitOrderParameters } from './types'
 import { log } from './consts'
 import { OrderBookApi } from '../order-book'
 import { buildAppData } from './appDataUtils'
@@ -8,7 +8,6 @@ import { getSigner } from '../common/utils/wallet'
 export async function postLimitOrder(
   params: LimitOrderParameters,
   advancedSettings?: LimitOrderAdvancedSettings,
-  additionalParams?: PostTradeAdditionalParams,
   _orderBookApi?: OrderBookApi
 ): Promise<string> {
   const {
@@ -40,5 +39,5 @@ export async function postLimitOrder(
     advancedSettings?.appData
   )
 
-  return postCoWProtocolTrade(orderBookApi, signer, appDataInfo, params, additionalParams)
+  return postCoWProtocolTrade(orderBookApi, signer, appDataInfo, params, advancedSettings?.additionalParams)
 }

--- a/src/trading/postSellNativeCurrencyOrder.test.ts
+++ b/src/trading/postSellNativeCurrencyOrder.test.ts
@@ -89,14 +89,10 @@ describe('postSellNativeCurrencyTrade', () => {
   it('Should call checkEthFlowOrderExists if it is set', async () => {
     const checkEthFlowOrderExists = jest.fn().mockResolvedValue(false)
 
-    await postSellNativeCurrencyOrder(
-      orderBookApiMock,
-      signer,
-      appDataMock,
-      defaultOrderParams,
-      '0',
-      checkEthFlowOrderExists
-    )
+    await postSellNativeCurrencyOrder(orderBookApiMock, signer, appDataMock, defaultOrderParams, {
+      networkCostsAmount: '0',
+      checkEthFlowOrderExists,
+    })
 
     expect(checkEthFlowOrderExists).toHaveBeenCalledTimes(1)
   })

--- a/src/trading/postSellNativeCurrencyOrder.ts
+++ b/src/trading/postSellNativeCurrencyOrder.ts
@@ -1,6 +1,5 @@
 import { Signer } from 'ethers'
-import { AppDataInfo, LimitTradeParametersFromQuote } from './types'
-import { EthFlowOrderExistsCallback } from './calculateUniqueOrderId'
+import { AppDataInfo, LimitTradeParametersFromQuote, PostTradeAdditionalParams } from './types'
 
 import { log } from './consts'
 import { OrderBookApi } from '../order-book'
@@ -11,8 +10,7 @@ export async function postSellNativeCurrencyOrder(
   signer: Signer,
   appData: Pick<AppDataInfo, 'fullAppData' | 'appDataKeccak256'>,
   _params: LimitTradeParametersFromQuote,
-  networkCostsAmount = '0',
-  checkEthFlowOrderExists?: EthFlowOrderExistsCallback
+  additionalParams: PostTradeAdditionalParams = {}
 ): Promise<{ txHash: string; orderId: string }> {
   const { appDataKeccak256, fullAppData } = appData
 
@@ -21,8 +19,7 @@ export async function postSellNativeCurrencyOrder(
     appDataKeccak256,
     _params,
     orderBookApi.context.chainId,
-    networkCostsAmount,
-    checkEthFlowOrderExists
+    additionalParams
   )
 
   log('Uploading app-data')

--- a/src/trading/postSwapOrder.ts
+++ b/src/trading/postSwapOrder.ts
@@ -1,4 +1,4 @@
-import { PostTradeAdditionalParams, SwapAdvancedSettings, SwapParameters } from './types'
+import { SwapAdvancedSettings, SwapParameters } from './types'
 
 import { postCoWProtocolTrade } from './postCoWProtocolTrade'
 import { getQuoteWithSigner, QuoteResultsWithSigner } from './getQuote'
@@ -8,20 +8,14 @@ import { OrderBookApi } from '../order-book'
 export async function postSwapOrder(
   params: SwapParameters,
   advancedSettings?: SwapAdvancedSettings,
-  additionalParams?: PostTradeAdditionalParams,
   orderBookApi?: OrderBookApi
 ) {
-  return postSwapOrderFromQuote(
-    await getQuoteWithSigner(params, advancedSettings, orderBookApi),
-    advancedSettings,
-    additionalParams
-  )
+  return postSwapOrderFromQuote(await getQuoteWithSigner(params, advancedSettings, orderBookApi), advancedSettings)
 }
 
 export async function postSwapOrderFromQuote(
   { orderBookApi, result: { signer, appDataInfo, quoteResponse, tradeParameters } }: QuoteResultsWithSigner,
-  advancedSettings?: SwapAdvancedSettings,
-  additionalParams?: PostTradeAdditionalParams
+  advancedSettings?: SwapAdvancedSettings
 ): Promise<string> {
   return postCoWProtocolTrade(
     orderBookApi,
@@ -32,7 +26,7 @@ export async function postSwapOrderFromQuote(
     {
       signingScheme: advancedSettings?.quoteRequest?.signingScheme,
       networkCostsAmount: quoteResponse.quote.feeAmount,
-      ...additionalParams,
+      ...advancedSettings?.additionalParams,
     }
   )
 }

--- a/src/trading/tradingSdk.ts
+++ b/src/trading/tradingSdk.ts
@@ -1,7 +1,6 @@
 import {
   LimitOrderAdvancedSettings,
   LimitTradeParameters,
-  PostTradeAdditionalParams,
   QuoteAndPost,
   SwapAdvancedSettings,
   TradeParameters,
@@ -48,7 +47,7 @@ export class TradingSdk {
 
     return {
       quoteResults: quoteResults.result,
-      postSwapOrderFromQuote: (advancedSettings?: SwapAdvancedSettings, additionalParams?: PostTradeAdditionalParams) =>
+      postSwapOrderFromQuote: (advancedSettings?: SwapAdvancedSettings) =>
         postSwapOrderFromQuote(
           {
             ...quoteResults,
@@ -60,32 +59,28 @@ export class TradingSdk {
               }),
             },
           },
-          advancedSettings,
-          additionalParams
+          advancedSettings
         ),
     }
   }
 
   async postSwapOrder(
     params: WithPartialTraderParams<TradeParameters>,
-    advancedSettings?: SwapAdvancedSettings,
-    additionalParams?: PostTradeAdditionalParams
+    advancedSettings?: SwapAdvancedSettings
   ): Promise<string> {
-    return postSwapOrder(this.mergeParams(params), advancedSettings, additionalParams, this.options.orderBookApi)
+    return postSwapOrder(this.mergeParams(params), advancedSettings, this.options.orderBookApi)
   }
 
   async postLimitOrder(
     params: WithPartialTraderParams<LimitTradeParameters>,
-    advancedSettings?: LimitOrderAdvancedSettings,
-    additionalParams?: PostTradeAdditionalParams
+    advancedSettings?: LimitOrderAdvancedSettings
   ): Promise<string> {
-    return postLimitOrder(this.mergeParams(params), advancedSettings, additionalParams, this.options.orderBookApi)
+    return postLimitOrder(this.mergeParams(params), advancedSettings, this.options.orderBookApi)
   }
 
   async postSellNativeCurrencyOrder(
     params: WithPartialTraderParams<TradeParameters>,
-    advancedSettings?: SwapAdvancedSettings,
-    additionalParams?: PostTradeAdditionalParams
+    advancedSettings?: SwapAdvancedSettings
   ): Promise<ReturnType<typeof postSellNativeCurrencyOrder>> {
     const quoteResults = await getQuoteWithSigner(this.mergeParams(params), advancedSettings, this.options.orderBookApi)
 
@@ -100,7 +95,7 @@ export class TradingSdk {
         getTradeParametersAfterQuote({ quoteParameters: tradeParameters, orderParameters: params }),
         quoteResponse
       ),
-      additionalParams
+      advancedSettings?.additionalParams
     )
   }
 

--- a/src/trading/tradingSdk.ts
+++ b/src/trading/tradingSdk.ts
@@ -1,6 +1,7 @@
 import {
   LimitOrderAdvancedSettings,
   LimitTradeParameters,
+  PostTradeAdditionalParams,
   QuoteAndPost,
   SwapAdvancedSettings,
   TradeParameters,
@@ -47,37 +48,44 @@ export class TradingSdk {
 
     return {
       quoteResults: quoteResults.result,
-      postSwapOrderFromQuote: () =>
-        postSwapOrderFromQuote({
-          ...quoteResults,
-          result: {
-            ...quoteResults.result,
-            tradeParameters: getTradeParametersAfterQuote({
-              quoteParameters: quoteResults.result.tradeParameters,
-              orderParameters: params,
-            }),
+      postSwapOrderFromQuote: (advancedSettings?: SwapAdvancedSettings, additionalParams?: PostTradeAdditionalParams) =>
+        postSwapOrderFromQuote(
+          {
+            ...quoteResults,
+            result: {
+              ...quoteResults.result,
+              tradeParameters: getTradeParametersAfterQuote({
+                quoteParameters: quoteResults.result.tradeParameters,
+                orderParameters: params,
+              }),
+            },
           },
-        }),
+          advancedSettings,
+          additionalParams
+        ),
     }
   }
 
   async postSwapOrder(
     params: WithPartialTraderParams<TradeParameters>,
-    advancedSettings?: SwapAdvancedSettings
+    advancedSettings?: SwapAdvancedSettings,
+    additionalParams?: PostTradeAdditionalParams
   ): Promise<string> {
-    return postSwapOrder(this.mergeParams(params), advancedSettings, this.options.orderBookApi)
+    return postSwapOrder(this.mergeParams(params), advancedSettings, additionalParams, this.options.orderBookApi)
   }
 
   async postLimitOrder(
     params: WithPartialTraderParams<LimitTradeParameters>,
-    advancedSettings?: LimitOrderAdvancedSettings
+    advancedSettings?: LimitOrderAdvancedSettings,
+    additionalParams?: PostTradeAdditionalParams
   ): Promise<string> {
-    return postLimitOrder(this.mergeParams(params), advancedSettings, this.options.orderBookApi)
+    return postLimitOrder(this.mergeParams(params), advancedSettings, additionalParams, this.options.orderBookApi)
   }
 
   async postSellNativeCurrencyOrder(
     params: WithPartialTraderParams<TradeParameters>,
-    advancedSettings?: SwapAdvancedSettings
+    advancedSettings?: SwapAdvancedSettings,
+    additionalParams?: PostTradeAdditionalParams
   ): Promise<ReturnType<typeof postSellNativeCurrencyOrder>> {
     const quoteResults = await getQuoteWithSigner(this.mergeParams(params), advancedSettings, this.options.orderBookApi)
 
@@ -91,7 +99,8 @@ export class TradingSdk {
       swapParamsToLimitOrderParams(
         getTradeParametersAfterQuote({ quoteParameters: tradeParameters, orderParameters: params }),
         quoteResponse
-      )
+      ),
+      additionalParams
     )
   }
 

--- a/src/trading/types.ts
+++ b/src/trading/types.ts
@@ -106,10 +106,12 @@ export interface LimitOrderParameters extends TraderParameters, LimitTradeParame
 export interface SwapAdvancedSettings {
   quoteRequest?: Partial<Omit<OrderQuoteRequest, 'kind'>>
   appData?: AppDataParams
+  additionalParams?: PostTradeAdditionalParams
 }
 
 export interface LimitOrderAdvancedSettings {
   appData?: AppDataParams
+  additionalParams?: PostTradeAdditionalParams
 }
 
 /**
@@ -132,10 +134,7 @@ export interface QuoteResultsSerialized extends Omit<QuoteResults, 'amountsAndCo
 export interface QuoteAndPost {
   quoteResults: QuoteResults
 
-  postSwapOrderFromQuote(
-    advancedSettings?: SwapAdvancedSettings,
-    additionalParams?: PostTradeAdditionalParams
-  ): Promise<string>
+  postSwapOrderFromQuote(advancedSettings?: SwapAdvancedSettings): Promise<string>
 }
 
 export type AppDataRootSchema = latest.AppDataRootSchema

--- a/src/trading/types.ts
+++ b/src/trading/types.ts
@@ -7,6 +7,7 @@ import {
   OrderQuoteRequest,
   OrderQuoteResponse,
   QuoteAmountsAndCosts,
+  SigningScheme,
   TokenAmount,
 } from '../order-book'
 import type { AccountAddress, CowEnv, SignerLike } from '../common'
@@ -131,7 +132,10 @@ export interface QuoteResultsSerialized extends Omit<QuoteResults, 'amountsAndCo
 export interface QuoteAndPost {
   quoteResults: QuoteResults
 
-  postSwapOrderFromQuote(): Promise<string>
+  postSwapOrderFromQuote(
+    advancedSettings?: SwapAdvancedSettings,
+    additionalParams?: PostTradeAdditionalParams
+  ): Promise<string>
 }
 
 export type AppDataRootSchema = latest.AppDataRootSchema
@@ -160,4 +164,34 @@ export interface TransactionParams {
   gasLimit: string
   to: string
   value: string
+}
+
+export interface EthFlowOrderExistsCallback {
+  (orderId: string, orderDigest: string): Promise<boolean>
+}
+
+/**
+ * Additional parameters for posting orders.
+ * In most of the cases you don't need to use them.
+ */
+export interface PostTradeAdditionalParams {
+  /**
+   * Selling native token orders are special, because they are created from smart-contract,
+   * and their validTo is always the same.
+   * Because of that, you might get the same orderId when trying to create an order with the same parameters
+   * The callback is needed to check if there is already an order with the same orderId
+   *
+   * @see https://github.com/cowprotocol/ethflowcontract/blob/main/src/libraries/EthFlowOrder.sol#L90
+   */
+  checkEthFlowOrderExists?: EthFlowOrderExistsCallback
+  /**
+   * Cost of executing the order onchain.
+   * The value is used in getQuoteAmountsAndCosts in order to calculate proper amounts
+   */
+  networkCostsAmount?: string
+  /**
+   * By default, is EIP712 for EOA wallets.
+   * You might need other types of signing, for example PRESIGN when sign order via Smart Contract wallets.
+   */
+  signingScheme?: SigningScheme
 }


### PR DESCRIPTION
I got to this change from the fact that it's impossible to pass `checkEthFlowOrderExists` callback through `TradingSdk`.
I faced that when started integrating `TradingSdk` into CoW Swap.
I decided to merge `networkCostsAmount`, `checkEthFlowOrderExists`, and `signingScheme` params into one container `PostTradeAdditionalParams` and pass it through all the functions. I did that in order to not blow amount of arguments in the existing functions.

+ one more improvement in order to cache MetadataApi instance: https://github.com/cowprotocol/cow-sdk/pull/255/commits/aee6893cd12579975b41599739ca3e292c1458fa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added more flexible configuration options for trade orders, enabling users to pass additional details such as network cost and signing preferences.
- **Refactor**
	- Consolidated order posting parameters into a single object for improved consistency and maintainability.
	- Optimized resource usage by reusing shared instances, reducing redundancy.
- **Tests**
	- Updated tests to align with the revised parameter structure and validate the enhanced order processing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->