### PR TITLE
fix(bridge): increase has limit for cowshed deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.70",
+  "version": "6.0.0-RC.71",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/bridging/const.ts
+++ b/src/bridging/const.ts
@@ -3,6 +3,6 @@ import { RAW_FILES_PATH } from '../common/consts/path'
 export const RAW_PROVIDERS_FILES_PATH = `${RAW_FILES_PATH}/src/bridging/providers`
 // Based on https://dashboard.tenderly.co/shoom/project/simulator/a5e29dac-d0f2-407f-9e3d-d1b916da595b
 export const DEFAULT_GAS_COST_FOR_HOOK_ESTIMATION = 240_000
-// Based on https://dashboard.tenderly.co/shoom/project/tx/0xe95a78b313530884604aff9954dc4bd5a70bfa97950cc6678ed1450846b37fa1/gas-usage
-export const COW_SHED_PROXY_CREATION_GAS = 260_000
+// Based on https://dashboard.tenderly.co/shoom/project/tx/0x2971aee9aa7237d24b254da8ccd4345ff77410c8829c8e825e9a02cb2cece5e6/gas-usage
+export const COW_SHED_PROXY_CREATION_GAS = 360_000
 export const HOOK_DAPP_BRIDGE_PROVIDER_PREFIX = 'cow-sdk://bridging/providers'


### PR DESCRIPTION
It turned out, 260k is not enough.
Corresponding to [tenderly](https://dashboard.tenderly.co/shoom/project/tx/0x2971aee9aa7237d24b254da8ccd4345ff77410c8829c8e825e9a02cb2cece5e6/gas-usage), it takes 288k (proxy) + 34k (ens) = 322k
On top of that I added 38k buffer just in case.