### PR TITLE
feat: update `Avalanche`, `Polygon`, and `Gnosis` labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.69",
+  "version": "6.0.0-RC.70",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/chains/details/arbitrum.ts
+++ b/src/chains/details/arbitrum.ts
@@ -12,7 +12,8 @@ const arbitrumOneLogoDark = `${RAW_CHAINS_FILES_PATH}/images/arbitrum-logo-dark.
  */
 export const arbitrumOne: ChainInfo = {
   id: SupportedChainId.ARBITRUM_ONE,
-  label: 'Arbitrum One',
+  label: 'Arbitrum',
+  eip155Label: 'Arbitrum One',
   nativeCurrency: {
     ...nativeCurrencyTemplate,
     chainId: SupportedChainId.ARBITRUM_ONE,

--- a/src/chains/details/avalanche.ts
+++ b/src/chains/details/avalanche.ts
@@ -8,7 +8,8 @@ const avaxLogo = `${RAW_CHAINS_FILES_PATH}/images/avax-logo.svg`
 // See https://github.com/wevm/viem/blob/main/src/chains/definitions/avalanche.ts
 export const avalanche: ChainInfo = {
   id: SupportedChainId.AVALANCHE,
-  label: 'Avalanche C-Chain',
+  label: 'Avalanche',
+  eip155Label: 'Avalanche C-Chain',
   logo: { light: avaxLogo, dark: avaxLogo },
   nativeCurrency: {
     ...nativeCurrencyTemplate,

--- a/src/chains/details/avalanche.ts
+++ b/src/chains/details/avalanche.ts
@@ -8,7 +8,7 @@ const avaxLogo = `${RAW_CHAINS_FILES_PATH}/images/avax-logo.svg`
 // See https://github.com/wevm/viem/blob/main/src/chains/definitions/avalanche.ts
 export const avalanche: ChainInfo = {
   id: SupportedChainId.AVALANCHE,
-  label: 'Avalanche',
+  label: 'Avalanche C-Chain',
   logo: { light: avaxLogo, dark: avaxLogo },
   nativeCurrency: {
     ...nativeCurrencyTemplate,

--- a/src/chains/details/base.ts
+++ b/src/chains/details/base.ts
@@ -12,6 +12,7 @@ const baseLogo = `${RAW_CHAINS_FILES_PATH}/images/base-logo.svg`
 export const base: ChainInfo = {
   id: SupportedChainId.BASE,
   label: 'Base',
+  eip155Label: 'Base',
   nativeCurrency: {
     ...nativeCurrencyTemplate,
     chainId: SupportedChainId.BASE,

--- a/src/chains/details/gnosis.ts
+++ b/src/chains/details/gnosis.ts
@@ -11,7 +11,7 @@ const gnosisChainLogo = `${RAW_CHAINS_FILES_PATH}/images/gnosis-logo.svg`
  */
 export const gnosisChain: ChainInfo = {
   id: SupportedChainId.GNOSIS_CHAIN,
-  label: 'Gnosis Chain',
+  label: 'Gnosis',
   nativeCurrency: {
     ...nativeCurrencyTemplate,
     chainId: SupportedChainId.GNOSIS_CHAIN,

--- a/src/chains/details/gnosis.ts
+++ b/src/chains/details/gnosis.ts
@@ -12,6 +12,7 @@ const gnosisChainLogo = `${RAW_CHAINS_FILES_PATH}/images/gnosis-logo.svg`
 export const gnosisChain: ChainInfo = {
   id: SupportedChainId.GNOSIS_CHAIN,
   label: 'Gnosis',
+  eip155Label: 'Gnosis',
   nativeCurrency: {
     ...nativeCurrencyTemplate,
     chainId: SupportedChainId.GNOSIS_CHAIN,

--- a/src/chains/details/mainnet.ts
+++ b/src/chains/details/mainnet.ts
@@ -12,6 +12,7 @@ const ethereumLogo = `${RAW_CHAINS_FILES_PATH}/images/mainnet-logo.svg`
 export const mainnet: ChainInfo = {
   id: SupportedChainId.MAINNET,
   label: 'Ethereum',
+  eip155Label: 'Ethereum Mainnet',
   nativeCurrency: {
     ...nativeCurrencyTemplate,
     chainId: SupportedChainId.MAINNET,

--- a/src/chains/details/optimism.ts
+++ b/src/chains/details/optimism.ts
@@ -8,6 +8,7 @@ const optimismLogo = `${RAW_CHAINS_FILES_PATH}/images/optimism-logo.svg`
 export const optimism: ChainInfo = {
   id: 10,
   label: 'Optimism',
+  eip155Label: 'OP Mainnet',
   logo: { light: optimismLogo, dark: optimismLogo },
   nativeCurrency: {
     ...nativeCurrencyTemplate,

--- a/src/chains/details/polygon.ts
+++ b/src/chains/details/polygon.ts
@@ -7,7 +7,7 @@ const polygonLogo = `${RAW_CHAINS_FILES_PATH}/images/polygon-logo.svg`
 // See https://github.com/wevm/viem/blob/main/src/chains/definitions/polygon.ts
 export const polygon: ChainInfo = {
   id: SupportedChainId.POLYGON,
-  label: 'Polygon',
+  label: 'Polygon Mainnet',
   logo: { light: polygonLogo, dark: polygonLogo },
   nativeCurrency: {
     ...nativeCurrencyTemplate,

--- a/src/chains/details/polygon.ts
+++ b/src/chains/details/polygon.ts
@@ -7,7 +7,8 @@ const polygonLogo = `${RAW_CHAINS_FILES_PATH}/images/polygon-logo.svg`
 // See https://github.com/wevm/viem/blob/main/src/chains/definitions/polygon.ts
 export const polygon: ChainInfo = {
   id: SupportedChainId.POLYGON,
-  label: 'Polygon Mainnet',
+  label: 'Polygon',
+  eip155Label: 'Polygon Mainnet',
   logo: { light: polygonLogo, dark: polygonLogo },
   nativeCurrency: {
     ...nativeCurrencyTemplate,

--- a/src/chains/details/sepolia.ts
+++ b/src/chains/details/sepolia.ts
@@ -12,6 +12,7 @@ const sepoliaLogo = `${RAW_CHAINS_FILES_PATH}/images/sepolia-logo.svg`
 export const sepolia: ChainInfo = {
   id: SupportedChainId.SEPOLIA,
   label: 'Sepolia',
+  eip155Label: 'Ethereum Sepolia',
   nativeCurrency: {
     ...nativeCurrencyTemplate,
     chainId: SupportedChainId.SEPOLIA,

--- a/src/chains/types.ts
+++ b/src/chains/types.ts
@@ -84,6 +84,11 @@ export interface ChainInfo {
   readonly label: string
 
   /**
+   * EIP155 label of the chain. Field used for connecting to MetaMask.
+   */
+  readonly eip155Label: string
+
+  /**
    * Native currency of the chain.
    */
   readonly nativeCurrency: TokenInfo


### PR DESCRIPTION
# Description

- add new property `eip155Label` to `ChainInfo`
- update chain details
- bump version 

# Test

- [Arbitrum](https://chainlist.org/chain/42161)
- [Avalanche](https://chainlist.org/chain/43114)
- [Base](https://chainlist.org/chain/8453)
- [Gnosis](https://chainlist.org/chain/100)
- [Mainnet](https://chainlist.org/chain/1)
- [Optimism](https://chainlist.org/chain/10)
- [Polygon](https://chainlist.org/chain/137)
- [Sepolia](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-11155111.json)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 6.0.0-RC.70.

* **Style**
  * Updated chain labels for improved clarity:
    * Changed "Avalanche" to "Avalanche C-Chain".
    * Changed "Gnosis Chain" to "Gnosis".
    * Changed "Polygon" to "Polygon Mainnet".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->