### PR TITLE
Slippage calculation rounding

### DIFF
--- a/src/common/utils/math.ts
+++ b/src/common/utils/math.ts
@@ -5,20 +5,20 @@ const BPS_FACTOR = 10_000n
 /**
  * Convert a percentage to a bps value.
  *
- * It rounds up.
+ * It rounds to the nearest integer.
  *
  * @param percentage - The percentage to convert
  * @returns The bps value
  */
 export function percentageToBps(percentage: number | bigint): number {
   const bps = typeof percentage === 'bigint' ? Number(percentage * BPS_FACTOR) : percentage * Number(BPS_FACTOR)
-  return Math.ceil(bps)
+  return Math.round(bps)
 }
 
 /**
  * Apply a percentage to a bigint value
  *
- * Rounds up.
+ * Rounds to the nearest integer.
  *
  * @param value - The value to apply the percentage to
  * @param percentage - The percentage to apply
@@ -26,7 +26,7 @@ export function percentageToBps(percentage: number | bigint): number {
  */
 export function applyPercentage(value: bigint, percentage: number): bigint {
   const valueMultiplied = (value * BigInt(Math.floor(percentage * SCALE))) / SCALE_BIGINT
-  const roundUp = valueMultiplied % 100n !== 0n ? 1n : 0n
 
+  const roundUp = valueMultiplied % 100n >= 50n ? 1n : 0n
   return valueMultiplied / 100n + roundUp
 }

--- a/src/trading/suggestSlippageFromFee.test.ts
+++ b/src/trading/suggestSlippageFromFee.test.ts
@@ -9,22 +9,27 @@ interface SuggestedFeeTest {
 }
 
 assertCases('handle different factors', [
-  { fee: 20n, factor: 0, expected: 0 },
-  { fee: 20n, factor: 1, expected: 1 },
-  { fee: 20n, factor: 25, expected: 5 },
-  { fee: 20n, factor: 50, expected: 10 },
-  { fee: 20n, factor: 75, expected: 15 },
-  { fee: 20n, factor: 100, expected: 20 },
-  { fee: 20n, factor: 200, expected: 40 },
-  { fee: 20n, factor: 100_000_000, expected: 20_000_000 },
+  { fee: 20n, factor: 0, expected: 0 }, // round(20*0) = 0
+  { fee: 20n, factor: 1, expected: 0 }, // round(20*0.01) = 0
+  { fee: 20n, factor: 2, expected: 0 }, // round(20*0.02) = 0
+  { fee: 20n, factor: 3, expected: 1 }, // round(20*0.03) = 1
+  { fee: 20n, factor: 25, expected: 5 }, // round(20*0.25) = 5
+  { fee: 20n, factor: 50, expected: 10 }, // round(20*0.5) = 10
+  { fee: 20n, factor: 75, expected: 15 }, // round(20*0.75) = 15
+  { fee: 20n, factor: 100, expected: 20 }, // round(20*1) = 20
+  { fee: 20n, factor: 200, expected: 40 }, // round(20*2) = 40
+  { fee: 20n, factor: 100_000_000, expected: 20_000_000 }, // round(20*1) = 20
 ])
 
 assertCases('Handle atoms', [
-  { fee: atoms(0.2), factor: 0, expected: 0 },
-  { fee: atoms(0.2), factor: 25, expected: 50000000000000000 },
-  { fee: atoms(0.2), factor: 50, expected: 100000000000000000 },
-  { fee: atoms(0.2), factor: 75, expected: 150000000000000000 },
-  { fee: atoms(0.2), factor: 100, expected: 200000000000000000 },
+  { fee: atoms(0.2), factor: 0, expected: 0 }, // round(0.2*1e18*0) = 0
+  { fee: atoms(0.2), factor: 1, expected: 2000000000000000 }, // round(0.2*1e18*0.01) = 2,000,000,000,000,000
+  { fee: atoms(0.2), factor: 2, expected: 4000000000000000 }, // round(0.2*1e18*0.02) = 4,000,000,000,000,000
+  { fee: atoms(0.2), factor: 3, expected: 6000000000000000 }, // round(0.2*1e18*0.03) = round(0.2*1e18*0.03)
+  { fee: atoms(0.2), factor: 25, expected: 50000000000000000 }, // round(0.2*1e18*0.25) = 50000000000000000
+  { fee: atoms(0.2), factor: 50, expected: 100000000000000000 }, // round(0.2*1e18*0.5) = 100000000000000000
+  { fee: atoms(0.2), factor: 75, expected: 150000000000000000 }, // round(0.2*1e18*0.75) = 150000000000000000
+  { fee: atoms(0.2), factor: 100, expected: 200000000000000000 }, // round(0.2*1e18*1) = 200000000000000000
 ])
 
 assertCases('Handle fee edge cases', [

--- a/src/trading/suggestSlippageFromVolume.test.ts
+++ b/src/trading/suggestSlippageFromVolume.test.ts
@@ -16,12 +16,14 @@ describe('Sell orders', () => {
   const isSell = true
 
   assertCases('handle different factors', isSell, [
-    { ...baseParams, percentage: 0, expected: 0 },
-    { ...baseParams, percentage: 0.5, expected: 1 },
-    { ...baseParams, percentage: 10, expected: 2 },
-    { ...baseParams, percentage: 25, expected: 4 },
-    { ...baseParams, percentage: 50, expected: 8 },
-    { ...baseParams, percentage: 100, expected: 15 },
+    { ...baseParams, percentage: 0, expected: 0 }, // round(15*0) = 0
+    { ...baseParams, percentage: 0.5, expected: 0 }, // round(15*0.005) = 0
+    { ...baseParams, percentage: 3, expected: 0 }, // round(15*0.03) = 0
+    { ...baseParams, percentage: 4, expected: 1 }, // round(15*0.04) = 1
+    { ...baseParams, percentage: 10, expected: 2 }, // round(15*0.1) = 2
+    { ...baseParams, percentage: 25, expected: 4 }, // round(15*0.25) = 4
+    { ...baseParams, percentage: 50, expected: 8 }, // round(15*0.5) = 8
+    { ...baseParams, percentage: 100, expected: 15 }, // round(15*1) = 15
     { ...baseParams, percentage: 100_000_000, expected: 15_000_000 },
   ])
 
@@ -55,13 +57,16 @@ describe('Buy orders', () => {
   const isSell = false
 
   assertCases('handle different factors', isSell, [
-    { ...baseParams, percentage: 0, expected: 0 },
-    { ...baseParams, percentage: 0.5, expected: 1 },
-    { ...baseParams, percentage: 10, expected: 2 },
-    { ...baseParams, percentage: 25, expected: 5 },
-    { ...baseParams, percentage: 50, expected: 10 },
-    { ...baseParams, percentage: 100, expected: 20 },
-    { ...baseParams, percentage: 100_000_000, expected: 20_000_000 },
+    { ...baseParams, percentage: 0, expected: 0 }, // round(20*0) = 0
+    { ...baseParams, percentage: 0.5, expected: 0 }, // round(20*0.005) = 0
+    { ...baseParams, percentage: 2.4, expected: 0 }, // round(20*0.024) = 0
+    { ...baseParams, percentage: 2.5, expected: 1 }, // round(20*0.025) = 1
+    { ...baseParams, percentage: 2.6, expected: 1 }, // round(20*0.026) = 1
+    { ...baseParams, percentage: 10, expected: 2 }, // round(20*0.1) = 2
+    { ...baseParams, percentage: 25, expected: 5 }, // round(20*0.25) = 5
+    { ...baseParams, percentage: 50, expected: 10 }, // round(20*0.5) = 10
+    { ...baseParams, percentage: 100, expected: 20 }, // round(20*1) = 20
+    { ...baseParams, percentage: 100_000_000, expected: 20_000_000 }, // round(20*1) = 20
   ])
 
   assertCases('Handle atoms', isSell, [


### PR DESCRIPTION
This PR is just a tiny proposal to do normal rounding instead of `ceil` (as I suggested in previous PRs).

In chosed `ceil` for the slippage tolerance, because I would want to make the suggestion "pessimistic", so I can be assure that the slippage is enough. 

The problem is that in practice, 1bps is not a big difference, so less is half a point (worst case using rounding), specially when we include a slippage for volume and a slippage for 50% of the fee (so we are already pessimistic).

One motivation to do this, is because empirically I was getting a lot of `51 BPS` when testing this. This is because, it adds `50 BPS` for the volume (so that's given), and the rest is because of the fee. 

So if the order is big enough to make the 50% less than half a point, I suggest to round it to `50 BPS` cause its weird to suggests users such an odd number: `51 BPS` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted rounding behavior for percentage calculations to round to the nearest integer instead of always rounding up.

- **Tests**
  - Updated and expanded test cases to accurately reflect the new rounding logic for percentage-based calculations, improving precision and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->