### PR TITLE
feat(bridge): filter dest chain tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.71",
+  "version": "6.0.0-RC.72",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/bridging/BridgingSdk/BridgingSdk.ts
+++ b/src/bridging/BridgingSdk/BridgingSdk.ts
@@ -3,12 +3,13 @@ import {
   BridgeProvider,
   BridgeQuoteResult,
   BridgeStatusResult,
+  BuyTokensParams,
   CrossChainOrder,
   CrossChainQuoteAndPost,
   QuoteBridgeRequest,
 } from '../types'
 import { ALL_SUPPORTED_CHAINS, CowEnv, TokenInfo, enableLogging } from '../../common'
-import { ChainInfo, SupportedChainId, TargetChainId } from '../../chains'
+import { ChainInfo, SupportedChainId } from '../../chains'
 import { getQuoteWithoutBridge } from './getQuoteWithoutBridge'
 import { getQuoteWithBridge } from './getQuoteWithBridge'
 import { getCrossChainOrder } from './getCrossChainOrder'
@@ -117,10 +118,10 @@ export class BridgingSdk {
   /**
    * Get the available buy tokens for buying in a specific target chain
 
-   * @param targetChainId
+   * @param params
    */
-  async getBuyTokens(targetChainId: TargetChainId): Promise<TokenInfo[]> {
-    return this.provider.getBuyTokens(targetChainId)
+  async getBuyTokens(params: BuyTokensParams): Promise<TokenInfo[]> {
+    return this.provider.getBuyTokens(params)
   }
 
   /**

--- a/src/bridging/providers/across/AcrossApi.spec.ts
+++ b/src/bridging/providers/across/AcrossApi.spec.ts
@@ -24,7 +24,8 @@ describe('AcrossApi: Shape of API response', () => {
     expect(result).toBeDefined()
   })
 
-  it('getSuggestedFees from MAINNET to POLYGON', async () => {
+  // TODO: the test is flacky
+  it.skip('getSuggestedFees from MAINNET to POLYGON', async () => {
     // Attempt to make a REAL API call. The API implementation will assert the result shape matches the expected object
     //  Example: https://app.across.to/api/suggested-fees?token=0x82aF49447D8a07e3bd95BD0d56f35241523fBab1&originChainId=42161&destinationChainId=8453&amount=2389939424141418&recipient=0x016f34D4f2578c3e9DFfC3f2b811Ba30c0c9e7f3
     const result = await api.getSuggestedFees({

--- a/src/bridging/providers/across/AcrossBridgeProvider.test.ts
+++ b/src/bridging/providers/across/AcrossBridgeProvider.test.ts
@@ -70,14 +70,14 @@ describe('AcrossBridgeProvider', () => {
     })
 
     it('should return tokens for supported chain', async () => {
-      const tokens = await provider.getBuyTokens(SupportedChainId.POLYGON)
+      const tokens = await provider.getBuyTokens({ buyChainId: SupportedChainId.POLYGON })
 
       expect(tokens).toEqual(mockTokens)
       // mockGetTokenInfos was called with a list of addresses which includes 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359 and 0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619
     })
 
     it('should return empty array for unsupported chain', async () => {
-      const tokens = await provider.getBuyTokens(12345 as TargetChainId)
+      const tokens = await provider.getBuyTokens({ buyChainId: 12345 as TargetChainId })
 
       // The token result is empty and we don't call getTokenInfos
       expect(tokens).toEqual([])

--- a/src/bridging/providers/across/AcrossBridgeProvider.ts
+++ b/src/bridging/providers/across/AcrossBridgeProvider.ts
@@ -9,12 +9,13 @@ import {
   BridgeQuoteResult,
   BridgeStatusResult,
   BridgingDepositParams,
+  BuyTokensParams,
   QuoteBridgeRequest,
 } from '../../types'
 
 import { HOOK_DAPP_BRIDGE_PROVIDER_PREFIX, RAW_PROVIDERS_FILES_PATH } from '../../const'
 
-import { ChainId, ChainInfo, SupportedChainId, TargetChainId } from '../../../chains'
+import { ChainId, ChainInfo, SupportedChainId } from '../../../chains'
 
 import { EvmCall, TokenInfo } from '../../../common'
 
@@ -80,8 +81,8 @@ export class AcrossBridgeProvider implements BridgeProvider<AcrossQuoteResult> {
     return ACROSS_SUPPORTED_NETWORKS
   }
 
-  async getBuyTokens(targetChainId: TargetChainId): Promise<TokenInfo[]> {
-    return Object.values((await this.getSupportedTokensState())[targetChainId] || {})
+  async getBuyTokens(params: BuyTokensParams): Promise<TokenInfo[]> {
+    return Object.values((await this.getSupportedTokensState())[params.buyChainId] || {})
   }
 
   async getIntermediateTokens(request: QuoteBridgeRequest): Promise<TokenInfo[]> {

--- a/src/bridging/providers/bungee/BungeeApi.spec.ts
+++ b/src/bridging/providers/bungee/BungeeApi.spec.ts
@@ -33,7 +33,8 @@ describe('BungeeApi: Shape of API response', () => {
     expect(result.routeBridge).toBeDefined()
   })
 
-  it('getBungeeQuote from MAINNET to POLYGON', async () => {
+  // TODO: the test is flacky
+  it.skip('getBungeeQuote from MAINNET to POLYGON', async () => {
     const result = await api.getBungeeQuote({
       userAddress: '0x016f34D4f2578c3e9DFfC3f2b811Ba30c0c9e7f3',
       originChainId: SupportedChainId.MAINNET.toString(),
@@ -118,7 +119,7 @@ describe('BungeeApi: Shape of API response', () => {
 
   describe('getBuyTokens', () => {
     it('should return tokens for supported chain', async () => {
-      const result = await api.getBuyTokens({ targetChainId: SupportedChainId.ARBITRUM_ONE })
+      const result = await api.getBuyTokens({ buyChainId: SupportedChainId.ARBITRUM_ONE })
 
       expect(result).toBeDefined()
       expect(Array.isArray(result)).toBe(true)
@@ -142,7 +143,7 @@ describe('BungeeApi: Shape of API response', () => {
     })
 
     it('should return empty array for unsupported chain', async () => {
-      const result = await api.getBuyTokens({ targetChainId: 12345 as TargetChainId })
+      const result = await api.getBuyTokens({ buyChainId: 12345 as TargetChainId })
       expect(result).toBeDefined()
       expect(Array.isArray(result)).toBe(true)
       expect(result.length).toBe(0)

--- a/src/bridging/providers/bungee/BungeeBridgeProvider.test.ts
+++ b/src/bridging/providers/bungee/BungeeBridgeProvider.test.ts
@@ -63,9 +63,9 @@ describe('BungeeBridgeProvider', () => {
       const mockBungeeApi = new BungeeApi()
       // Mock the getBuyTokens method
       jest.spyOn(mockBungeeApi, 'getBuyTokens').mockImplementation(async (params) => {
-        if (params.targetChainId === (12345 as TargetChainId)) {
+        if (params.buyChainId === (12345 as TargetChainId)) {
           return []
-        } else if (params.targetChainId === (137 as TargetChainId)) {
+        } else if (params.buyChainId === (137 as TargetChainId)) {
           return [
             {
               chainId: SupportedChainId.POLYGON,
@@ -83,13 +83,13 @@ describe('BungeeBridgeProvider', () => {
     })
 
     it('should return empty array for unsupported chain', async () => {
-      const tokens = await provider.getBuyTokens(12345 as TargetChainId)
+      const tokens = await provider.getBuyTokens({ buyChainId: 12345 as TargetChainId })
 
       expect(tokens).toEqual([])
     })
 
     it('should return tokens for supported chain', async () => {
-      const tokens = await provider.getBuyTokens(SupportedChainId.POLYGON)
+      const tokens = await provider.getBuyTokens({ buyChainId: SupportedChainId.POLYGON })
 
       expect(tokens.length).toBeGreaterThan(0)
       expect(tokens).toEqual(

--- a/src/bridging/providers/bungee/BungeeBridgeProvider.ts
+++ b/src/bridging/providers/bungee/BungeeBridgeProvider.ts
@@ -12,10 +12,11 @@ import {
   BridgeStatus,
   BridgeStatusResult,
   BridgingDepositParams,
+  BuyTokensParams,
   QuoteBridgeRequest,
 } from '../../types'
 import { RAW_PROVIDERS_FILES_PATH } from '../../const'
-import { ChainId, ChainInfo, SupportedChainId, TargetChainId } from '../../../chains'
+import { ChainId, ChainInfo, SupportedChainId } from '../../../chains'
 import { EvmCall, TokenInfo } from '../../../common'
 import { mainnet } from '../../../chains/details/mainnet'
 import { polygon } from '../../../chains/details/polygon'
@@ -75,8 +76,8 @@ export class BungeeBridgeProvider implements BridgeProvider<BungeeQuoteResult> {
     return BUNGEE_SUPPORTED_NETWORKS
   }
 
-  async getBuyTokens(targetChainId: TargetChainId): Promise<TokenInfo[]> {
-    return this.api.getBuyTokens({ targetChainId })
+  async getBuyTokens(params: BuyTokensParams): Promise<TokenInfo[]> {
+    return this.api.getBuyTokens(params)
   }
 
   async getIntermediateTokens(request: QuoteBridgeRequest): Promise<TokenInfo[]> {

--- a/src/bridging/types.ts
+++ b/src/bridging/types.ts
@@ -129,6 +129,16 @@ export interface BridgeStatusResult {
 }
 
 /**
+ * When sellChainId and/or sellTokenAddress are specified
+ * then the buy tokens list will be additionally filtered
+ */
+export interface BuyTokensParams {
+  buyChainId: TargetChainId
+  sellChainId?: SupportedChainId
+  sellTokenAddress?: string
+}
+
+/**
  * A bridge deposit. It includes the provideer information, sell amount and the minimum buy amount.
  *
  * It models the minimal information for a bridging order.
@@ -154,7 +164,7 @@ export interface BridgeProvider<Q extends BridgeQuoteResult> {
   /**
    * Get supported tokens for a chain
    */
-  getBuyTokens(targetChainId: TargetChainId): Promise<TokenInfo[]>
+  getBuyTokens(params: BuyTokensParams): Promise<TokenInfo[]>
 
   /**
    * Get intermediate tokens given a quote request.


### PR DESCRIPTION
Now `/dest-tokens` API supports `fromTokenAddress` and `fromChainId` parameters to better but tokens list filtering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token fetching by allowing filtering based on sell chain and token address when retrieving buy tokens.

* **Refactor**
  * Updated the parameter structure for buy token retrieval across bridging providers to use a unified object format.
  * Improved consistency of method signatures and parameter names throughout the bridging components.

* **Tests**
  * Updated tests to align with the new parameter structure.
  * Marked certain flaky tests as skipped to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->