### PR TITLE
feat: app data 3.1.0

### DIFF
--- a/examples/nodejs/src/index.ts
+++ b/examples/nodejs/src/index.ts
@@ -58,11 +58,11 @@ const privateKey = 'xxx'
       appData: {
         metadata: {
           partnerFee: {
-            bps: 100,
+            volumeBps: 100,
             recipient: '0xfb3c7eb936cAA12B5A884d612393969A557d4307',
           },
         },
       },
-    }
+    },
   )
 })()

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "trading:generateSchemas": "ts-node scripts/generateTradingSchemas.ts"
   },
   "dependencies": {
-    "@cowprotocol/app-data": "^3.0.0",
+    "@cowprotocol/app-data": "^3.1.0",
     "@cowprotocol/contracts": "^1.8.0",
     "@ethersproject/abstract-signer": "^5.8.0",
     "@openzeppelin/merkle-tree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.42",
+  "version": "6.0.0-RC.43",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/trading/appDataUtils.test.ts
+++ b/src/trading/appDataUtils.test.ts
@@ -25,19 +25,19 @@ describe('AppData utils', () => {
         environment: 'staging',
         metadata: {
           partnerFee: {
-            bps: 66,
+            volumeBps: 66,
             recipient: '0xccc',
           },
           replacedOrder: {
             uid: '0xaaa',
           },
         },
-      }
+      },
     )
     const parsedData = JSON.parse(data.fullAppData)
 
     expect(parsedData.environment).toBe('staging')
-    expect(parsedData.metadata.partnerFee.bps).toBe(66)
+    expect(parsedData.metadata.partnerFee.volumeBps).toBe(66)
     expect(parsedData.metadata.partnerFee.recipient).toBe('0xccc')
     expect(parsedData.metadata.replacedOrder.uid).toBe('0xaaa')
   })

--- a/src/trading/getOrderToSign.ts
+++ b/src/trading/getOrderToSign.ts
@@ -1,7 +1,8 @@
 import { BuyTokenDestination, getQuoteAmountsAndCosts, type OrderParameters, SellTokenSource } from '../order-book'
 import { UnsignedOrder } from '../order-signing'
-import { LimitTradeParameters } from './types'
 import { DEFAULT_QUOTE_VALIDITY, DEFAULT_SLIPPAGE_BPS } from './consts'
+import { LimitTradeParameters } from './types'
+import { getPartnerFeeBps } from './utils/getPartnerFeeBps'
 
 interface OrderToSignParams {
   from: string
@@ -11,7 +12,7 @@ interface OrderToSignParams {
 export function getOrderToSign(
   { from, networkCostsAmount = '0' }: OrderToSignParams,
   limitOrderParams: LimitTradeParameters,
-  appDataKeccak256: string
+  appDataKeccak256: string,
 ): UnsignedOrder {
   const {
     sellAmount,
@@ -46,7 +47,7 @@ export function getOrderToSign(
   const { afterSlippage } = getQuoteAmountsAndCosts({
     orderParams,
     slippagePercentBps: slippageBps,
-    partnerFeeBps: partnerFee?.bps,
+    partnerFeeBps: getPartnerFeeBps(partnerFee),
     sellDecimals: sellTokenDecimals,
     buyDecimals: buyTokenDecimals,
   })

--- a/src/trading/postSwapOrder.test.ts
+++ b/src/trading/postSwapOrder.test.ts
@@ -1,10 +1,10 @@
 import { getQuoteWithSigner } from './getQuote'
 
-import { postSwapOrderFromQuote } from './postSwapOrder'
-import { SwapParameters } from './types'
-import { OrderKind } from '../order-book'
 import { parseUnits } from 'ethers/lib/utils'
 import { SupportedChainId } from '../chains'
+import { OrderKind } from '../order-book'
+import { postSwapOrderFromQuote } from './postSwapOrder'
+import { SwapParameters } from './types'
 
 const WETH_ADDRESS = '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'
 const COW_ADDRESS = '0x0625aFB445C3B6B7B929342a04A22599fd5dBB59'
@@ -148,7 +148,7 @@ describe('postSwapOrder', () => {
     const orderParams = {
       ...SELL_ORDER_PARAMS,
       partnerFee: {
-        bps: 50,
+        volumeBps: 50,
         recipient: '0x444cc',
       },
     }

--- a/src/trading/utils/getPartnerFeeBps.ts
+++ b/src/trading/utils/getPartnerFeeBps.ts
@@ -1,0 +1,22 @@
+import { latest } from '@cowprotocol/app-data'
+
+export function getPartnerFeeBps(partnerFee: latest.PartnerFee | undefined): number | undefined {
+  if (!partnerFee) {
+    return undefined
+  }
+
+  if ('volumeBps' in partnerFee) {
+    return partnerFee.volumeBps
+  }
+
+  if (Array.isArray(partnerFee)) {
+    for (const fee of partnerFee) {
+      if ('volumeBps' in fee) {
+        return fee.volumeBps
+      }
+    }
+  }
+  // TODO: what do we do when partnerFee doesn't have volumeBps? (priceImprovementBps or surplusBps). Is it safe to ignore?
+
+  return undefined
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,10 +1411,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cowprotocol/app-data@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-3.0.0.tgz#e5e7676ee8884c5348553883d0e65562c2f09e66"
-  integrity sha512-EyNoyoq3VnVIzvylLdn4Q1r0tU7HOikkjXzYY9PXJ/DUfj9gka7lOyNK7Ot8En2eUYTl3DNAle9RP7kt2sEpeg==
+"@cowprotocol/app-data@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-3.1.0.tgz#2ba5ec7d958b2510f17b08c7e18e05157032c4da"
+  integrity sha512-hdIWp6fGz/vx3gdoJgwd8Dx8rYAblpZEBiXss5mNzgF/LBb21VVhF075sDl9oxyesKuJayKjgiAgaFiZYVgblA==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"


### PR DESCRIPTION
# Summary

Update to latest app-data v3.1.0

The main change is the new `metadata.partnerFee` format.

The old `metadata.partnerFee.bps` has been renamed to ``metadata.partnerFee.volumeBps`.
Besides, the field accepts 2 new fee types, and can also take an array of partner fees.

In this change, only the old behaviour (volume based fee) is supported, obj or array style.
Surplus and price improvement fee styles cannot be applied as they happen only after the trade and cannot be predicted ahead of time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a utility to extract partner fee basis points from advanced fee structures.

- **Bug Fixes**
  - Updated key names in partner fee metadata to use `volumeBps` instead of `bps` for improved consistency.

- **Chores**
  - Upgraded package dependencies and incremented the package version.
  - Standardized import order and formatting across several files.
  - Updated tests to reflect changes in partner fee key naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->