### PR TITLE
fix: thow for sellAmount zero

### DIFF
--- a/src/trading/suggestSlippageFromVolume.test.ts
+++ b/src/trading/suggestSlippageFromVolume.test.ts
@@ -38,7 +38,7 @@ describe('Sell orders', () => {
       ...baseParams,
       sellAfter: -10n,
       percentage: 0.5,
-      expected: 'sellAmount must be non-negative: -10',
+      expected: 'sellAmount must be greater than 0: -10',
       description: 'sellAmountAfterFees is 0, sellBefore is 0',
     },
 
@@ -77,7 +77,7 @@ describe('Buy orders', () => {
       ...baseParams,
       sellBefore: -10n,
       percentage: 0.5,
-      expected: 'sellAmount must be non-negative: -10',
+      expected: 'sellAmount must be greater than 0: -10',
       description: 'sellAmountAfterFees is 0, sellBefore is 0',
     },
   ])

--- a/src/trading/suggestSlippageFromVolume.test.ts
+++ b/src/trading/suggestSlippageFromVolume.test.ts
@@ -33,12 +33,21 @@ describe('Sell orders', () => {
   ])
 
   assertCases('Handle edge case with sellAmount', isSell, [
-    // sellBefore is 0: returns maximum slippage
+    // sellAfter is negative: it throws an error
     {
       ...baseParams,
       sellAfter: -10n,
       percentage: 0.5,
       expected: 'sellAmount must be greater than 0: -10',
+      description: 'sellAmountAfterFees is 0, sellBefore is 0',
+    },
+
+    // sellAfter is 0: it throws an error
+    {
+      ...baseParams,
+      sellAfter: 0n,
+      percentage: 0.5,
+      expected: 'sellAmount must be greater than 0: 0',
       description: 'sellAmountAfterFees is 0, sellBefore is 0',
     },
 

--- a/src/trading/suggestSlippageFromVolume.test.ts
+++ b/src/trading/suggestSlippageFromVolume.test.ts
@@ -72,12 +72,21 @@ describe('Buy orders', () => {
   ])
 
   assertCases('Handle edge case with sellAmount', isSell, [
-    // sellBefore is 0: returns maximum slippage
+    // sellBefore is negative: it throws an error
     {
       ...baseParams,
       sellBefore: -10n,
       percentage: 0.5,
       expected: 'sellAmount must be greater than 0: -10',
+      description: 'sellAmountAfterFees is 0, sellBefore is 0',
+    },
+
+    // sellBefore is 0: it throws an error
+    {
+      ...baseParams,
+      sellBefore: 0n,
+      percentage: 0.5,
+      expected: 'sellAmount must be greater than 0: 0',
       description: 'sellAmountAfterFees is 0, sellBefore is 0',
     },
   ])

--- a/src/trading/suggestSlippageFromVolume.ts
+++ b/src/trading/suggestSlippageFromVolume.ts
@@ -16,8 +16,8 @@ export function suggestSlippageFromVolume(params: SuggestSlippageFromVolumeParam
   const sellAmount = isSell ? sellAmountAfterNetworkCosts : sellAmountBeforeNetworkCosts
 
   // Negative sell amounts are not allowed
-  if (sellAmount < 0n) {
-    throw new Error('sellAmount must be non-negative: ' + sellAmount)
+  if (sellAmount <= 0n) {
+    throw new Error('sellAmount must be greater than 0: ' + sellAmount)
   }
 
   // Slippage percentage must be non-negative


### PR DESCRIPTION
Addresses this comment https://github.com/cowprotocol/cow-sdk/pull/313/files#r2097544450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved input validation for sell amounts, now requiring values to be greater than zero.
  - Updated error messages to clearly indicate that sell amounts must be greater than zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->