### PR TITLE
feat: suggest fee (smart fee)

### DIFF
--- a/src/common/utils/math.ts
+++ b/src/common/utils/math.ts
@@ -1,0 +1,22 @@
+/**
+ * Convert a percentage to a bps value.
+ *
+ * It rounds up.
+ *
+ * @param percentage - The percentage to convert
+ * @returns The bps value
+ */
+export function percentageToBps(percentage: number | bigint): number {
+  const bps = typeof percentage === 'bigint' ? Number(percentage * 10_000n) : percentage * 10_000
+  return Math.ceil(bps)
+}
+
+/**
+ * Apply a percentage to a bigint value
+ * @param value - The value to apply the percentage to
+ * @param percentage - The percentage to apply
+ * @returns The value after applying the percentage
+ */
+export function applyPercentage(value: bigint, percentage: number): bigint {
+  return (value * BigInt(percentage)) / 100n
+}

--- a/src/common/utils/math.ts
+++ b/src/common/utils/math.ts
@@ -13,10 +13,16 @@ export function percentageToBps(percentage: number | bigint): number {
 
 /**
  * Apply a percentage to a bigint value
+ *
+ * Rounds up.
+ *
  * @param value - The value to apply the percentage to
  * @param percentage - The percentage to apply
  * @returns The value after applying the percentage
  */
 export function applyPercentage(value: bigint, percentage: number): bigint {
-  return (value * BigInt(percentage)) / 100n
+  const valueMultiplied = value * BigInt(percentage)
+  const roundUp = valueMultiplied % 100n !== 0n ? 1n : 0n
+
+  return valueMultiplied / 100n + roundUp
 }

--- a/src/common/utils/math.ts
+++ b/src/common/utils/math.ts
@@ -1,3 +1,5 @@
+const BPS_FACTOR = 10_000n
+
 /**
  * Convert a percentage to a bps value.
  *
@@ -7,7 +9,7 @@
  * @returns The bps value
  */
 export function percentageToBps(percentage: number | bigint): number {
-  const bps = typeof percentage === 'bigint' ? Number(percentage * 10_000n) : percentage * 10_000
+  const bps = typeof percentage === 'bigint' ? Number(percentage * BPS_FACTOR) : percentage * Number(BPS_FACTOR)
   return Math.ceil(bps)
 }
 

--- a/src/trading/suggestSlippageBps.ts
+++ b/src/trading/suggestSlippageBps.ts
@@ -29,12 +29,10 @@ export function suggestSlippageBps(params: SuggestSlippageBps): number {
   const sellAmount = isSell ? sellAmountAfterNetworkCosts : sellAmountBeforeNetworkCosts
   const { feeAmount } = quote.quote
 
-  const suggestedSlippageBps = suggestSlippageBpsFromFee({
+  return suggestSlippageBpsFromFee({
     feeAmount: BigInt(feeAmount),
     sellAmount,
     isSell,
     multiplyingFactorPercent: SLIPPAGE_FEE_MULTIPLIER_PERCENT,
   })
-
-  return suggestedSlippageBps
 }

--- a/src/trading/suggestSlippageBpsFromFee.test.ts
+++ b/src/trading/suggestSlippageBpsFromFee.test.ts
@@ -1,0 +1,143 @@
+import { suggestSlippageBpsFromFee } from './suggestSlippageBpsFromFee'
+
+interface SuggestedFeeTest {
+  fee: bigint
+  sell: bigint
+  factor: number
+  expected: number | string
+  description?: string
+}
+
+describe('Sell orders', () => {
+  const isSell = true
+
+  assertCases('handle different factors', isSell, [
+    // expected = 1 - (100 - 20 * 1.00) / (100 - 20) = 0
+    { fee: 20n, sell: 100n, factor: 0, expected: 0 },
+
+    // expected = 1 - (100 - 20 * 1.25) / (100 - 20) = 0.125
+    { fee: 20n, sell: 100n, factor: 25, expected: 625 },
+
+    // expected = 1 - (100 - 20 * 1.50) / (100 - 20) = 0.125
+    { fee: 20n, sell: 100n, factor: 50, expected: 1250 },
+
+    // expected = 1 - (100 - 20 * 1.75) / (100 - 20) = 0.125
+    { fee: 20n, sell: 100n, factor: 75, expected: 1875 },
+
+    // expected = 1 - (100 - 20 * 2) / (100 - 20) = 0.125
+    { fee: 20n, sell: 100n, factor: 100, expected: 2500 },
+
+    // expected = 1 - (100 - 20 * 1.5) / (100 - 20) = 0.125
+    { fee: 20n, sell: 100n, factor: 200, expected: 5000 },
+
+    // Absurd factor, returns max slippage
+    { fee: 20n, sell: 100n, factor: 100_000_000, expected: 10000 },
+  ])
+
+  assertCases('Handle atoms', isSell, [
+    // expected = 1 - (1 - 0.2 * 1) / (1 - 0.2) = 0
+    { fee: atoms(0.2), sell: atoms(1), factor: 0, expected: 0 },
+
+    // expected = 1 - (1 - 0.2 * 1.25) / (1 - 0.2) = 0.125
+    { fee: atoms(0.2), sell: atoms(1), factor: 25, expected: 625 },
+
+    // expected = 1 - (1 - 0.2 * 1.5) / (1 - 0.2) = 0.125
+    { fee: atoms(0.2), sell: atoms(1), factor: 50, expected: 1250 },
+
+    // expected = 1 - (1 - 0.2 * 1.75) / (1 - 0.2) = 0.125
+    { fee: atoms(0.2), sell: atoms(1), factor: 75, expected: 1875 },
+
+    // expected = 1 - (1 - 0.2 * 1.5) / (1 - 0.2) = 0.125
+    { fee: atoms(0.2), sell: atoms(1), factor: 100, expected: 2500 },
+  ])
+
+  assertCases('Handle edge case with sellAmount', isSell, [
+    // Fee is 0: returns maximum slippage
+    { fee: 0n, sell: 0n, factor: 50, expected: 10_000, description: 'amount is 0, fee is 0' },
+
+    // Fee is 0: returns maximum slippage
+    { fee: 20n, sell: 0n, factor: 50, expected: 10_000, description: 'amount is 0, fee is not 0' },
+  ])
+
+  assertCases('Handle edge case with fees', isSell, [
+    // Fee is 0
+    //   expected = 1 - (100 - 20 * 1.5) / (100 - 20) = 0.125
+    { fee: 0n, sell: 100n, factor: 50, expected: 0, description: 'fee is 0' },
+
+    // Fee is all the sell amount
+    //   expected = 1 - (100 - 20 * 1.5) / (100 - 20) = 0.125
+    { fee: 100n, sell: 100n, factor: 50, expected: 10_000, description: 'fee is equal to sellAmount' },
+
+    // Fee is bigger than the sell amount (should not happen)
+    //   expected = 1 - (100 - 20 * 1.5) / (100 - 20) = 0.125
+    { fee: 100n, sell: 100n, factor: 50, expected: 10_000, description: 'fee is bigger than sellAmount' },
+
+    // Fee is negative, it should throw an error
+    {
+      fee: -100n,
+      sell: 100n,
+      factor: 50,
+      expected: 'Fee amount cannot be negative: -100',
+      description: 'fee is negative',
+    },
+  ])
+})
+
+describe('Buy orders', () => {
+  const isSell = false
+
+  assertCases('handle different factors', isSell, [
+    // // expected = (100 + 20 * 1) / (100 + 20) - 1 = 0
+    { fee: 20n, sell: 100n, factor: 0, expected: 0 },
+
+    // // expected = 1 - (100 + 20 * 1.25) / (100 + 20) - 1 = 0.125
+    { fee: 20n, sell: 100n, factor: 25, expected: 417 },
+
+    // expected = (100 + 20 * 1.5) / (100 + 20) - 1 = 0.125
+    { fee: 20n, sell: 100n, factor: 50, expected: 834 },
+
+    // // expected = 1 - (100 + 20 * 1.75) / (100 + 20) - 1 = 0.125
+    { fee: 20n, sell: 100n, factor: 75, expected: 1250 },
+
+    // // expected = 1 - (100 + 20 * 1.5) / (100 + 20) - 1 = 0.125
+    { fee: 20n, sell: 100n, factor: 100, expected: 1667 },
+
+    // expected = 1 - (100 + 20 * 1.5) / (100 + 20) - 1 = 0.125
+    { fee: 20n, sell: 100n, factor: 200, expected: 3334 },
+
+    // Absurd factor, returns max slippage
+    { fee: 20n, sell: 100n, factor: 100_000_000, expected: 10000 },
+  ])
+})
+
+function atoms(amount: number) {
+  return BigInt(amount * 1e18)
+}
+
+function assertCases(description: string, isSell: boolean, testCases: SuggestedFeeTest[]) {
+  describe(description, () => {
+    testCases.forEach(({ sell, fee, factor, expected, description: testCaseDescription }) => {
+      const shouldThrow = typeof expected === 'string'
+      const expectedDescription = shouldThrow ? `should throw "${expected}"` : `should return ${expected} BPS`
+      const caseDescription = testCaseDescription
+        ? `When ${testCaseDescription}, ${expectedDescription}`
+        : `suggestSlippageBpsFromFee(sell=${sell}, fee=${fee}, factor=${factor}) ${expectedDescription}`
+
+      it(`[${isSell ? 'sell' : 'buy'}] ${caseDescription}`, () => {
+        // If expected is a string, it should throw an error
+        const params = {
+          feeAmount: fee,
+          sellAmount: sell,
+          isSell,
+          multiplyingFactorPercent: factor,
+        }
+        if (shouldThrow) {
+          expect(() => suggestSlippageBpsFromFee(params)).toThrow(expected)
+        } else {
+          const result = suggestSlippageBpsFromFee(params)
+          expect(result).toBe(expected)
+        }
+      })
+    })
+  })
+}

--- a/src/trading/suggestSlippageBpsFromFee.test.ts
+++ b/src/trading/suggestSlippageBpsFromFee.test.ts
@@ -105,19 +105,19 @@ describe('Buy orders', () => {
     // // expected = (100 + 20 * 1) / (100 + 20) - 1 = 0
     { fee: 20n, sell: 100n, factor: 0, expected: 50 },
 
-    // // expected = 1 - (100 + 20 * 1.25) / (100 + 20) - 1 = 0.125
+    // // expected = (100 + 20 * 1.25) / (100 + 20) - 1 = 0.04166666667
     { fee: 20n, sell: 100n, factor: 25, expected: 417 },
 
-    // expected = (100 + 20 * 1.5) / (100 + 20) - 1 = 0.125
+    // expected = (100 + 20 * 1.5) / (100 + 20) - 1 = 0.08333333333
     { fee: 20n, sell: 100n, factor: 50, expected: 834 },
 
-    // // expected = 1 - (100 + 20 * 1.75) / (100 + 20) - 1 = 0.125
+    // // expected = (100 + 20 * 1.75) / (100 + 20) - 1 = 0.125
     { fee: 20n, sell: 100n, factor: 75, expected: 1250 },
 
-    // // expected = 1 - (100 + 20 * 1.5) / (100 + 20) - 1 = 0.125
+    // expected = (100 + 20 * 2) / (100 + 20) - 1 = 0.1666666667
     { fee: 20n, sell: 100n, factor: 100, expected: 1667 },
 
-    // expected = 1 - (100 + 20 * 1.5) / (100 + 20) - 1 = 0.125
+    // expected = (100 + 20 * 3) / (100 + 20) - 1 = 0.3333333333
     { fee: 20n, sell: 100n, factor: 200, expected: 3334 },
 
     // Absurd factor, returns max slippage

--- a/src/trading/suggestSlippageBpsFromFee.ts
+++ b/src/trading/suggestSlippageBpsFromFee.ts
@@ -4,7 +4,7 @@ const MIN_SLIPPAGE_BPS = 50
 const MAX_SLIPPAGE_BPS = 10_000 // 100% in BPS
 const ONE_HUNDRED_PERCENT_DECIMAL = 1 // 100 in decimal percentage
 
-const SCALE = 10n ** 18n // 18 decimal places of precision. Used to avoid depending on Big Decimal libraries
+const SCALE = 10n ** 6n // 6 decimal places of precision. Used to avoid depending on Big Decimal libraries
 
 export interface SuggestSlippageBpsFromFeeParams {
   /**

--- a/src/trading/suggestSlippageBpsFromFee.ts
+++ b/src/trading/suggestSlippageBpsFromFee.ts
@@ -53,7 +53,7 @@ export function suggestSlippagePercent(params: SuggestSlippageBpsFromFeeParams):
   }
 
   // Multiplying factor must be a valid percentage
-  if (multiplyingFactorPercent < 0n) {
+  if (multiplyingFactorPercent < 0) {
     throw new Error('multiplyingFactorPercent must be a percentage: ' + multiplyingFactorPercent)
   }
 

--- a/src/trading/suggestSlippageBpsFromFee.ts
+++ b/src/trading/suggestSlippageBpsFromFee.ts
@@ -1,7 +1,8 @@
 import { applyPercentage, percentageToBps } from 'src/common/utils/math'
 
 const MIN_SLIPPAGE_BPS = 50
-const MAX_SLIPPAGE_BPS = 10_000 // 100% (this is)
+const MAX_SLIPPAGE_BPS = 10_000 // 100% in BPS
+const ONE_HUNDRED_PERCENT_DECIMAL = 1 // 100 in decimal percentage
 
 const SCALE = 10n ** 18n // 18 decimal places of precision. Used to avoid depending on Big Decimal libraries
 
@@ -60,12 +61,13 @@ export function suggestSlippagePercent(params: SuggestSlippageBpsFromFeeParams):
   // Get the amount we want to account for our slippage
   const feeAfterIncrease = applyPercentage(feeAmount, 100 + multiplyingFactorPercent)
 
-  // Account fee (fee is deducted to sell amount for sell orders and added to sell amount for buy orders)
+  // Account fee (fee is deducted to sell amount for sell orders and added for buy orders)
   const sellAmountAccountingFee = isSell ? sellAmount - feeAmount : sellAmount + feeAmount
 
   // Return maximum slippage if the sellAmount after accounting for the fee is 0 or negative
   if (sellAmountAccountingFee <= 0n) {
-    return MAX_SLIPPAGE_BPS
+    // Return 1 (== 100 %) so that later conversion to BPS is consistent
+    return ONE_HUNDRED_PERCENT_DECIMAL
   }
 
   if (isSell) {

--- a/src/trading/suggestSlippageBpsFromFee.ts
+++ b/src/trading/suggestSlippageBpsFromFee.ts
@@ -1,0 +1,84 @@
+import { applyPercentage, percentageToBps } from 'src/common/utils/math'
+
+const SCALE = BigInt(1e18) // 18 decimal places of precision. Used to avoid depending on Big Decimal libraries
+
+const MAX_SLIPPAGE_BPS = 10_000 // 100% (this is)
+
+export interface SuggestSlippageBpsFromFeeParams {
+  /**
+   * Fee amount in the sell token returned by the quote
+   */
+  feeAmount: bigint
+
+  /**
+   * Actual mount to be sold
+   *
+   * For sell orders, its expected the sell amount after applying the fee is applied
+   * For buy orders, its expected to be the sell amount before the fee is applied
+   */
+  sellAmount: bigint
+
+  /**
+   * Whether the order is a sell order or a buy order
+   */
+  isSell: boolean
+
+  /**
+   * The factor to multiply the fee amount by to get the suggested slippage.
+   *
+   * For example, if the factor is 50% it would calculate which slippage would allow the fee to increase by 50% and still go through.
+   */
+  multiplyingFactorPercent: number
+}
+
+/**
+ * Return the slippage in BPS that would allow the fee to increase by the multiplying factor percent.
+ *
+ * If the fees are bigger or equal to the sell amount, it returns the 10_000 BPS (100% slippage).
+ */
+export function suggestSlippageBpsFromFee(params: SuggestSlippageBpsFromFeeParams): number {
+  const { feeAmount, sellAmount, isSell, multiplyingFactorPercent } = params
+
+  // Negative fees are not allowed
+  if (feeAmount < 0n) {
+    throw new Error('Fee amount cannot be negative: ' + feeAmount)
+  }
+
+  // Multiplying factor must be a valid percentage
+  if (multiplyingFactorPercent < 0n) {
+    throw new Error('multiplyingFactorPercent must be a percentage: ' + multiplyingFactorPercent)
+  }
+
+  // Get the amount we want to account for our slippage
+  const feeAfterIncrease = applyPercentage(feeAmount, 100 + multiplyingFactorPercent)
+
+  // Account fee (fee is deducted to sell amount for sell orders and added to sell amount for buy orders)
+  const sellAmountAccountingFee = isSell ? sellAmount - feeAmount : sellAmount + feeAmount
+
+  // Return maximum slippage if the sellAmount after accounting for the fee is 0 or negative
+  if (sellAmountAccountingFee <= 0n) {
+    return MAX_SLIPPAGE_BPS
+  }
+
+  if (isSell) {
+    // For sell orders:
+    // 1 - ((sellAmount - feeAmount * multiplier) / (sellAmount - feeAmount))
+    // i.e: feeAmount=5, sellAmount=100, multiplier=1.5
+    //    suggestSlippageBpsFromFee = 1 - (100-5*1.5) / (100-5) = 0.02631578947
+    //    suggestSlippageBpsFromFee (in scale) = 1e18 - (1e18*(100-5*1.5)) / (100-5) = 26,315,789,473,684,210
+    //    suggestSlippageBpsFromFee = 26,315,789,473,684,210 / 1e18 = 0.02631578947
+    const percentageInScale = SCALE - (SCALE * (sellAmount - feeAfterIncrease)) / sellAmountAccountingFee
+
+    return Math.min(percentageToBps(Number(percentageInScale) / Number(SCALE)), MAX_SLIPPAGE_BPS)
+  } else {
+    // For buy orders:
+    // ((sellAmount + feeAmount * feeMultiplierFactor) / (sellAmount + feeAmount)) - 1
+    // i.e: feeAmount=5, sellAmount=100, multiplier=1.5
+    //    suggestSlippageBpsFromFee = (100+5*1.5) / (100+5) - 1 = 0.02380952381
+    //    suggestSlippageBpsFromFee (in scale) = (1e18*(100+5*1.5)) / (100+5) - 1e18 = 23,809,523,809,523,809
+    //    suggestSlippageBpsFromFee = 23,809,523,809,523,809 / 1e18 = 0.02380952381
+    const percentageInScale = (SCALE * (sellAmount + feeAfterIncrease)) / sellAmountAccountingFee - SCALE
+
+    return Math.min(percentageToBps(Number(percentageInScale) / Number(SCALE)), MAX_SLIPPAGE_BPS)
+  }
+}

--- a/src/trading/suggestSlippageBpsFromFee.ts
+++ b/src/trading/suggestSlippageBpsFromFee.ts
@@ -3,7 +3,7 @@ import { applyPercentage, percentageToBps } from 'src/common/utils/math'
 const MIN_SLIPPAGE_BPS = 50
 const MAX_SLIPPAGE_BPS = 10_000 // 100% (this is)
 
-const SCALE = BigInt(1e18) // 18 decimal places of precision. Used to avoid depending on Big Decimal libraries
+const SCALE = 10n ** 18n // 18 decimal places of precision. Used to avoid depending on Big Decimal libraries
 
 export interface SuggestSlippageBpsFromFeeParams {
   /**
@@ -12,7 +12,7 @@ export interface SuggestSlippageBpsFromFeeParams {
   feeAmount: bigint
 
   /**
-   * Actual mount to be sold
+   * Actual amount to be sold
    *
    * For sell orders, its expected the sell amount after applying the fee is applied
    * For buy orders, its expected to be the sell amount before the fee is applied

--- a/src/trading/suggestSlippageBpsFromFee.ts
+++ b/src/trading/suggestSlippageBpsFromFee.ts
@@ -15,7 +15,7 @@ export interface SuggestSlippageBpsFromFeeParams {
   /**
    * Actual amount to be sold
    *
-   * For sell orders, its expected the sell amount after applying the fee is applied
+   * For sell orders, its expected the sell amount after the fee is applied
    * For buy orders, its expected to be the sell amount before the fee is applied
    */
   sellAmount: bigint


### PR DESCRIPTION
Implements the "smart" slippage calculations.

Follow up on https://github.com/cowprotocol/cow-sdk/pull/306

This order has been placed using the new SDK: https://explorer.cow.fi/sepolia/orders/0xb31414879f27655ab1e45b48f2e908700ae1d758172adf0aa9b2496f87870ff2016f34d4f2578c3e9dffc3f2b811ba30c0c9e7f36823a1f5?tab=overview



## Details
Mimics the logic used in CoW Swap with a few differences.

- The suggested BPS are rounded up instead of down.
- The new fee costs you get after applying the percentage, now rounds up (this is important, because we want to cover with the slippage at least the fee increase)
- Handle a few extra edge cases (see tests)
- It will never return BPS bigger than 10_000 --> 100%, or less than 50
   - CoW Swap allows only a maximum of 500 BPS. I've let it go all the way to 10_000. I think it should be UIs who recommend users to review the order. 
   - The only way to get to those numbers is if the fee is really significant compared to the sell volume, and I think in this case it makes sense to have a very high slippage. 
   - IMO It should be the responsibility of the UI to inform the user or add a cap. Yes, it can get the super high recommendation of slipage tolerance, but only if the order is super small.
   - Anyways, lets discuss the options, because here we can do a lot of fine-tuning


## Test
Adds exhaustive unit tests
<img width="932" alt="Screenshot at May 13 18-56-56" src="https://github.com/user-attachments/assets/2f64d692-5b58-4a45-ab4a-6d42b5bcd803" />

Also, I deployed a RC: `6.0.0-RC.38`
This way, it should be easy to test this using NPM.

I used the NPM package and checked that:

The quote returns now a suggested slippage:
<img width="532" alt="image" src="https://github.com/user-attachments/assets/68b4a0e4-1f0d-41cc-afce-fd333dacab43" />

The app-data is updated (not the one from the quote, because we reuse the first quote we do with 50 BPS), but for posting the order w e
<img width="640" alt="Screenshot at May 13 20-11-22" src="https://github.com/user-attachments/assets/2a18e5f3-b2a0-47d5-b730-44abce2c0683" />

I posted an order using the SDK with auto-slippage:
<img width="1203" alt="image" src="https://github.com/user-attachments/assets/fa1637d4-a4a2-4782-adf4-6332911d5376" />


https://explorer.cow.fi/sepolia/orders/0xb31414879f27655ab1e45b48f2e908700ae1d758172adf0aa9b2496f87870ff2016f34d4f2578c3e9dffc3f2b811ba30c0c9e7f36823a1f5?tab=overview


I also tested that if I provide a slippage (so not using auto-slippage), then I get to use the slippage I want (but still I get the suggested slippage in the result):
https://explorer.cow.fi/sepolia/orders/0x03cf60670ea839b2d16e39d8bf0b9c7c4098aa983e2ef1ce1bb164750c19b166016f34d4f2578c3e9dffc3f2b811ba30c0c9e7f36823a256?tab=overview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic slippage suggestion based on order fees for more accurate trading recommendations.
  - Added new utilities for advanced percentage and basis point calculations.
- **Refactor**
  - Improved and modularized quote amount and cost calculations for better clarity and reusability.
- **Tests**
  - Added comprehensive tests for slippage suggestion logic to ensure reliability and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->