### PR TITLE
fix(bridge): override appData before sending order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.33",
+  "version": "6.0.0-RC.34",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.32",
+  "version": "6.0.0-RC.33",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.34",
+  "version": "6.0.0-RC.35",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/bridging/BridgingSdk/getQuoteWithBridging.ts
+++ b/src/bridging/BridgingSdk/getQuoteWithBridging.ts
@@ -28,6 +28,7 @@ import { jsonWithBigintReplacer } from '../../common/utils/serialize'
 import { parseUnits } from '@ethersproject/units'
 import { SignerLike } from '../../common'
 import { QuoteResultsWithSigner } from '../../trading/getQuote'
+import { BridgeProviderQuoteError } from '../errors'
 
 type GetQuoteWithBridgeParams<T extends BridgeQuoteResult> = {
   /**
@@ -223,7 +224,7 @@ async function getBaseBridgeQuoteRequest<T extends BridgeQuoteResult>(params: {
   const intermediateTokens = await provider.getIntermediateTokens(quoteBridgeRequest)
 
   if (intermediateTokens.length === 0) {
-    throw new Error('No path found (not intermediate token for bridging)')
+    throw new BridgeProviderQuoteError('No path found (not intermediate token for bridging)', {})
   }
 
   // We just pick the first intermediate token for now

--- a/src/bridging/BridgingSdk/getQuoteWithBridging.ts
+++ b/src/bridging/BridgingSdk/getQuoteWithBridging.ts
@@ -127,6 +127,7 @@ export async function getQuoteWithBridge<T extends BridgeQuoteResult>(
   const { result: swapResult, orderBookApi } = await tradingSdk.getQuoteResults(swapParams, {
     ...advancedSettings,
     appData: {
+      ...advancedSettings?.appData,
       metadata: {
         hooks: {
           pre: advancedSettingsHooks?.pre,


### PR DESCRIPTION
Comes from: https://github.com/cowprotocol/cowswap/pull/5588#issuecomment-2824901769

`postSwapOrderFromQuote` in brodging sdk was ignoring `advancedSettings` so we didn't override appData params before seding order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for overriding app data when obtaining bridge quotes and posting swap orders, enabling more flexible advanced settings.

- **Bug Fixes**
  - Improved error handling with a specific error type for missing intermediate tokens during bridging.

- **Chores**
  - Updated the package version to 6.0.0-RC.35.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->