### PR TITLE
feat: change Avalanche explorer from Snowtrace to Snowscan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.62",
+  "version": "6.0.0-RC.63",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/chains/details/avalanche.ts
+++ b/src/chains/details/avalanche.ts
@@ -40,7 +40,7 @@ export const avalanche: ChainInfo = {
     url: 'https://build.avax.network/docs',
   },
   blockExplorer: {
-    name: 'Snowtrace',
-    url: 'https://snowtrace.io',
+    name: 'Snowscan',
+    url: 'https://snowscan.xyz/',
   },
 }

--- a/src/chains/details/avalanche.ts
+++ b/src/chains/details/avalanche.ts
@@ -41,6 +41,6 @@ export const avalanche: ChainInfo = {
   },
   blockExplorer: {
     name: 'Snowscan',
-    url: 'https://snowscan.xyz/',
+    url: 'https://snowscan.xyz',
   },
 }


### PR DESCRIPTION
# Description

- change Avalanche explorer from Snowtrace to [Snowscan](https://snowscan.xyz/) 
- bump version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the package version to 6.0.0-RC.63.

- **Bug Fixes**
  - Updated Avalanche chain information to display the new block explorer name ("Snowscan") and URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->