### PR TITLE
feat: enable avalanche

### DIFF
--- a/src/bridging/providers/bungee/BungeeBridgeProvider.ts
+++ b/src/bridging/providers/bungee/BungeeBridgeProvider.ts
@@ -18,6 +18,7 @@ import { EvmCall, TokenInfo } from '../../../common'
 import { mainnet } from '../../../chains/details/mainnet'
 import { polygon } from '../../../chains/details/polygon'
 import { arbitrumOne } from '../../../chains/details/arbitrum'
+import { avalanche } from '../../../chains/details/avalanche'
 import { base } from '../../../chains/details/base'
 import { optimism } from '../../../chains/details/optimism'
 import { BungeeApi, BungeeApiOptions } from './BungeeApi'
@@ -34,7 +35,7 @@ import type { JsonRpcProvider } from '@ethersproject/providers'
 import type { Signer } from 'ethers'
 
 export const BUNGEE_HOOK_DAPP_ID = `${HOOK_DAPP_BRIDGE_PROVIDER_PREFIX}/bungee`
-export const BUNGEE_SUPPORTED_NETWORKS = [mainnet, polygon, arbitrumOne, base, optimism]
+export const BUNGEE_SUPPORTED_NETWORKS = [mainnet, polygon, arbitrumOne, base, optimism, avalanche]
 
 /** There will be no dex swaps happening while bridging. Hence slippage will be zero */
 const SLIPPAGE_TOLERANCE_BPS = 0


### PR DESCRIPTION
for cctp routes to & from avalanche

Test txns:
Base to Avalanche: https://explorer.cow.fi/base/orders/0x91c7a253aa2aa25589036b09e23844bb5263c2f6a9b074fb0381792187906e5bdaee4d2156de6fe6f7d50ca047136d758f96a6f068918ccd?tab=bridge

Avalanche to Base:
https://explorer.cow.fi/avax/orders/0x0ad90f75f2cf2f680b5f04d415016716482bbad5cf4f26cbea39bc4b8ccd48e6daee4d2156de6fe6f7d50ca047136d758f96a6f068919b39?tab=bridge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Avalanche network to the Bungee bridge provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->