### PR TITLE
fix(networks): update avalanche, base and bnb explorer names to match the UI

### DIFF
--- a/src/chains/details/avalanche.ts
+++ b/src/chains/details/avalanche.ts
@@ -1,6 +1,6 @@
 import { nativeCurrencyTemplate } from '../../common/consts/tokens'
-import { ChainInfo, SupportedChainId } from '../types'
 import { RAW_CHAINS_FILES_PATH } from '../const/path'
+import { ChainInfo, SupportedChainId } from '../types'
 
 // TODO: this is the AVAX token logo, we should add Avalanche symbol logo as well
 const avaxLogo = `${RAW_CHAINS_FILES_PATH}/images/avax-logo.svg`
@@ -41,7 +41,7 @@ export const avalanche: ChainInfo = {
     url: 'https://build.avax.network/docs',
   },
   blockExplorer: {
-    name: 'Snowscan',
+    name: 'SnowScan',
     url: 'https://snowscan.xyz',
   },
 }

--- a/src/chains/details/base.ts
+++ b/src/chains/details/base.ts
@@ -1,6 +1,6 @@
-import { ChainInfo, SupportedChainId } from '../types'
 import { nativeCurrencyTemplate } from '../../common/consts/tokens'
 import { RAW_CHAINS_FILES_PATH } from '../const/path'
+import { ChainInfo, SupportedChainId } from '../types'
 
 const baseLogo = `${RAW_CHAINS_FILES_PATH}/images/base-logo.svg`
 
@@ -42,7 +42,7 @@ export const base: ChainInfo = {
     url: 'https://docs.base.org',
   },
   blockExplorer: {
-    name: 'Basescan',
+    name: 'BaseScan',
     url: 'https://basescan.org',
   },
   bridges: [

--- a/src/chains/details/bnb.ts
+++ b/src/chains/details/bnb.ts
@@ -41,7 +41,7 @@ export const bnb: ChainInfo = {
     url: 'https://docs.bnbchain.org',
   },
   blockExplorer: {
-    name: 'BNB Smart Chain Explorer',
+    name: 'BscScan',
     url: 'https://bscscan.com',
   },
 }


### PR DESCRIPTION
# Summary

No functional changes.
Purely updating the explorer names of Avalanche, Base and BNB to match the respective UIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected block explorer display names to match official branding:
    - Avalanche: SnowScan (was Snowscan)
    - Base: BaseScan (was Basescan)
    - BNB: BscScan (was BNB Smart Chain Explorer)
  - Ensures clearer identification in the UI and consistency across networks; links/URLs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->