### PR TITLE
feat(trading-sdk): return unsigned order after posting order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.23",
+  "version": "6.0.0-RC.24",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/trading/getEthFlowTransaction.ts
+++ b/src/trading/getEthFlowTransaction.ts
@@ -8,6 +8,7 @@ import { GAS_LIMIT_DEFAULT } from './consts'
 import type { EthFlowOrder } from '../common/generated/EthFlow'
 import { adjustEthFlowOrderParams, calculateGasMargin } from './utils'
 import { Signer } from '@ethersproject/abstract-signer'
+import type { UnsignedOrder } from '../order-signing'
 
 export async function getEthFlowTransaction(
   signer: Signer,
@@ -15,7 +16,7 @@ export async function getEthFlowTransaction(
   _params: LimitTradeParametersFromQuote,
   chainId: SupportedChainId,
   additionalParams: PostTradeAdditionalParams = {}
-): Promise<{ orderId: string; transaction: TransactionParams }> {
+): Promise<{ orderId: string; transaction: TransactionParams; orderToSign: UnsignedOrder }> {
   const { networkCostsAmount = '0', checkEthFlowOrderExists } = additionalParams
   const from = await signer.getAddress()
 
@@ -49,6 +50,7 @@ export async function getEthFlowTransaction(
 
   return {
     orderId,
+    orderToSign,
     transaction: {
       data,
       gasLimit: '0x' + calculateGasMargin(estimatedGas).toString(16),

--- a/src/trading/postCoWProtocolTrade.ts
+++ b/src/trading/postCoWProtocolTrade.ts
@@ -62,5 +62,5 @@ export async function postCoWProtocolTrade(
 
   log(`Order created, id: ${orderId}`)
 
-  return { orderId, signature, signingScheme }
+  return { orderId, signature, signingScheme, orderToSign }
 }

--- a/src/trading/postSellNativeCurrencyOrder.ts
+++ b/src/trading/postSellNativeCurrencyOrder.ts
@@ -15,7 +15,7 @@ export async function postSellNativeCurrencyOrder(
 ): Promise<OrderPostingResult> {
   const { appDataKeccak256, fullAppData } = appData
 
-  const { orderId, transaction } = await getEthFlowTransaction(
+  const { orderId, transaction, orderToSign } = await getEthFlowTransaction(
     signer,
     appDataKeccak256,
     _params,
@@ -30,5 +30,5 @@ export async function postSellNativeCurrencyOrder(
   const txReceipt = await signer.sendTransaction(transaction)
 
   log(`On-chain order transaction sent, txHash: ${txReceipt.hash}, order: ${orderId}`)
-  return { txHash: txReceipt.hash, orderId, signature: '', signingScheme: SigningScheme.EIP1271 }
+  return { txHash: txReceipt.hash, orderId, orderToSign, signature: '', signingScheme: SigningScheme.EIP1271 }
 }

--- a/src/trading/types.ts
+++ b/src/trading/types.ts
@@ -164,6 +164,7 @@ export interface OrderPostingResult {
   txHash?: string
   signingScheme: SigningScheme
   signature: Signature
+  orderToSign: UnsignedOrder
 }
 
 export interface QuoteAndPost {


### PR DESCRIPTION
Since there are `additionalParams`, order data might be changed while posting the order (see https://github.com/cowprotocol/cow-sdk/pull/256).
We recalculate the order data taking into account the additional parameters.
Since the order data is changed, we should return a new instance of `UnsignedOrder`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package version to the new release candidate.
- **New Features**
	- Enhanced trading responses now include additional order details, offering improved transparency and more complete order information during transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->