### PR TITLE
refactor: lib, verifier addresses

### DIFF
--- a/src/bridging/providers/bungee/BungeeBridgeProvider.ts
+++ b/src/bridging/providers/bungee/BungeeBridgeProvider.ts
@@ -67,7 +67,7 @@ export class BungeeBridgeProvider implements BridgeProvider<BungeeQuoteResult> {
 
   info: BridgeProviderInfo = {
     name: 'Bungee',
-    logoUrl: `${RAW_PROVIDERS_FILES_PATH}/bungee/bungee-logo.png`, // TODO: set valid logo
+    logoUrl: `${RAW_PROVIDERS_FILES_PATH}/bungee/bungee-logo.png`,
     dappId: BUNGEE_HOOK_DAPP_ID,
   }
 
@@ -167,7 +167,6 @@ export class BungeeBridgeProvider implements BridgeProvider<BungeeQuoteResult> {
   }
 
   getGasLimitEstimationForHook(_request: QuoteBridgeRequest): number {
-    // TODO sim and replace gas limit
     return DEFAULT_GAS_COST_FOR_HOOK_ESTIMATION
   }
 

--- a/src/bridging/providers/bungee/abi.ts
+++ b/src/bridging/providers/bungee/abi.ts
@@ -200,6 +200,11 @@ export const BUNGEE_COWSWAP_LIB_ABI = [
     type: 'error',
   },
   {
+    inputs: [],
+    name: 'PositionOutOfBounds',
+    type: 'error',
+  },
+  {
     inputs: [
       {
         internalType: 'uint256',
@@ -207,9 +212,9 @@ export const BUNGEE_COWSWAP_LIB_ABI = [
         type: 'uint256',
       },
       {
-        internalType: 'bytes',
+        internalType: 'uint256',
         name: '_compare',
-        type: 'bytes',
+        type: 'uint256',
       },
       {
         internalType: 'uint256',
@@ -236,9 +241,9 @@ export const BUNGEE_COWSWAP_LIB_ABI = [
         type: 'uint256',
       },
       {
-        internalType: 'bytes',
+        internalType: 'uint256',
         name: '_compare',
-        type: 'bytes',
+        type: 'uint256',
       },
       {
         internalType: 'uint256',
@@ -294,14 +299,43 @@ export const BUNGEE_COWSWAP_LIB_ABI = [
   {
     inputs: [
       {
+        internalType: 'bytes',
+        name: '_original',
+        type: 'bytes',
+      },
+      {
+        internalType: 'uint256',
+        name: '_start',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'replaceUint256',
+    outputs: [
+      {
+        internalType: 'bytes',
+        name: '',
+        type: 'bytes',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
         internalType: 'uint256',
         name: '_base',
         type: 'uint256',
       },
       {
-        internalType: 'bytes',
+        internalType: 'uint256',
         name: '_compare',
-        type: 'bytes',
+        type: 'uint256',
       },
       {
         internalType: 'uint256',

--- a/src/bridging/providers/bungee/const/contracts.ts
+++ b/src/bridging/providers/bungee/const/contracts.ts
@@ -1,6 +1,6 @@
 import { AdditionalTargetChainId, SupportedChainId, TargetChainId } from '../../../../chains'
 
-const BUNGEE_COWSWAP_LIB_ADDRESS = '0x411b20d4593fee999b37bdb4a9d0ff862bdc0c77'
+const BUNGEE_COWSWAP_LIB_ADDRESS = '0x75b6ba5fcab20848ca00f132d253638fea82e598'
 export const BungeeCowswapLibAddresses: Record<TargetChainId, string | undefined> = {
   [SupportedChainId.MAINNET]: BUNGEE_COWSWAP_LIB_ADDRESS,
   [SupportedChainId.GNOSIS_CHAIN]: BUNGEE_COWSWAP_LIB_ADDRESS,

--- a/src/bridging/providers/bungee/const/contracts.ts
+++ b/src/bridging/providers/bungee/const/contracts.ts
@@ -1,25 +1,25 @@
-// TODO deploy on all chains
 import { AdditionalTargetChainId, SupportedChainId, TargetChainId } from '../../../../chains'
 
+const BUNGEE_COWSWAP_LIB_ADDRESS = '0x411b20d4593fee999b37bdb4a9d0ff862bdc0c77'
 export const BungeeCowswapLibAddresses: Record<TargetChainId, string | undefined> = {
-  [SupportedChainId.MAINNET]: undefined,
-  [SupportedChainId.GNOSIS_CHAIN]: undefined,
-  [SupportedChainId.ARBITRUM_ONE]: '0x73eb30778f7e3958bfd974d10c0be559c2c65e22',
-  [SupportedChainId.BASE]: undefined,
-  [SupportedChainId.AVALANCHE]: undefined,
-  [SupportedChainId.POLYGON]: undefined,
+  [SupportedChainId.MAINNET]: BUNGEE_COWSWAP_LIB_ADDRESS,
+  [SupportedChainId.GNOSIS_CHAIN]: BUNGEE_COWSWAP_LIB_ADDRESS,
+  [SupportedChainId.ARBITRUM_ONE]: BUNGEE_COWSWAP_LIB_ADDRESS,
+  [SupportedChainId.BASE]: BUNGEE_COWSWAP_LIB_ADDRESS,
+  [SupportedChainId.AVALANCHE]: BUNGEE_COWSWAP_LIB_ADDRESS,
+  [SupportedChainId.POLYGON]: BUNGEE_COWSWAP_LIB_ADDRESS,
   [SupportedChainId.SEPOLIA]: undefined,
-  [AdditionalTargetChainId.OPTIMISM]: undefined,
+  [AdditionalTargetChainId.OPTIMISM]: BUNGEE_COWSWAP_LIB_ADDRESS,
 }
 
-// TODO deploy on all chains
+const SOCKET_VERIFIER_ADDRESS = '0xa27A3f5A96DF7D8Be26EE2790999860C00eb688D'
 export const SocketVerifierAddresses: Record<TargetChainId, string | undefined> = {
-  [SupportedChainId.MAINNET]: undefined,
-  [SupportedChainId.GNOSIS_CHAIN]: undefined,
-  [SupportedChainId.ARBITRUM_ONE]: '0x69D9f76e4cbE81044FE16C399387b12e4DBF27B1',
-  [SupportedChainId.BASE]: undefined,
-  [SupportedChainId.AVALANCHE]: undefined,
-  [SupportedChainId.POLYGON]: undefined,
+  [SupportedChainId.MAINNET]: SOCKET_VERIFIER_ADDRESS,
+  [SupportedChainId.GNOSIS_CHAIN]: SOCKET_VERIFIER_ADDRESS,
+  [SupportedChainId.ARBITRUM_ONE]: SOCKET_VERIFIER_ADDRESS,
+  [SupportedChainId.BASE]: SOCKET_VERIFIER_ADDRESS,
+  [SupportedChainId.AVALANCHE]: SOCKET_VERIFIER_ADDRESS,
+  [SupportedChainId.POLYGON]: SOCKET_VERIFIER_ADDRESS,
   [SupportedChainId.SEPOLIA]: undefined,
-  [AdditionalTargetChainId.OPTIMISM]: undefined,
+  [AdditionalTargetChainId.OPTIMISM]: SOCKET_VERIFIER_ADDRESS,
 }


### PR DESCRIPTION
- Deployed a new BungeeCowswapLib contract that uses lesser gas for amount replacement, and takes uint256 as input
  - Changed the weiroll txn build accordingly
- Deployed verifier contracts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new error type and a new function in the Bungee bridging library, enhancing error handling and data replacement capabilities.

- **Refactor**
  - Updated contract addresses for supported chains to use shared constants, improving consistency across networks.
  - Simplified logic for handling token amounts by switching from raw byte manipulation to direct uint256 value replacement in deposit call creation.

- **Style**
  - Removed outdated comments and unused code for improved code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->