### PR TITLE
feat(bridge): make SigningStepManager async

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.0.0-RC.79",
+  "version": "6.0.0-RC.80",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/bridging/BridgingSdk/getQuoteWithBridge.ts
+++ b/src/bridging/BridgingSdk/getQuoteWithBridge.ts
@@ -180,7 +180,7 @@ export async function getQuoteWithBridge<T extends BridgeQuoteResult>(
     swap: result.swapResult,
     bridge: result.bridgeResult,
     async postSwapOrderFromQuote(advancedSettings?: SwapAdvancedSettings, signingStepManager?: SigningStepManager) {
-      signingStepManager?.beforeBridgingSign?.()
+      await signingStepManager?.beforeBridgingSign?.()
 
       // Sign the hooks with the real signer
       const { swapResult } = await signHooksAndSetSwapResult(signer, hookEstimatedGasLimit, advancedSettings).catch(
@@ -191,7 +191,7 @@ export async function getQuoteWithBridge<T extends BridgeQuoteResult>(
         },
       )
 
-      signingStepManager?.afterBridgingSign?.()
+      await signingStepManager?.afterBridgingSign?.()
 
       const quoteResults: QuoteResultsWithSigner = {
         result: {
@@ -205,7 +205,7 @@ export async function getQuoteWithBridge<T extends BridgeQuoteResult>(
         orderBookApi,
       }
 
-      signingStepManager?.beforeOrderSign?.()
+      await signingStepManager?.beforeOrderSign?.()
 
       return postSwapOrderFromQuote(quoteResults, {
         ...advancedSettings,
@@ -220,8 +220,8 @@ export async function getQuoteWithBridge<T extends BridgeQuoteResult>(
           signingStepManager?.onOrderSignError?.()
           throw error
         })
-        .then((result) => {
-          signingStepManager?.afterOrderSign?.()
+        .then(async (result) => {
+          await signingStepManager?.afterOrderSign?.()
 
           return result
         })

--- a/src/trading/tradingSdk.ts
+++ b/src/trading/tradingSdk.ts
@@ -49,8 +49,11 @@ export class TradingSdk {
 
     return {
       quoteResults: quoteResults.result,
-      postSwapOrderFromQuote: (advancedSettings?: SwapAdvancedSettings, signingStepManager?: SigningStepManager) => {
-        signingStepManager?.beforeOrderSign?.()
+      postSwapOrderFromQuote: async (
+        advancedSettings?: SwapAdvancedSettings,
+        signingStepManager?: SigningStepManager,
+      ) => {
+        await signingStepManager?.beforeOrderSign?.()
 
         return postSwapOrderFromQuote(
           {

--- a/src/trading/types.ts
+++ b/src/trading/types.ts
@@ -114,10 +114,10 @@ export interface LimitOrderParameters extends TraderParameters, LimitTradeParame
  * When postSwapOrderFromQuote() is called, it will execute provided callback corresponding to signing order
  */
 export interface SigningStepManager {
-  beforeBridgingSign?(): void
-  afterBridgingSign?(): void
-  beforeOrderSign?(): void
-  afterOrderSign?(): void
+  beforeBridgingSign?(): Promise<void> | void
+  afterBridgingSign?(): Promise<void> | void
+  beforeOrderSign?(): Promise<void> | void
+  afterOrderSign?(): Promise<void> | void
   onBridgingSignError?(): void
   onOrderSignError?(): void
 }


### PR DESCRIPTION
Just made `SigningStepManager` callbacks async 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for asynchronous operations in order signing lifecycle callbacks, allowing custom hooks to perform async actions during signing steps.

* **Chores**
  * Updated package version to 6.0.0-RC.80.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->