### PR TITLE
fix(trading-sdk): override receiver and validTo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.24",
+  "version": "6.0.0-RC.25",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/trading/postSwapOrder.test.ts
+++ b/src/trading/postSwapOrder.test.ts
@@ -184,4 +184,25 @@ describe('postSwapOrder', () => {
     // 30000000000000000000 - (30000000000000000000 * 8 / 100) = 27600000000000000000
     expect(call.buyAmount).toBe('27600000000000000000')
   })
+
+  it('When receiver/validTo is present in advancedSettings quoteRequest, then it should end up in the order', async () => {
+    const orderBookApi = {
+      context: {
+        chainId: SELL_ORDER_PARAMS.chainId,
+      },
+      getQuote: jest.fn().mockResolvedValue(SELL_ORDER_QUOTE_MOCK),
+      sendOrder: jest.fn().mockResolvedValue('0x01'),
+    }
+    const validTo = 5600000
+    const receiver = '0x974caa59e49682cda0ad2bbe82983419a2ecc400'
+
+    await postSwapOrderFromQuote(await getQuoteWithSigner(SELL_ORDER_PARAMS, undefined, orderBookApi as any), {
+      quoteRequest: { receiver, validTo },
+    })
+
+    const call = orderBookApi.sendOrder.mock.calls[0][0]
+
+    expect(call.receiver).toBe(receiver)
+    expect(call.validTo).toBe(validTo)
+  })
 })

--- a/src/trading/postSwapOrder.ts
+++ b/src/trading/postSwapOrder.ts
@@ -42,6 +42,16 @@ export async function postSwapOrderFromQuote(
     params.partnerFee = partnerFeeOverride
   }
 
+  /**
+   * Override receiver and validTo in params
+   */
+  if (advancedSettings?.quoteRequest) {
+    const { receiver, validTo } = advancedSettings.quoteRequest
+
+    if (receiver) params.receiver = receiver
+    if (validTo) params.validTo = validTo
+  }
+
   return postCoWProtocolTrade(orderBookApi, signer, appDataInfo, params, {
     signingScheme: advancedSettings?.quoteRequest?.signingScheme,
     networkCostsAmount: quoteResponse.quote.feeAmount,

--- a/src/trading/types.ts
+++ b/src/trading/types.ts
@@ -106,7 +106,7 @@ export interface LimitTradeParametersFromQuote extends LimitTradeParameters {
 export interface LimitOrderParameters extends TraderParameters, LimitTradeParameters {}
 
 export interface SwapAdvancedSettings {
-  quoteRequest?: Partial<Omit<OrderQuoteRequest, 'kind'>>
+  quoteRequest?: Partial<Omit<OrderQuoteRequest, 'kind'> & { validTo: number }>
   appData?: AppDataParams
   additionalParams?: PostTradeAdditionalParams
 }


### PR DESCRIPTION
The SDK was ignoring receiver and validTo overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the package version to a new release candidate.
- **New Features**
	- Enhanced swap order functionality to support additional advanced settings for improved trade customization.
- **Tests**
	- Added test coverage to verify that advanced settings are applied correctly during swap order processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->