### PR TITLE
chore: use latest app-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "trading:generateSchemas": "ts-node scripts/generateTradingSchemas.ts"
   },
   "dependencies": {
-    "@cowprotocol/app-data": "^2.5.1",
+    "@cowprotocol/app-data": "3.0.0-rc.0",
     "@cowprotocol/contracts": "^1.7.0",
     "@ethersproject/abstract-signer": "^5.8.0",
     "@openzeppelin/merkle-tree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "trading:generateSchemas": "ts-node scripts/generateTradingSchemas.ts"
   },
   "dependencies": {
-    "@cowprotocol/app-data": "3.0.0-rc.0",
+    "@cowprotocol/app-data": "^3.0.0",
     "@cowprotocol/contracts": "^1.7.0",
     "@ethersproject/abstract-signer": "^5.8.0",
     "@openzeppelin/merkle-tree": "^1.0.8",

--- a/src/bridging/BridgingSdk/BridgingSdk.test.ts
+++ b/src/bridging/BridgingSdk/BridgingSdk.test.ts
@@ -15,7 +15,7 @@ import {
   WithPartialTraderParams,
 } from '../../trading'
 import { BridgeCallDetails, BridgeQuoteResult, QuoteBridgeRequest } from '../types'
-import { latestAppData } from '@cowprotocol/app-data'
+import { latest as latestAppData } from '@cowprotocol/app-data'
 import {
   BuyTokenDestination,
   OrderBookApi,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,10 +1762,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cowprotocol/app-data@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-3.0.0-rc.0.tgz#d171c275c480e9bed397b447e606360863842a4d"
-  integrity sha512-YvMiqHkIS2ylQezFK48OE6Id0BuvGL1fh7AtuAzZK7EAHl/5UpM3sKb6ZCymd/45BpRF5GXBujmZt09ijM9Wfg==
+"@cowprotocol/app-data@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-3.0.0.tgz#e5e7676ee8884c5348553883d0e65562c2f09e66"
+  integrity sha512-EyNoyoq3VnVIzvylLdn4Q1r0tU7HOikkjXzYY9PXJ/DUfj9gka7lOyNK7Ot8En2eUYTl3DNAle9RP7kt2sEpeg==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,10 +1762,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cowprotocol/app-data@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-2.5.1.tgz#c674ddfd161afd9a2ff425468b90a4b2f94d4341"
-  integrity sha512-GvcLQ44ZUHKdSAXiZ+YCaIehtme/OIvbvL/4go1UqNLTj3jDTDkagPh7CH/z2IPwFWTADyNZO/RSzKrW5UDNaA==
+"@cowprotocol/app-data@3.0.0-rc.0":
+  version "3.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-3.0.0-rc.0.tgz#d171c275c480e9bed397b447e606360863842a4d"
+  integrity sha512-YvMiqHkIS2ylQezFK48OE6Id0BuvGL1fh7AtuAzZK7EAHl/5UpM3sKb6ZCymd/45BpRF5GXBujmZt09ijM9Wfg==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"


### PR DESCRIPTION
Use the latest app-data to test https://github.com/cowprotocol/app-data/pull/83


Checked the:
- types work
- test pass
- build works


<img width="830" alt="image" src="https://github.com/user-attachments/assets/83b99a14-c311-4ae7-83c6-4f95ee47270f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated a dependency to a newer release candidate version.
- **Style**
  - Improved import statement formatting in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->