### PR TITLE
fix(bridge): unify quote errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.65",
+  "version": "6.0.0-RC.66",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/bridging/BridgingSdk/getQuoteWithBridge.ts
+++ b/src/bridging/BridgingSdk/getQuoteWithBridge.ts
@@ -22,7 +22,7 @@ import { OrderKind } from '../../order-book'
 import { jsonWithBigintReplacer } from '../../common/utils/serialize'
 import { parseUnits } from '@ethersproject/units'
 import { QuoteResultsWithSigner } from '../../trading/getQuote'
-import { BridgeProviderQuoteError } from '../errors'
+import { BridgeProviderQuoteError, BridgeQuoteErrors } from '../errors'
 import { getTradeParametersAfterQuote } from '../../trading/utils/misc'
 import { BridgeResultContext, GetBridgeResultResult, GetQuoteWithBridgeParams } from './types'
 import { getBridgeSignedHook } from './getBridgeSignedHook'
@@ -216,7 +216,7 @@ async function getBaseBridgeQuoteRequest<T extends BridgeQuoteResult>(params: {
   const intermediateTokens = await provider.getIntermediateTokens(quoteBridgeRequest)
 
   if (intermediateTokens.length === 0) {
-    throw new BridgeProviderQuoteError('No path found (not intermediate token for bridging)', {})
+    throw new BridgeProviderQuoteError(BridgeQuoteErrors.NO_INTERMEDIATE_TOKENS)
   }
 
   // We just pick the first intermediate token for now

--- a/src/bridging/errors.ts
+++ b/src/bridging/errors.ts
@@ -1,10 +1,31 @@
+export enum BridgeQuoteErrors {
+  NO_INTERMEDIATE_TOKENS = 'NO_INTERMEDIATE_TOKENS',
+  API_ERROR = 'API_ERROR',
+  INVALID_API_JSON_RESPONSE = 'INVALID_API_JSON_RESPONSE',
+  ONLY_SELL_ORDER_SUPPORTED = 'ONLY_SELL_ORDER_SUPPORTED',
+  TX_BUILD_ERROR = 'TX_BUILD_ERROR',
+  QUOTE_ERROR = 'QUOTE_ERROR',
+  NO_ROUTES = 'NO_ROUTES',
+  INVALID_BRIDGE = 'INVALID_BRIDGE',
+}
+
 export class BridgeProviderQuoteError extends Error {
+  constructor(
+    message: BridgeQuoteErrors,
+    public readonly context?: unknown,
+  ) {
+    super(message)
+    this.name = 'BridgeProviderQuoteError'
+  }
+}
+
+export class BridgeProviderError extends Error {
   constructor(
     message: string,
     public readonly context: unknown,
   ) {
     super(message)
-    this.name = 'BridgeProviderQuoteError'
+    this.name = 'BridgeProviderError'
   }
 }
 

--- a/src/bridging/providers/across/AcrossApi.test.ts
+++ b/src/bridging/providers/across/AcrossApi.test.ts
@@ -1,6 +1,7 @@
 import { AcrossApi } from './AcrossApi'
 import { SupportedChainId } from '../../../chains'
 import { DepositStatusRequest, DepositStatusResponse, SuggestedFeesRequest, SuggestedFeesResponse } from './types'
+import { BridgeQuoteErrors } from '../../errors'
 
 // Mock fetch globally
 const mockFetch = jest.fn()
@@ -64,7 +65,7 @@ describe('AcrossApi', () => {
           destinationChainId: '137',
           destinationToken: '0x0000000000000000000000000000000000000002',
         }),
-      ).rejects.toThrow('Across Api Error')
+      ).rejects.toThrow(BridgeQuoteErrors.API_ERROR)
     })
   })
 
@@ -146,7 +147,7 @@ describe('AcrossApi', () => {
           destinationChainId: SupportedChainId.POLYGON,
           amount: 1000000000000000000n,
         }),
-      ).rejects.toThrow('Across Api Error')
+      ).rejects.toThrow(BridgeQuoteErrors.API_ERROR)
     })
   })
 
@@ -239,7 +240,7 @@ describe('AcrossApi', () => {
           originChainId: '1',
           depositId: '1234567890',
         }),
-      ).rejects.toThrow('Across Api Error')
+      ).rejects.toThrow(BridgeQuoteErrors.API_ERROR)
     })
   })
 })

--- a/src/bridging/providers/across/AcrossApi.ts
+++ b/src/bridging/providers/across/AcrossApi.ts
@@ -9,7 +9,7 @@ import {
   SuggestedFeesRequest,
   SuggestedFeesResponse,
 } from './types'
-import { BridgeProviderQuoteError } from '../../errors'
+import { BridgeProviderQuoteError, BridgeQuoteErrors } from '../../errors'
 import { TokenInfo } from '../../../common'
 
 const ACROSS_API_URL = 'https://app.across.to/api'
@@ -103,7 +103,7 @@ export class AcrossApi {
 
     if (!response.ok) {
       const errorBody = await response.json()
-      throw new BridgeProviderQuoteError('Across Api Error', errorBody)
+      throw new BridgeProviderQuoteError(BridgeQuoteErrors.API_ERROR, errorBody)
     }
 
     // Validate the response
@@ -112,10 +112,7 @@ export class AcrossApi {
       if (isValidResponse(json)) {
         return json
       } else {
-        throw new BridgeProviderQuoteError(
-          `Invalid response for Across API call ${path}. The response doesn't pass the validation. Did the API change?`,
-          json,
-        )
+        throw new BridgeProviderQuoteError(BridgeQuoteErrors.INVALID_API_JSON_RESPONSE, { path, json })
       }
     }
 

--- a/src/bridging/providers/across/AcrossBridgeProvider.ts
+++ b/src/bridging/providers/across/AcrossBridgeProvider.ts
@@ -35,7 +35,7 @@ import { OrderKind } from '@cowprotocol/contracts'
 import { SuggestedFeesResponse } from './types'
 import { getDepositParams } from './getDepositParams'
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { BridgeProviderQuoteError } from '../../errors'
+import { BridgeProviderQuoteError, BridgeQuoteErrors } from '../../errors'
 
 type SupportedTokensState = Record<ChainId, Record<string, TokenInfo>>
 
@@ -85,7 +85,7 @@ export class AcrossBridgeProvider implements BridgeProvider<AcrossQuoteResult> {
 
   async getIntermediateTokens(request: QuoteBridgeRequest): Promise<TokenInfo[]> {
     if (request.kind !== OrderKind.SELL) {
-      throw new BridgeProviderQuoteError('Only SELL is supported for now', { kind: request.kind })
+      throw new BridgeProviderQuoteError(BridgeQuoteErrors.ONLY_SELL_ORDER_SUPPORTED, { kind: request.kind })
     }
 
     const { sellTokenChainId, buyTokenChainId, buyTokenAddress } = request

--- a/src/bridging/providers/bungee/BungeeApi.test.ts
+++ b/src/bridging/providers/bungee/BungeeApi.test.ts
@@ -1,103 +1,104 @@
 import { BungeeApi } from './BungeeApi'
 import { BungeeQuote, BungeeQuoteAPIRequest, BungeeBridge, BungeeQuoteAPIResponse } from './types'
+import { BridgeQuoteErrors } from '../../errors'
 
 // Mock fetch globally
 const mockFetch = jest.fn()
 global.fetch = mockFetch
 
- const mockQuoteResponse: BungeeQuoteAPIResponse = {
-      success: true,
-      statusCode: 200,
-      result: {
-        originChainId: 1,
-        destinationChainId: 137,
-        userAddress: '0x123',
-        receiverAddress: '0x456',
-        input: {
+const mockQuoteResponse: BungeeQuoteAPIResponse = {
+  success: true,
+  statusCode: 200,
+  result: {
+    originChainId: 1,
+    destinationChainId: 137,
+    userAddress: '0x123',
+    receiverAddress: '0x456',
+    input: {
+      token: {
+        chainId: 1,
+        address: '0x0000000000000000000000000000000000000001',
+        name: 'USD Coin',
+        symbol: 'USDC',
+        decimals: 6,
+        logoURI: 'https://example.com/usdc.png',
+        icon: 'usdc',
+      },
+      amount: '1000000',
+      priceInUsd: 1,
+      valueInUsd: 1000,
+    },
+    destinationExec: null,
+    autoRoute: null,
+    manualRoutes: [
+      {
+        quoteId: '123',
+        quoteExpiry: 1234567890,
+        output: {
           token: {
-            chainId: 1,
-            address: '0x0000000000000000000000000000000000000001',
+            chainId: 137,
+            address: '0x0000000000000000000000000000000000000002',
             name: 'USD Coin',
             symbol: 'USDC',
             decimals: 6,
             logoURI: 'https://example.com/usdc.png',
             icon: 'usdc',
           },
-          amount: '1000000',
+          amount: '990000',
           priceInUsd: 1,
-          valueInUsd: 1000,
+          valueInUsd: 990,
+          minAmountOut: '980000',
+          effectiveReceivedInUsd: 980,
         },
-        destinationExec: null,
-        autoRoute: null,
-        manualRoutes: [
-          {
-            quoteId: '123',
-            quoteExpiry: 1234567890,
-            output: {
-              token: {
-                chainId: 137,
-                address: '0x0000000000000000000000000000000000000002',
-                name: 'USD Coin',
-                symbol: 'USDC',
-                decimals: 6,
-                logoURI: 'https://example.com/usdc.png',
-                icon: 'usdc',
-              },
-              amount: '990000',
-              priceInUsd: 1,
-              valueInUsd: 990,
-              minAmountOut: '980000',
-              effectiveReceivedInUsd: 980,
-            },
-            affiliateFee: null,
-            approvalData: {
-              spenderAddress: '0x0000000000000000000000000000000000000003',
-              amount: '1000000',
-              tokenAddress: '0x0000000000000000000000000000000000000001',
-              userAddress: '0x123',
-            },
-            gasFee: {
-              gasToken: {
-                chainId: 1,
-                address: '0x0000000000000000000000000000000000000004',
-                symbol: 'ETH',
-                name: 'Ethereum',
-                decimals: 18,
-                icon: 'eth',
-                logoURI: 'https://example.com/eth.png',
-                chainAgnosticId: null,
-              },
-              gasLimit: '100000',
-              gasPrice: '20000000000',
-              estimatedFee: '0.001',
-              feeInUsd: 2,
-            },
-            slippage: 0.5,
-            estimatedTime: 300,
-            routeDetails: {
-              name: 'Across',
-              logoURI: 'https://example.com/across.png',
-              routeFee: {
-                token: {
-                  chainId: 1,
-                  address: '0x0000000000000000000000000000000000000001',
-                  name: 'USD Coin',
-                  symbol: 'USDC',
-                  decimals: 6,
-                  logoURI: 'https://example.com/usdc.png',
-                  icon: 'usdc',
-                },
-                amount: '1000',
-                feeInUsd: 1,
-                priceInUsd: 1,
-              },
-              dexDetails: null,
-            },
-            refuel: null,
+        affiliateFee: null,
+        approvalData: {
+          spenderAddress: '0x0000000000000000000000000000000000000003',
+          amount: '1000000',
+          tokenAddress: '0x0000000000000000000000000000000000000001',
+          userAddress: '0x123',
+        },
+        gasFee: {
+          gasToken: {
+            chainId: 1,
+            address: '0x0000000000000000000000000000000000000004',
+            symbol: 'ETH',
+            name: 'Ethereum',
+            decimals: 18,
+            icon: 'eth',
+            logoURI: 'https://example.com/eth.png',
+            chainAgnosticId: null,
           },
-        ],
+          gasLimit: '100000',
+          gasPrice: '20000000000',
+          estimatedFee: '0.001',
+          feeInUsd: 2,
+        },
+        slippage: 0.5,
+        estimatedTime: 300,
+        routeDetails: {
+          name: 'Across',
+          logoURI: 'https://example.com/across.png',
+          routeFee: {
+            token: {
+              chainId: 1,
+              address: '0x0000000000000000000000000000000000000001',
+              name: 'USD Coin',
+              symbol: 'USDC',
+              decimals: 6,
+              logoURI: 'https://example.com/usdc.png',
+              icon: 'usdc',
+            },
+            amount: '1000',
+            feeInUsd: 1,
+            priceInUsd: 1,
+          },
+          dexDetails: null,
+        },
+        refuel: null,
       },
-    }
+    ],
+  },
+}
 
 describe('BungeeApi', () => {
   let api: BungeeApi
@@ -159,7 +160,7 @@ describe('BungeeApi', () => {
           disableSwapping: true,
           disableAuto: true,
         }),
-      ).rejects.toThrow('Bungee Api Error')
+      ).rejects.toThrow(BridgeQuoteErrors.API_ERROR)
     })
   })
 
@@ -382,7 +383,7 @@ describe('BungeeApi', () => {
         quoteTimestamp: 1234567890,
       }
 
-      await expect(api.getBungeeBuildTx(mockQuote)).rejects.toThrow('Bungee Api Error')
+      await expect(api.getBungeeBuildTx(mockQuote)).rejects.toThrow(BridgeQuoteErrors.API_ERROR)
     })
   })
 
@@ -453,7 +454,7 @@ describe('BungeeApi', () => {
         json: () => Promise.resolve({ text: 'Error message' }),
       })
 
-      await expect(api.getEvents({ orderId: '123' })).rejects.toThrow('Bungee Events Api Error')
+      await expect(api.getEvents({ orderId: '123' })).rejects.toThrow(BridgeQuoteErrors.API_ERROR)
     })
   })
 
@@ -483,7 +484,7 @@ describe('BungeeApi', () => {
         json: () => Promise.resolve({ text: 'Error message' }),
       })
 
-      await expect(api.getAcrossStatus('0x123')).rejects.toThrow('Across Api Error')
+      await expect(api.getAcrossStatus('0x123')).rejects.toThrow(BridgeQuoteErrors.API_ERROR)
     })
   })
 

--- a/src/bridging/providers/bungee/BungeeBridgeProvider.ts
+++ b/src/bridging/providers/bungee/BungeeBridgeProvider.ts
@@ -29,7 +29,7 @@ import { createBungeeDepositCall } from './createBungeeDepositCall'
 import { HOOK_DAPP_BRIDGE_PROVIDER_PREFIX } from './const/misc'
 import { BungeeBridgeName, BungeeBuildTx, BungeeEventStatus, BungeeQuote, BungeeQuoteAPIRequest } from './types'
 import { getSigner } from '../../../common/utils/wallet'
-import { BridgeProviderQuoteError } from '../../errors'
+import { BridgeProviderQuoteError, BridgeQuoteErrors } from '../../errors'
 
 export const BUNGEE_HOOK_DAPP_ID = `${HOOK_DAPP_BRIDGE_PROVIDER_PREFIX}/bungee`
 export const BUNGEE_SUPPORTED_NETWORKS = [mainnet, polygon, arbitrumOne, base, optimism]
@@ -76,7 +76,7 @@ export class BungeeBridgeProvider implements BridgeProvider<BungeeQuoteResult> {
 
   async getIntermediateTokens(request: QuoteBridgeRequest): Promise<TokenInfo[]> {
     if (request.kind !== OrderKind.SELL) {
-      throw new BridgeProviderQuoteError('Only SELL is supported for now', { kind: request.kind })
+      throw new BridgeProviderQuoteError(BridgeQuoteErrors.ONLY_SELL_ORDER_SUPPORTED, { kind: request.kind })
     }
 
     return this.api.getIntermediateTokens({
@@ -121,7 +121,7 @@ export class BungeeBridgeProvider implements BridgeProvider<BungeeQuoteResult> {
     )
 
     if (!isBuildTxValid) {
-      throw new BridgeProviderQuoteError('Build tx data is invalid', quoteWithBuildTx)
+      throw new BridgeProviderQuoteError(BridgeQuoteErrors.TX_BUILD_ERROR, quoteWithBuildTx)
     }
 
     // convert bungee quote response to BridgeQuoteResult


### PR DESCRIPTION
On client side (CoW Swap) we need to display bridge quote errors in user frendly way.
For that I added `BridgeQuoteErrors` enum so we can map them in client side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal error handling to use standardized error codes for bridging operations, improving consistency and clarity of error messages.
  - Introduced new error types and centralized error codes for bridge quoting and provider errors.
  - Incremented package version to 6.0.0-RC.66.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->