### PR TITLE
feat: tag RC versions as next not latest

### DIFF
--- a/workflows/publish.sh
+++ b/workflows/publish.sh
@@ -42,6 +42,10 @@ if ! [ "$version_tag" = "$latest_tag" ]; then
   exit 1
 fi
 
-yarn publish --access public
+if [[ "$version_tag" == *"RC"* ]]; then
+  yarn publish --access public --tag next
+else
+  yarn publish --access public
+fi
 
 echo "Package $package_name version $version successfully published."


### PR DESCRIPTION
This PR changes the publishing behaviour of NPM so RCs are tagged as`next` in the npm registry, but as `next`.

This prevents situations where pre-releases are used by people unintentionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the package publishing workflow to automatically apply a distinct tag for pre-release versions, ensuring that release candidates are clearly differentiated from stable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->