### PR TITLE
fix(quote-amounts): fix amounts after partner fee calculations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.2.0-RC.1",
+  "version": "6.3.0",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/order-book/quoteAmountsAndCostsUtils.test.ts
+++ b/src/order-book/quoteAmountsAndCostsUtils.test.ts
@@ -79,7 +79,7 @@ describe('Calculation of before/after fees amounts', () => {
         expect(result.beforeNetworkCosts.buyAmount.toString()).toBe(
           (
             (+orderParams.sellAmount + +orderParams.feeAmount) * // SellAmountAfterNetworkCosts
-            (+orderParams.buyAmount / +orderParams.sellAmount)
+            (+orderParams.buyAmount / (+orderParams.sellAmount + +orderParams.feeAmount))
           ) // Price
             .toFixed()
         )
@@ -101,11 +101,9 @@ describe('Calculation of before/after fees amounts', () => {
           slippagePercentBps: 0,
         })
 
-        const buyAmountBeforeNetworkCosts =
-          (+orderParams.sellAmount + +orderParams.feeAmount) * // SellAmountAfterNetworkCosts
-          (+orderParams.buyAmount / +orderParams.sellAmount) // Price
+        const buyAmountAfterNetworkCosts = +orderParams.buyAmount
 
-        const partnerFeeAmount = Math.floor((buyAmountBeforeNetworkCosts * partnerFeeBps) / 100 / 100)
+        const partnerFeeAmount = Math.floor((buyAmountAfterNetworkCosts * partnerFeeBps) / 100 / 100)
 
         expect(Number(result.costs.partnerFee.amount)).toBe(partnerFeeAmount)
       })
@@ -122,7 +120,7 @@ describe('Calculation of before/after fees amounts', () => {
           slippagePercentBps: 0,
         })
 
-        const partnerFeeAmount = Math.floor((+orderParams.sellAmount * partnerFeeBps) / 100 / 100)
+        const partnerFeeAmount = Math.floor(((+orderParams.sellAmount + +orderParams.feeAmount) * partnerFeeBps) / 100 / 100)
 
         expect(Number(result.costs.partnerFee.amount)).toBe(partnerFeeAmount)
       })

--- a/src/order-book/quoteAmountsAndCostsUtils.ts
+++ b/src/order-book/quoteAmountsAndCostsUtils.ts
@@ -55,17 +55,17 @@ function _getQuoteAmountsWithCosts(params: {
   const buyAmountAfterNetworkCosts = getBigNumber(orderParams.buyAmount, buyDecimals)
 
   /**
-   * This is an actual price of the quote since it's derrived only from the quote sell and buy amounts
-   */
-  const quotePrice = buyAmountAfterNetworkCosts.num / sellAmountBeforeNetworkCosts.num
-
-  /**
    * Before networkCosts + networkCosts = After networkCosts :)
    */
   const sellAmountAfterNetworkCosts = getBigNumber(
     sellAmountBeforeNetworkCosts.big + networkCostAmount.big,
     sellDecimals
   )
+
+  /**
+   * This is an actual price of the quote since it's derrived only from the quote sell and buy amounts
+   */
+  const quotePrice = buyAmountAfterNetworkCosts.num / sellAmountAfterNetworkCosts.num
 
   /**
    * Since the quote contains only buy amount after network costs
@@ -95,8 +95,6 @@ function getQuoteAmountsWithPartnerFee(params: {
   const {
     sellAmountAfterNetworkCosts,
     buyAmountAfterNetworkCosts,
-    buyAmountBeforeNetworkCosts,
-    sellAmountBeforeNetworkCosts,
     isSell,
     partnerFeeBps,
   } = params
@@ -104,7 +102,7 @@ function getQuoteAmountsWithPartnerFee(params: {
   /**
    * Partner fee is always added on the surplus amount, for sell-orders it's buy amount, for buy-orders it's sell amount
    */
-  const surplusAmount = isSell ? buyAmountBeforeNetworkCosts.big : sellAmountBeforeNetworkCosts.big
+  const surplusAmount = isSell ? buyAmountAfterNetworkCosts.big : sellAmountAfterNetworkCosts.big
   const partnerFeeAmount = partnerFeeBps > 0 ? (surplusAmount * BigInt(partnerFeeBps)) / ONE_HUNDRED_BPS : BigInt(0)
 
   /**


### PR DESCRIPTION
1. `quotePrice` was miscalculating a bit, it was doing: `buyAmountAfterNetworkCosts / sellAmountBeforeNetworkCosts`, but we should not mix `afterNetworkCosts` and `beforeNetworkCosts` amounts
2. `partnerFeeAmount` was also wrong. It should always be `afterNetworkCosts` (it's even mentioned in the tests description), but for some reason it was using `beforeNetworkCosts`.

Please review the changes carefully, they are important.