### PR TITLE
Chore(sdk-agnostic-lib): Revert "feat: add more tokens to `Avalanche` and `Polygon` (#320)"

### DIFF
--- a/examples/vanilla/src/tokens.ts
+++ b/examples/vanilla/src/tokens.ts
@@ -57,17 +57,4 @@ export const TOKENS: Record<SupportedChainId, Token[]> = {
     new Token(SupportedChainId.BASE, '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', 6, 'USDC', 'USD Coin'),
     new Token(SupportedChainId.BASE, '0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42', 6, 'EURC', 'EURC'),
   ],
-  [SupportedChainId.AVALANCHE]: [
-    new Token(SupportedChainId.AVALANCHE, ETH_ADDRESS, 18, 'AVAX', 'Avalanche'),
-    new Token(SupportedChainId.AVALANCHE, '0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7', 6, 'USDT', 'Tether USD'),
-    new Token(SupportedChainId.AVALANCHE, '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7', 18, 'WAVAX', 'Wrapped AVAX'),
-    new Token(SupportedChainId.AVALANCHE, '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e', 6, 'USDC', 'USD Coin'),
-  ],
-  [SupportedChainId.POLYGON]: [
-    new Token(SupportedChainId.POLYGON, ETH_ADDRESS, 18, 'POL', 'POL ex MATIC'),
-    new Token(SupportedChainId.POLYGON, '0xc2132d05d31c914a87c6611c10748aeb04b58e8f', 6, 'USDT', 'Tether USD'),
-    new Token(SupportedChainId.POLYGON, '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270', 18, 'WPOL', 'Wrapped POL'),
-    new Token(SupportedChainId.POLYGON, '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359', 6, 'USDC', 'USD Coin'),
-    new Token(SupportedChainId.POLYGON, '0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063', 18, 'DAI', 'DAI Coin'),
-  ],
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.44",
+  "version": "6.0.0-RC.43",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/chains/details/polygon.ts
+++ b/src/chains/details/polygon.ts
@@ -1,22 +1,22 @@
 import { nativeCurrencyTemplate } from '../../common/consts/tokens'
-import { ChainInfo, SupportedChainId } from '../types'
+import { ChainInfo } from '../types'
 import { RAW_CHAINS_FILES_PATH } from '../const/path'
 
 const polygonLogo = `${RAW_CHAINS_FILES_PATH}/images/polygon-logo.svg`
 
 // See https://github.com/wevm/viem/blob/main/src/chains/definitions/polygon.ts
 export const polygon: ChainInfo = {
-  id: SupportedChainId.POLYGON,
+  id: 137,
   label: 'Polygon',
   logo: { light: polygonLogo, dark: polygonLogo },
   nativeCurrency: {
     ...nativeCurrencyTemplate,
-    chainId: SupportedChainId.POLYGON,
+    chainId: 137,
     name: 'POL',
     symbol: 'POL',
     logoUrl: polygonLogo,
   },
-  addressPrefix: 'polygon',
+  addressPrefix: 'op',
   isTestnet: false,
   contracts: {
     multicall3: {


### PR DESCRIPTION
This PR temporarily reverts commit `219ab33` ("feat: add more tokens to Avalanche and Polygon") from the `SDK-AGNOSTIC-LIB` branch.

That commit was added directly to `main`, and the `SDK-AGNOSTIC-LIB` branch was later created from `main`, causing it to inherit this change. Since our `bleu/refactor` branch was created earlier (without this commit), all PRs from our refactor work were running into unnecessary conflicts.

By reverting this commit temporarily, we avoid conflicts across multiple PRs. The original change will be restored when we complete the refactor and merge everything back into `main`, which already contains this commit.

This is a safe and temporary solution to simplify the ongoing development and review process.

This reverts commit 219ab33a560fd3800092e2db16098431cef2196e.