### PR TITLE
feat(bridge): get bridging params from bungee

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.54",
+  "version": "6.0.0-RC.55",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.55",
+  "version": "6.0.0-RC.56",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.57",
+  "version": "6.0.0-RC.58",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.56",
+  "version": "6.0.0-RC.57",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/bridging/providers/bungee/BungeeApi.ts
+++ b/src/bridging/providers/bungee/BungeeApi.ts
@@ -400,14 +400,12 @@ function isValidBungeeEventsResponse(response: unknown): response is BungeeEvent
     // Check required fields
     return (
       'identifier' in e &&
-      'srcTransactionHash' in e &&
       'bridgeName' in e &&
       'fromChainId' in e &&
       'isCowswapTrade' in e &&
       'orderId' in e &&
       'recipient' in e &&
       'sender' in e &&
-      'destTransactionHash' in e &&
       'srcTxStatus' in e &&
       'destTxStatus' in e
     )

--- a/src/bridging/providers/bungee/BungeeBridgeProvider.ts
+++ b/src/bridging/providers/bungee/BungeeBridgeProvider.ts
@@ -269,17 +269,21 @@ export class BungeeBridgeProvider implements BridgeProvider<BungeeQuoteResult> {
     if (event.srcTxStatus === BungeeEventStatus.COMPLETED && event.destTxStatus === BungeeEventStatus.PENDING) {
       // if bridgeName = across,
       if (event.bridgeName === BungeeBridgeName.ACROSS) {
-        // check across api to check status is expired or refunded
-        const acrossStatus = await this.api.getAcrossStatus(event.orderId)
-        if (acrossStatus === 'expired') {
-          return { status: BridgeStatus.EXPIRED, depositTxHash: event.srcTransactionHash }
-        }
-        if (acrossStatus === 'refunded') {
-          // refunded means failed
-          return { status: BridgeStatus.REFUND, depositTxHash: event.srcTransactionHash }
+        try {
+          // check across api to check status is expired or refunded
+          const acrossStatus = await this.api.getAcrossStatus(event.orderId)
+          if (acrossStatus === 'expired') {
+            return { status: BridgeStatus.EXPIRED, depositTxHash: event.srcTransactionHash }
+          }
+          if (acrossStatus === 'refunded') {
+            // refunded means failed
+            return { status: BridgeStatus.REFUND, depositTxHash: event.srcTransactionHash }
+          }
+        } catch (e) {
+          console.error('BungeeBridgeProvider get across status error', e)
         }
       }
-      // if not across, waiting for dest tx, return in_progress
+      // if not across or across API fails, waiting for dest tx, return in_progress
       return { status: BridgeStatus.IN_PROGRESS, depositTxHash: event.srcTransactionHash }
     }
 

--- a/src/bridging/providers/bungee/BungeeBridgeProvider.ts
+++ b/src/bridging/providers/bungee/BungeeBridgeProvider.ts
@@ -208,12 +208,27 @@ export class BungeeBridgeProvider implements BridgeProvider<BungeeQuoteResult> {
   async getBridgingParams(
     _chainId: ChainId,
     _provider: JsonRpcProvider,
-    _orderUid: string,
+    orderId: string,
     _txHash: string,
   ): Promise<BridgingDepositParams | null> {
-    console.log('getBridgingParams() Method not implemented in BungeeBridgeProvider.')
+    const events = await this.api.getEvents({ orderId })
+    const event = events[0]
 
-    return null
+    if (!event) return null
+
+    return {
+      inputTokenAddress: event.srcTokenAddress,
+      outputTokenAddress: event.destTokenAddress,
+      inputAmount: BigInt(event.srcAmount),
+      outputAmount: BigInt(event.destAmount),
+      owner: event.sender,
+      quoteTimestamp: null,
+      fillDeadline: null,
+      recipient: event.recipient,
+      sourceChainId: event.fromChainId,
+      destinationChainId: event.toChainId,
+      bridgingId: orderId,
+    }
   }
 
   async decodeBridgeHook(_hook: latestAppData.CoWHook): Promise<BridgeDeposit> {

--- a/src/bridging/providers/bungee/BungeeBridgeProvider.ts
+++ b/src/bridging/providers/bungee/BungeeBridgeProvider.ts
@@ -220,7 +220,7 @@ export class BungeeBridgeProvider implements BridgeProvider<BungeeQuoteResult> {
       inputTokenAddress: event.srcTokenAddress,
       outputTokenAddress: event.destTokenAddress,
       inputAmount: BigInt(event.srcAmount),
-      outputAmount: BigInt(event.destAmount),
+      outputAmount: event.destAmount ? BigInt(event.destAmount) : null,
       owner: event.sender,
       quoteTimestamp: null,
       fillDeadline: null,

--- a/src/bridging/providers/bungee/types.ts
+++ b/src/bridging/providers/bungee/types.ts
@@ -229,9 +229,9 @@ export type BungeeEvent = {
   srcTokenSymbol: string
   to: string
   toChainId: number
-  // When destTxStatus is PENDING the tx hash is undefined
+  // When destTxStatus is PENDING the tx hash and destAmount are undefined
   destTransactionHash?: string
-  destAmount: string
+  destAmount?: string
   destBlockHash: string
   destBlockNumber: number
   destBlockTimeStamp: number

--- a/src/bridging/providers/bungee/types.ts
+++ b/src/bridging/providers/bungee/types.ts
@@ -206,7 +206,8 @@ export enum BungeeBridgeName {
 
 export type BungeeEvent = {
   identifier: string
-  srcTransactionHash: string
+  // When srcTxStatus is PENDING the tx hash is undefined
+  srcTransactionHash?: string
   bridgeName: BungeeBridgeName
   fromChainId: number
   gasUsed: string
@@ -228,7 +229,8 @@ export type BungeeEvent = {
   srcTokenSymbol: string
   to: string
   toChainId: number
-  destTransactionHash: string
+  // When destTxStatus is PENDING the tx hash is undefined
+  destTransactionHash?: string
   destAmount: string
   destBlockHash: string
   destBlockNumber: number

--- a/src/bridging/types.ts
+++ b/src/bridging/types.ts
@@ -369,8 +369,8 @@ export interface BridgingDepositParams {
   inputAmount: bigint
   outputAmount: bigint
   owner: Address
-  quoteTimestamp: number
-  fillDeadline: number
+  quoteTimestamp: number | null
+  fillDeadline: number | null
   recipient: Address
   sourceChainId: number
   destinationChainId: number

--- a/src/bridging/types.ts
+++ b/src/bridging/types.ts
@@ -367,7 +367,7 @@ export interface BridgingDepositParams {
   inputTokenAddress: Address
   outputTokenAddress: Address
   inputAmount: bigint
-  outputAmount: bigint
+  outputAmount: bigint | null
   owner: Address
   quoteTimestamp: number | null
   fillDeadline: number | null


### PR DESCRIPTION
1. Fixed  `destTransactionHash` and `destTransactionHash` in `BungeeEvent`. The hashes are optional
2. Implemented `getBridgingParams` in Bungee provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved support for handling Bungee events where transaction hashes may be missing due to pending transaction statuses.
	- Enabled fetching and returning detailed bridging parameters for Bungee bridge orders.
- **Bug Fixes**
	- Enhanced type handling to allow certain timestamp fields to be explicitly null when unavailable.
	- Improved error handling and logging for status retrieval in the Across bridge integration.
- **Chores**
	- Updated the application version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->