### PR TITLE
feat: get crosschain order details

### DIFF
--- a/src/bridging/BridgingSdk/BridgingSdk.ts
+++ b/src/bridging/BridgingSdk/BridgingSdk.ts
@@ -7,7 +7,7 @@ import {
   GetErc20Decimals,
   QuoteBridgeRequest,
 } from '../types'
-import { ALL_SUPPORTED_CHAINS, TokenInfo } from '../../common'
+import { ALL_SUPPORTED_CHAINS, CowEnv, TokenInfo } from '../../common'
 import { ChainInfo, SupportedChainId, TargetChainId } from '../../chains'
 import { getQuoteWithoutBridge } from './getQuoteWithoutBridge'
 import { getQuoteWithBridge } from './getQuoteWithBridging'
@@ -42,6 +42,26 @@ export interface BridgingSdkOptions {
    * Enable logging for the bridging SDK.
    */
   enableLogging?: boolean
+}
+
+/**
+ * Parameters for the `getOrder` method.
+ */
+export interface GetOrderParams {
+  /**
+   * The unique identifier of the order.
+   */
+  orderId: string
+
+  /**
+   * The chain ID of the order.
+   */
+  chainId: SupportedChainId
+
+  /**
+   * The environment of the order
+   */
+  env?: CowEnv
 }
 
 export type BridgingSdkConfig = Required<Omit<BridgingSdkOptions, 'enableLogging' | 'getErc20Decimals'>> &
@@ -157,14 +177,15 @@ export class BridgingSdk {
     }
   }
 
-  async getOrder(orderId: string, chainId: SupportedChainId): Promise<CrossChainOrder> {
+  async getOrder(params: GetOrderParams): Promise<CrossChainOrder> {
     const { orderBookApi } = this.config
-
+    const { orderId, chainId, env } = params
     return getCrossChainOrder({
       orderId,
       chainId,
       orderBookApi,
       providers: this.config.providers,
+      env: env || orderBookApi.context.env,
     })
   }
 }

--- a/src/bridging/BridgingSdk/getCrossChainOrder.ts
+++ b/src/bridging/BridgingSdk/getCrossChainOrder.ts
@@ -3,6 +3,7 @@ import { SupportedChainId } from '../../chains'
 import { OrderBookApi } from 'src/order-book'
 import { getPostHooks } from '../utils'
 import { HOOK_DAPP_BRIDGE_PROVIDER_PREFIX } from '../providers/across/const/misc'
+import { CowEnv } from '../../common'
 
 /**
  * Fetch a cross-chain order and its status.
@@ -12,10 +13,11 @@ export async function getCrossChainOrder(params: {
   chainId: SupportedChainId
   orderBookApi: OrderBookApi
   providers: BridgeProvider<BridgeQuoteResult>[]
+  env: CowEnv
 }): Promise<CrossChainOrder> {
-  const { orderId, chainId, orderBookApi, providers } = params
+  const { orderId, chainId, orderBookApi, providers, env } = params
 
-  const chainContext = { chainId }
+  const chainContext = { chainId, env }
   const order = await orderBookApi.getOrder(orderId, chainContext)
 
   const postHooks = getPostHooks(order.fullAppData ?? undefined)

--- a/src/bridging/BridgingSdk/getCrossChainOrder.ts
+++ b/src/bridging/BridgingSdk/getCrossChainOrder.ts
@@ -68,7 +68,7 @@ export async function getCrossChainOrder(params: {
       fillTimeInSeconds,
     }
   } else {
-    // Bridging initiated yet
+    // Bridging not initiated yet
     return {
       chainId,
       order,

--- a/src/bridging/BridgingSdk/getCrossChainOrder.ts
+++ b/src/bridging/BridgingSdk/getCrossChainOrder.ts
@@ -26,7 +26,8 @@ export async function getCrossChainOrder(params: {
   })
 
   if (!bridgingHook) {
-    throw new Error('Order ${orderId} is not a cross-chain order')
+    throw new Error(`Order ${orderId} is not a cross-chain order`)
+  }
   }
   // Bridge provider would be the last part of the dappId
   const bridgeProviderName = bridgingHook.dappId?.split(HOOK_DAPP_BRIDGE_PROVIDER_PREFIX).pop()

--- a/src/bridging/BridgingSdk/getCrossChainOrder.ts
+++ b/src/bridging/BridgingSdk/getCrossChainOrder.ts
@@ -1,0 +1,76 @@
+import { BridgeProvider, BridgeQuoteResult, BridgeStatus, CrossChainOrder } from '../types'
+import { SupportedChainId } from '../../chains'
+import { OrderBookApi } from 'src/order-book'
+import { getPostHooks } from '../utils'
+import { HOOK_DAPP_BRIDGE_PROVIDER_PREFIX } from '../providers/across/const/misc'
+
+/**
+ * Fetch a cross-chain order and its status.
+ */
+export async function getCrossChainOrder(params: {
+  orderId: string
+  chainId: SupportedChainId
+  orderBookApi: OrderBookApi
+  providers: BridgeProvider<BridgeQuoteResult>[]
+}): Promise<CrossChainOrder> {
+  const { orderId, chainId, orderBookApi, providers } = params
+
+  const chainContext = { chainId }
+  const order = await orderBookApi.getOrder(orderId, chainContext)
+
+  const postHooks = getPostHooks(order.fullAppData ?? undefined)
+
+  // Assuming we only have one bridging hook
+  const bridgingHook = postHooks.find((hook) => {
+    return hook.dappId?.startsWith(HOOK_DAPP_BRIDGE_PROVIDER_PREFIX)
+  })
+
+  if (!bridgingHook) {
+    throw new Error('Order ${orderId} is not a cross-chain order')
+  }
+  // Bridge provider would be the last part of the dappId
+  const bridgeProviderName = bridgingHook.dappId?.split(HOOK_DAPP_BRIDGE_PROVIDER_PREFIX).pop()
+
+  // Find the provider by name (note that I could just have use this.provider, but just wanted to leave it ready in case we implement multiple providers)
+  const provider = providers.find((provider) => provider.info.name === bridgeProviderName)
+  if (!provider) {
+    throw new Error(
+      `Unknown Bridge provider: ${bridgeProviderName}. Add provider to the SDK config to be able to decode the order`
+    )
+  }
+
+  // TODO: We might want to decode the bridge appData (reverse the encoding of the call in the provider)
+  //const bridgeDeposit = await provider.decodeBridgeHook(bridgingHook)
+
+  // Check if there are any trades for this order
+  const trades = await orderBookApi.getTrades({ orderUid: order.uid }, chainContext)
+  if (trades.length > 0) {
+    // Bridging already initiated
+    const firstTrade = trades[0]
+    if (!firstTrade.txHash) {
+      // Shouldn't happen, but lets make typescript happy
+      throw new Error(`No tx hash found for order ${orderId} . First trade, with log index ${firstTrade.logIndex}`)
+    }
+
+    // We need to get all Trade events from the TX in the settlement contract, because the deposit event will be
+    const bridgingId = await provider.getBridgingId(orderId, firstTrade.txHash)
+    const { status, fillTimeInSeconds } = await provider.getStatus(bridgingId)
+    const explorerUrl = provider.getExplorerUrl(bridgingId)
+
+    return {
+      chainId,
+      order,
+      status,
+      bridgingId,
+      explorerUrl,
+      fillTimeInSeconds,
+    }
+  } else {
+    // Bridging initiated yet
+    return {
+      chainId,
+      order,
+      status: BridgeStatus.NOT_INITIATED,
+    }
+  }
+}

--- a/src/bridging/BridgingSdk/getCrossChainOrder.ts
+++ b/src/bridging/BridgingSdk/getCrossChainOrder.ts
@@ -28,7 +28,6 @@ export async function getCrossChainOrder(params: {
   if (!bridgingHook) {
     throw new Error(`Order ${orderId} is not a cross-chain order`)
   }
-  }
   // Bridge provider would be the last part of the dappId
   const bridgeProviderName = bridgingHook.dappId?.split(HOOK_DAPP_BRIDGE_PROVIDER_PREFIX).pop()
 

--- a/src/bridging/BridgingSdk/getCrossChainOrder.ts
+++ b/src/bridging/BridgingSdk/getCrossChainOrder.ts
@@ -52,8 +52,8 @@ export async function getCrossChainOrder(params: {
       throw new Error(`No tx hash found for order ${orderId} . First trade, with log index ${firstTrade.logIndex}`)
     }
 
-    // We need to get all Trade events from the TX in the settlement contract, because the deposit event will be
-    const bridgingId = await provider.getBridgingId(orderId, firstTrade.txHash)
+    // Get bridging id for this order
+    const bridgingId = await provider.getBridgingId(orderId, firstTrade.txHash, firstTrade.logIndex)
     const { status, fillTimeInSeconds } = await provider.getStatus(bridgingId)
     const explorerUrl = provider.getExplorerUrl(bridgingId)
 

--- a/src/bridging/providers/across/AcrossBridgeProvider.test.ts
+++ b/src/bridging/providers/across/AcrossBridgeProvider.test.ts
@@ -176,7 +176,7 @@ describe('AcrossBridgeProvider', () => {
 
   describe('getBridgingId', () => {
     it('should return bridging id', async () => {
-      await expect(provider.getBridgingId('123', '123')).rejects.toThrowError('Not implemented')
+      await expect(provider.getBridgingId('123', '123', 1)).rejects.toThrowError('Not implemented')
     })
   })
 

--- a/src/bridging/providers/across/AcrossBridgeProvider.ts
+++ b/src/bridging/providers/across/AcrossBridgeProvider.ts
@@ -175,7 +175,7 @@ export class AcrossBridgeProvider implements BridgeProvider<AcrossQuoteResult> {
     throw new Error('Not implemented')
   }
 
-  async getBridgingId(_orderUid: string, _settlementTx: string): Promise<string> {
+  async getBridgingId(_orderUid: string, _settlementTx: string, _logIndex: number): Promise<string> {
     // TODO: get events from the mined transaction, extract the deposit id
     throw new Error('Not implemented')
   }

--- a/src/bridging/providers/across/AcrossBridgeProvider.ts
+++ b/src/bridging/providers/across/AcrossBridgeProvider.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Signer } from 'ethers'
+import { latest as latestAppData } from '@cowprotocol/app-data'
 
 import {
   BridgeDeposit,
@@ -28,8 +29,9 @@ import { getChainConfigs, getTokenAddress, getTokenSymbol, toBridgeQuoteResult }
 import { CowShedSdk, CowShedSdkOptions } from '../../../cow-shed'
 import { createAcrossDepositCall } from './createAcrossDepositCall'
 import { OrderKind } from '@cowprotocol/contracts'
+import { HOOK_DAPP_BRIDGE_PROVIDER_PREFIX } from './const/misc'
 
-const HOOK_DAPP_ID = 'cow-sdk://bridging/providers/across'
+const HOOK_DAPP_ID = `${HOOK_DAPP_BRIDGE_PROVIDER_PREFIX}/across`
 export const ACROSS_SUPPORTED_NETWORKS = [mainnet, polygon, arbitrumOne, base, optimism]
 
 // We need to review if we should set an additional slippage tolerance, for now assuming the quote gives you the exact price of bridging and no further slippage is needed
@@ -169,7 +171,7 @@ export class AcrossBridgeProvider implements BridgeProvider<AcrossQuoteResult> {
     }
   }
 
-  async decodeBridgeHook(_hook: BridgeHook): Promise<BridgeDeposit> {
+  async decodeBridgeHook(_hook: latestAppData.CoWHook): Promise<BridgeDeposit> {
     throw new Error('Not implemented')
   }
 

--- a/src/bridging/providers/across/AcrossBridgeProvider.ts
+++ b/src/bridging/providers/across/AcrossBridgeProvider.ts
@@ -177,6 +177,7 @@ export class AcrossBridgeProvider implements BridgeProvider<AcrossQuoteResult> {
 
   async getBridgingId(_orderUid: string, _settlementTx: string, _logIndex: number): Promise<string> {
     // TODO: get events from the mined transaction, extract the deposit id
+    // Important. A settlement could have many bridge-and-swap transactions, maybe even using different providers, this is why the log index might be handy to find which of the depositIds corresponds to the bridging transaction
     throw new Error('Not implemented')
   }
 

--- a/src/bridging/providers/across/const/misc.ts
+++ b/src/bridging/providers/across/const/misc.ts
@@ -1,0 +1,1 @@
+export const HOOK_DAPP_BRIDGE_PROVIDER_PREFIX = 'cow-sdk://bridging/providers'

--- a/src/bridging/providers/mock/MockBridgeProvider.ts
+++ b/src/bridging/providers/mock/MockBridgeProvider.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { latest as latestAppData } from '@cowprotocol/app-data'
 import {
   BridgeDeposit,
   BridgeHook,
@@ -133,7 +134,7 @@ export class MockBridgeProvider implements BridgeProvider<BridgeQuoteResult> {
       },
     }
   }
-  async decodeBridgeHook(_hook: BridgeHook): Promise<BridgeDeposit> {
+  async decodeBridgeHook(_hook: latestAppData.CoWHook): Promise<BridgeDeposit> {
     return {
       kind: OrderKind.SELL,
       provider: this.info,

--- a/src/bridging/providers/mock/MockBridgeProvider.ts
+++ b/src/bridging/providers/mock/MockBridgeProvider.ts
@@ -156,7 +156,7 @@ export class MockBridgeProvider implements BridgeProvider<BridgeQuoteResult> {
     }
   }
 
-  async getBridgingId(_orderUid: string, _settlementTx: string): Promise<string> {
+  async getBridgingId(_orderUid: string, _settlementTx: string, _logIndex: number): Promise<string> {
     return BRIDGING_ID
   }
 

--- a/src/bridging/types.ts
+++ b/src/bridging/types.ts
@@ -184,8 +184,9 @@ export interface BridgeProvider<Q extends BridgeQuoteResult> {
    * Get the identifier of the bridging transaction from the settlement transaction.
    * @param orderUid - The unique identifier of the order
    * @param settlementTx - The settlement transaction in which the bridging post-hook was executed
+   * @param logIndex - The log index of the trade within the settlement transaction
    */
-  getBridgingId(orderUid: string, settlementTx: string): Promise<string>
+  getBridgingId(orderUid: string, settlementTx: string, logIndex: number): Promise<string>
 
   /**
    * Get the explorer url for a bridging id.

--- a/src/bridging/types.ts
+++ b/src/bridging/types.ts
@@ -1,7 +1,7 @@
 import { latest as latestAppData } from '@cowprotocol/app-data'
 import { ChainInfo, SupportedChainId, TargetChainId } from '../chains'
 import { TokenInfo } from '../common/types/tokens'
-import { Address, Amounts, OrderKind } from '../order-book'
+import { Address, Amounts, EnrichedOrder, OrderKind } from '../order-book'
 import { EvmCall } from '../common/types/ethereum'
 import {
   OrderPostingResult,
@@ -178,7 +178,7 @@ export interface BridgeProvider<Q extends BridgeQuoteResult> {
    *
    * @param hook - The bridge hook
    */
-  decodeBridgeHook(hook: BridgeHook): Promise<BridgeDeposit>
+  decodeBridgeHook(hook: latestAppData.CoWHook): Promise<BridgeDeposit>
 
   /**
    * Get the identifier of the bridging transaction from the settlement transaction.
@@ -314,3 +314,12 @@ export interface BridgeQuoteResults extends BridgeQuoteResult {
 }
 
 export type GetErc20Decimals = (chainId: TargetChainId, tokenAddress: string) => Promise<number>
+
+export interface CrossChainOrder {
+  chainId: SupportedChainId
+  order: EnrichedOrder
+  status: BridgeStatus
+  bridgingId?: string
+  explorerUrl?: string
+  fillTimeInSeconds?: number
+}

--- a/src/bridging/utils.ts
+++ b/src/bridging/utils.ts
@@ -1,4 +1,5 @@
 import { QuoteAndPost } from '../trading'
+import { latest as latestAppData } from '@cowprotocol/app-data'
 import { BridgeQuoteAndPost, CrossChainQuoteAndPost } from './types'
 
 export function isBridgeQuoteAndPost(quote: CrossChainQuoteAndPost): quote is BridgeQuoteAndPost {
@@ -19,4 +20,26 @@ export function assertIsQuoteAndPost(quote: CrossChainQuoteAndPost): asserts quo
   if (!isQuoteAndPost(quote)) {
     throw new Error('Quote result is not of type QuoteAndPost. Are you sure the sell and buy chains are the same?')
   }
+}
+
+export function getPostHooks(fullAppData?: string): latestAppData.CoWHook[] {
+  if (!fullAppData) {
+    return []
+  }
+
+  const appData = JSON.parse(fullAppData)
+  if (!isAppDoc(appData)) {
+    return []
+  }
+
+  if (!appData.metadata.hooks) {
+    return []
+  }
+
+  return appData.metadata.hooks.post || []
+}
+
+// TODO: Move to app-data project
+export function isAppDoc(appData: unknown): appData is latestAppData.AppDataRootSchema {
+  return typeof appData === 'object' && appData !== null && 'version' in appData && 'metadata' in appData
 }


### PR DESCRIPTION
Draft of the SDK method that returns an order, its information, including: `bridgeId`, the bridge provider explorer url, bridge status, and an estimation of the time to be filled

This won't be working for now, as this will depend on the BridgeProvider implementing methods like `getBridgingId`.

returns:
```typescript
export interface CrossChainOrder {
  chainId: SupportedChainId
  order: EnrichedOrder
  status: BridgeStatus
  bridgingId?: string
  explorerUrl?: string
  fillTimeInSeconds?: number
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated cross-chain order management, allowing retrieval of detailed order information including status updates and bridging details.
  - Enhanced configuration requirements to support robust order processing and improved tracking of cross-chain operations.
  - Introduced new utility functions for handling application document validation and extracting post hooks.
  - Added a new method for fetching cross-chain orders based on order ID and chain ID.

- **Bug Fixes**
  - Updated method signatures to accommodate additional parameters, ensuring compatibility with the latest data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->