### PR TITLE
feat(bridge): expose more CrossChainOrder data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.58",
+  "version": "6.0.0-RC.59",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/bridging/BridgingSdk/getCrossChainOrder.ts
+++ b/src/bridging/BridgingSdk/getCrossChainOrder.ts
@@ -58,6 +58,7 @@ export async function getCrossChainOrder(params: GetCrossChainOrderParams): Prom
     }
 
     const state: CrossChainOrder = {
+      provider,
       chainId,
       order,
       statusResult: {

--- a/src/bridging/index.ts
+++ b/src/bridging/index.ts
@@ -4,6 +4,8 @@ export * from './utils'
 
 // SDK
 export * from './BridgingSdk/BridgingSdk'
+export * from './const'
+export { getCrossChainOrder } from './BridgingSdk/getCrossChainOrder'
 
 // Providers
 export {

--- a/src/bridging/providers/across/AcrossApi.spec.ts
+++ b/src/bridging/providers/across/AcrossApi.spec.ts
@@ -1,6 +1,7 @@
 import { AdditionalTargetChainId, SupportedChainId } from '../../../chains'
 import { AcrossApi } from './AcrossApi'
 import { DepositStatusResponse } from './types'
+
 describe('AcrossApi: Shape of API response', () => {
   let api: AcrossApi
 

--- a/src/bridging/providers/across/AcrossBridgeProvider.test.ts
+++ b/src/bridging/providers/across/AcrossBridgeProvider.test.ts
@@ -168,6 +168,7 @@ describe('AcrossBridgeProvider', () => {
         dappId: ACROSS_HOOK_DAPP_ID,
         name: 'Across',
         logoUrl: expect.stringContaining('across-logo.png'),
+        website: 'https://across.to',
       })
     })
   })

--- a/src/bridging/providers/across/AcrossBridgeProvider.ts
+++ b/src/bridging/providers/across/AcrossBridgeProvider.ts
@@ -72,6 +72,7 @@ export class AcrossBridgeProvider implements BridgeProvider<AcrossQuoteResult> {
     name: 'Across',
     logoUrl: `${RAW_PROVIDERS_FILES_PATH}/across/across-logo.png`,
     dappId: ACROSS_HOOK_DAPP_ID,
+    website: 'https://across.to',
   }
 
   async getNetworks(): Promise<ChainInfo[]> {

--- a/src/bridging/providers/bungee/BungeeBridgeProvider.test.ts
+++ b/src/bridging/providers/bungee/BungeeBridgeProvider.test.ts
@@ -249,6 +249,7 @@ describe('BungeeBridgeProvider', () => {
         dappId: BUNGEE_HOOK_DAPP_ID,
         name: 'Bungee',
         logoUrl: expect.stringContaining('bungee-logo.png'),
+        website: 'https://www.bungee.exchange',
       })
     })
   })

--- a/src/bridging/providers/bungee/BungeeBridgeProvider.ts
+++ b/src/bridging/providers/bungee/BungeeBridgeProvider.ts
@@ -69,6 +69,7 @@ export class BungeeBridgeProvider implements BridgeProvider<BungeeQuoteResult> {
     name: 'Bungee',
     logoUrl: `${RAW_PROVIDERS_FILES_PATH}/bungee/bungee-logo.png`,
     dappId: BUNGEE_HOOK_DAPP_ID,
+    website: 'https://www.bungee.exchange',
   }
 
   async getNetworks(): Promise<ChainInfo[]> {

--- a/src/bridging/providers/mock/MockBridgeProvider.ts
+++ b/src/bridging/providers/mock/MockBridgeProvider.ts
@@ -110,6 +110,7 @@ export class MockBridgeProvider implements BridgeProvider<BridgeQuoteResult> {
     name: 'Mock',
     logoUrl: `${RAW_PROVIDERS_FILES_PATH}/mock/mock-logo.png`,
     dappId: 'mockProvider',
+    website: 'https://across.to',
   }
 
   async getNetworks(): Promise<ChainInfo[]> {

--- a/src/bridging/types.ts
+++ b/src/bridging/types.ts
@@ -20,6 +20,7 @@ export interface BridgeProviderInfo {
   name: string
   logoUrl: string
   dappId: string
+  website: string
 }
 
 interface WithSellToken {
@@ -378,6 +379,7 @@ export interface BridgingDepositParams {
 }
 
 export interface CrossChainOrder {
+  provider: BridgeProvider<BridgeQuoteResult>
   chainId: SupportedChainId
   order: EnrichedOrder
   statusResult: BridgeStatusResult


### PR DESCRIPTION
The data is needed in Explorer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a website URL to bridge provider information, making it easier for users to access official provider sites.
	- Bridge provider details are now included directly with cross-chain orders.
- **Style**
	- Minor formatting improvements in test files.
- **Tests**
	- Updated tests to validate the presence of website URLs in provider information.
- **Chores**
	- Updated internal version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->