### PR TITLE
fix(trading): return consistent trade params regardless of auto-slippage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.59",
+  "version": "6.0.0-RC.60",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/trading/getEthFlowTransaction.ts
+++ b/src/trading/getEthFlowTransaction.ts
@@ -2,11 +2,11 @@ import { LimitTradeParametersFromQuote, PostTradeAdditionalParams, TransactionPa
 import { calculateUniqueOrderId } from './calculateUniqueOrderId'
 import { getOrderToSign } from './getOrderToSign'
 import { type EthFlow, EthFlow__factory } from '../common/generated'
-import { BARN_ETH_FLOW_ADDRESS, CowEnv, ETH_FLOW_ADDRESS, WRAPPED_NATIVE_CURRENCIES } from '../common'
+import { BARN_ETH_FLOW_ADDRESS, CowEnv, ETH_FLOW_ADDRESS } from '../common'
 import { SupportedChainId } from '../chains'
 import { GAS_LIMIT_DEFAULT } from './consts'
 import type { EthFlowOrder } from '../common/generated/EthFlow'
-import { calculateGasMargin } from './utils/misc'
+import { adjustEthFlowOrderParams, calculateGasMargin } from './utils/misc'
 import { Signer } from '@ethersproject/abstract-signer'
 import type { UnsignedOrder } from '../order-signing'
 import { getDefaultSlippageBps } from './utils/slippage'
@@ -23,10 +23,10 @@ export async function getEthFlowTransaction(
   const slippageBps = _params.slippageBps ?? getDefaultSlippageBps(chainId, true)
 
   const params = {
-    ..._params,
-    sellToken: WRAPPED_NATIVE_CURRENCIES[chainId].address,
+    ...adjustEthFlowOrderParams(chainId, _params),
     slippageBps,
   }
+
   const { quoteId } = params
 
   const contract = getEthFlowContract(signer, params.env)

--- a/src/trading/getQuote.test.ts
+++ b/src/trading/getQuote.test.ts
@@ -179,6 +179,32 @@ describe('getQuoteToSign', () => {
         // 2% slippage
         expect(+result.amountsAndCosts.afterSlippage.buyAmount.toString()).toBe(buyAmount - (buyAmount * 2) / 100)
       })
+
+      describe.each<boolean>([true, false])('With/without dynamic slippage', (withDynamicSlippage) => {
+        const slippageBps = withDynamicSlippage ? undefined : 100
+
+        it('Quote request sell token must be a wrapped token', async () => {
+          await getQuoteWithSigner(
+            { ...defaultOrderParams, chainId: SupportedChainId.MAINNET, sellToken: ETH_ADDRESS, slippageBps },
+            {},
+            orderBookApiMock,
+          )
+
+          const call = getQuoteMock.mock.calls[0][0]
+
+          expect(call.sellToken).toBe(WRAPPED_NATIVE_CURRENCIES[SupportedChainId.MAINNET].address)
+        })
+
+        it('Sell token in tradeParameters must not be overridden with wrapped', async () => {
+          const { result } = await getQuoteWithSigner(
+            { ...defaultOrderParams, chainId: SupportedChainId.MAINNET, sellToken: ETH_ADDRESS, slippageBps },
+            {},
+            orderBookApiMock,
+          )
+
+          expect(result.tradeParameters.sellToken).toBe(ETH_ADDRESS)
+        })
+      })
     })
   })
 

--- a/src/trading/suggestSlippageBps.ts
+++ b/src/trading/suggestSlippageBps.ts
@@ -12,7 +12,7 @@ const SLIPPAGE_VOLUME_MULTIPLIER_PERCENT = 0.5 // Account for 0.5% volume as sli
 
 export interface SuggestSlippageBps {
   isEthFlow: boolean
-  tradeParameters: TradeParameters
+  tradeParameters: Pick<TradeParameters, 'sellTokenDecimals' | 'buyTokenDecimals'>
   quote: OrderQuoteResponse
   trader: QuoterParameters
   advancedSettings?: SwapAdvancedSettings

--- a/src/trading/utils/misc.ts
+++ b/src/trading/utils/misc.ts
@@ -1,6 +1,7 @@
 import { LimitTradeParametersFromQuote, TradeParameters } from '../types'
 import { OrderQuoteResponse, QuoteAmountsAndCosts } from '../../order-book'
-import { ETH_ADDRESS } from '../../common'
+import { ETH_ADDRESS, WRAPPED_NATIVE_CURRENCIES } from '../../common'
+import { SupportedChainId } from '../../chains'
 
 export function swapParamsToLimitOrderParams(
   params: TradeParameters,
@@ -75,4 +76,25 @@ export function getTradeParametersAfterQuote({
   sellToken: string
 }): TradeParameters {
   return { ...quoteParameters, sellToken }
+}
+
+/**
+ * ETH-flow orders are special and need to be adjusted
+ * 1. Sell token should be the wrapped native currency
+ */
+export function adjustEthFlowOrderParams(chainId: SupportedChainId, params: TradeParameters): TradeParameters
+
+export function adjustEthFlowOrderParams(
+  chainId: SupportedChainId,
+  params: LimitTradeParametersFromQuote,
+): LimitTradeParametersFromQuote
+
+export function adjustEthFlowOrderParams(
+  chainId: SupportedChainId,
+  params: TradeParameters | LimitTradeParametersFromQuote,
+): typeof params {
+  return {
+    ...params,
+    sellToken: WRAPPED_NATIVE_CURRENCIES[chainId].address,
+  }
 }

--- a/src/trading/utils/slippage.ts
+++ b/src/trading/utils/slippage.ts
@@ -1,4 +1,3 @@
-import { getIsEthFlowOrder } from './misc'
 import { SupportedChainId } from '../../chains'
 
 const SCALE = 10n ** 6n // 6 decimal places of precision. Used to avoid depending on Big Decimal libraries
@@ -64,16 +63,7 @@ export function getSlippagePercent(params: {
   }
 }
 
-export function getDefaultSlippageBps(chainId: SupportedChainId, isEthFlowOrder: boolean): number
-
-export function getDefaultSlippageBps(chainId: SupportedChainId, sellToken: string): number
-
-export function getDefaultSlippageBps(chainId: SupportedChainId, isEthFlowOrSellToken: boolean | string): number {
-  const isEthFlow =
-    typeof isEthFlowOrSellToken === 'boolean'
-      ? isEthFlowOrSellToken
-      : getIsEthFlowOrder({ sellToken: isEthFlowOrSellToken })
-
+export function getDefaultSlippageBps(chainId: SupportedChainId, isEthFlow: boolean): number {
   if (isEthFlow) {
     return ETH_FLOW_DEFAULT_SLIPPAGE_BPS[chainId]
   } else {


### PR DESCRIPTION
There was inconsitency between manual and auto slippage scenarios.
For ETH-flow orders when fetching a quote, we should use wrapped token address as a sellToken instead of 0xeeeee...

In `getQuote()` result, for auto-slippage it was returning sellToken = 0xeeeee, but when slippage is manual, it was returning wrapped token address.
After that fix it will always return 0xeeeee in both cases to keep the data consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of ETH trades to ensure the correct token addresses are used internally and externally, regardless of slippage settings.

- **Refactor**
  - Streamlined internal logic for ETH-flow order parameter adjustments and slippage determination, resulting in more consistent and maintainable trade processing.

- **Tests**
  - Added new tests to verify that ETH trades use the appropriate token addresses in both internal requests and returned trade parameters.

- **Chores**
  - Updated the package version to 6.0.0-RC.60.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->