### PR TITLE
fix: fix conversion of struct to twap data when t0 set to epoc

### DIFF
--- a/src/composable/orderTypes/Twap.ts
+++ b/src/composable/orderTypes/Twap.ts
@@ -540,7 +540,7 @@ export function transformDataToStruct(data: TwapData): TwapStruct {
     sellAmount,
     buyAmount,
     numberOfParts,
-    startTime: startTime = DEFAULT_START_TIME,
+    startTime = DEFAULT_START_TIME,
     timeBetweenParts,
     durationOfPart = DEFAULT_DURATION_OF_PART,
     ...rest
@@ -595,7 +595,7 @@ export function transformStructToData(struct: TwapStruct): TwapData {
     ? { durationType: DurationType.AUTO }
     : { durationType: DurationType.LIMIT_DURATION, duration: span }
 
-  const startTime: StartTime = span.isZero()
+  const startTime: StartTime = startEpoch.isZero()
     ? { startType: StartTimeValue.AT_MINING_TIME }
     : { startType: StartTimeValue.AT_EPOCH, epoch: startEpoch }
 


### PR DESCRIPTION
This PR fixes a small c&p error in the conversion logic from the twap struct to the twap data.

Additionally adds two unit tests to assert the case of t0 being an epoch (instead of t0=0, which means mining time).

## Test
```
yarn test
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new test scenarios to validate correct handling of order timing when start times are defined by an epoch.
  - Updated validations to ensure orders become active as expected.

- **Refactor**
  - Streamlined the order time initialization logic for more reliable processing of order start times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->