### PR TITLE
feat(networks): add `isZkSync` flag to chaininfo

### DIFF
--- a/src/chains/details/lens.ts
+++ b/src/chains/details/lens.ts
@@ -56,4 +56,5 @@ export const lens: ChainInfo = {
       url: 'https://lens.xyz/bridge',
     },
   ],
+  isZkSync: true,
 }

--- a/src/chains/types.ts
+++ b/src/chains/types.ts
@@ -149,4 +149,9 @@ export interface ChainInfo {
     [key: string]: ChainRpcUrls
     default: ChainRpcUrls
   }
+
+  /**
+   * Whether the chain is zkSync based.
+   */
+  readonly isZkSync?: boolean
 }

--- a/src/chains/utils.ts
+++ b/src/chains/utils.ts
@@ -38,3 +38,7 @@ export function isAdditionalTargetChain(chainId: ChainId): chainId is Additional
 export function isTargetChainId(chainId: ChainId): chainId is TargetChainId {
   return isSupportedChain(chainId) || isAdditionalTargetChain(chainId)
 }
+
+export function isZkSyncChain(chainId: ChainId): boolean {
+  return !!getChainInfo(chainId)?.isZkSync
+}


### PR DESCRIPTION
# Summary

Added a flag to chain info to indicate whether the chain is zkSync based.
Added util fn `isZkSyncChain` to check it.