### PR TITLE
fix: add adapter param to BridgingSdk and update docs

### DIFF
--- a/packages/bridging/src/BridgingSdk/BridgingSdk.ts
+++ b/packages/bridging/src/BridgingSdk/BridgingSdk.ts
@@ -16,7 +16,7 @@ import { BridgeProviderError } from '../errors'
 import { SwapAdvancedSettings, TradingSdk } from '@cowprotocol/sdk-trading'
 import { OrderBookApi } from '@cowprotocol/sdk-order-book'
 import { ALL_SUPPORTED_CHAINS, ChainInfo, CowEnv, SupportedChainId } from '@cowprotocol/sdk-config'
-import { enableLogging } from '@cowprotocol/sdk-common'
+import { AbstractProviderAdapter, enableLogging, setGlobalAdapter } from '@cowprotocol/sdk-common'
 
 export interface BridgingSdkOptions {
   /**
@@ -67,7 +67,14 @@ export type BridgingSdkConfig = Required<Omit<BridgingSdkOptions, 'enableLogging
 export class BridgingSdk {
   protected config: BridgingSdkConfig
 
-  constructor(readonly options: BridgingSdkOptions) {
+  constructor(
+    readonly options: BridgingSdkOptions,
+    adapter?: AbstractProviderAdapter,
+  ) {
+    if (adapter) {
+      setGlobalAdapter(adapter)
+    }
+
     const { providers, ...restOptions } = options
 
     // For simplicity, we support only a single provider in the initial implementation

--- a/packages/bridging/src/README.md
+++ b/packages/bridging/src/README.md
@@ -49,17 +49,18 @@ yarn add @cowprotocol/cow-sdk
 ### Basic Setup
 
 ```typescript
-import { BridgingSdk, BungeeBridgeProvider, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { BridgingSdk, BungeeBridgeProvider } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
 
-const rpcUrls: Record<SupportedChainId, string> = {
-  [SupportedChainId.MAINNET]: 'https://eth-mainnet.alchemyapi.io/v2/YOUR_KEY',
-  [SupportedChainId.POLYGON]: 'https://polygon-mainnet.alchemyapi.io/v2/YOUR_KEY',
-  [SupportedChainId.ARBITRUM_ONE]: 'https://arb-mainnet.alchemyapi.io/v2/YOUR_KEY',
-  [SupportedChainId.OPTIMISM]: 'https://opt-mainnet.alchemyapi.io/v2/YOUR_KEY',
-  [SupportedChainId.BASE]: 'https://base-mainnet.alchemyapi.io/v2/YOUR_KEY',
-  [SupportedChainId.AVALANCHE]: 'https://avalanche-mainnet.alchemyapi.io/v2/YOUR_KEY',
-  // ... add other chain RPC URLs as needed
-}
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Initialize the bridge provider
 const bungeeProvider = new BungeeBridgeProvider({
@@ -69,10 +70,13 @@ const bungeeProvider = new BungeeBridgeProvider({
 })
 
 // Create the BridgingSdk instance
-const bridgingSdk = new BridgingSdk({
-  providers: [bungeeProvider],
-  enableLogging: true, // Optional: enable debug logging
-})
+const bridgingSdk = new BridgingSdk(
+  {
+    providers: [bungeeProvider],
+    enableLogging: true, // Optional: enable debug logging
+  },
+  adapter
+)
 ```
 
 ### Basic Cross-Chain Swap
@@ -181,7 +185,18 @@ interface BridgingSdkOptions {
 ### Advanced Configuration with Custom `TradingSDK`
 
 ```typescript
-import { BridgingSdk, BungeeBridgeProvider, TradingSdk, OrderBookApi, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { BridgingSdk, BungeeBridgeProvider, OrderBookApi, SupportedChainId, TradingSdk } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 const orderBookApi: OrderBookApi = new OrderBookApi({
   env: 'prod', // or 'staging'
@@ -196,6 +211,7 @@ const tradingSdk: TradingSdk = new TradingSdk(
   {
     orderBookApi,
   },
+  adapter
 )
 
 const bungeeProvider: BungeeBridgeProvider = new BungeeBridgeProvider({
@@ -204,12 +220,15 @@ const bungeeProvider: BungeeBridgeProvider = new BungeeBridgeProvider({
   },
 })
 
-const bridgingSdk: BridgingSdk = new BridgingSdk({
-  providers: [bungeeProvider],
-  tradingSdk,
-  orderBookApi,
-  enableLogging: false,
-})
+const bridgingSdk: BridgingSdk = new BridgingSdk(
+  {
+    providers: [bungeeProvider],
+    tradingSdk,
+    orderBookApi,
+    enableLogging: false,
+  },
+  adapter
+)
 ```
 
 ## Core Methods
@@ -317,16 +336,17 @@ import {
 } from '@cowprotocol/cow-sdk'
 import { formatEther, parseEther } from '@ethersproject/units'
 import { useWeb3React } from '@web3-react/core'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
 
-const getRpcUrl = (chainId: SupportedChainId): string => {
-  // Add your RPC URLs here
-  const rpcUrls: Record<SupportedChainId, string> = {
-    [SupportedChainId.MAINNET]: 'https://eth-mainnet.alchemyapi.io/v2/YOUR_KEY',
-    [SupportedChainId.POLYGON]: 'https://polygon-mainnet.alchemyapi.io/v2/YOUR_KEY',
-    // ... other chains
-  } as Record<SupportedChainId, string>
-  return rpcUrls[chainId]
-}
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 const bungeeProvider = new BungeeBridgeProvider({
   apiOptions: {
@@ -334,7 +354,12 @@ const bungeeProvider = new BungeeBridgeProvider({
   },
 })
 
-const bridgingSdk = new BridgingSdk({ providers: [bungeeProvider] })
+const bridgingSdk = new BridgingSdk(
+  {
+    providers: [bungeeProvider]
+  },
+  adapter
+)
 
 const appCode = 'COW_BRIDGING_REACT_EXAMPLE'
 
@@ -414,6 +439,18 @@ const { OrderKind } = require('@cowprotocol/contracts')
 const { Wallet } = require('@ethersproject/wallet')
 const { parseEther } = require('@ethersproject/units')
 
+const { ViemAdapter } = require('@cowprotocol/sdk-viem-adapter')
+const { createPublicClient, http, privateKeyToAccount } = require('viem')
+const { sepolia } = require('viem/chains')
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
+
 // Configure environment
 require('dotenv').config()
 
@@ -433,10 +470,13 @@ async function main() {
   })
 
   // Initialize BridgingSdk
-  const bridgingSdk = new BridgingSdk({
-    providers: [bungeeProvider],
-    enableLogging: true,
-  })
+  const bridgingSdk = new BridgingSdk(
+    {
+      providers: [bungeeProvider],
+      enableLogging: true,
+    },
+    adapter
+  )
 
   // Prepare quote request
   const quoteBridgeRequest = {

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -34,13 +34,20 @@ import {
   GenericContract,
   setGlobalAdapter,
 } from '@cowprotocol/sdk-common'
-import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
-import { JsonRpcProvider, Wallet } from 'ethers'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
 
 // Create and configure adapter
-const provider = new JsonRpcProvider('YOUR_RPC_URL')
-const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
-const adapter = new EthersV6Adapter({ provider, signer: wallet })
+// There are EthersV5Adapter and EthersV6Adapter as well
+// @cowprotocol/sdk-ethers-v5-adapter, @cowprotocol/sdk-ethers-v6-adapter
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Set up global adapter
 setGlobalAdapter(adapter)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -84,13 +84,20 @@ import {
   setGlobalAdapter,
   SupportedChainId
 } from '@cowprotocol/cow-sdk'
-import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
-import { JsonRpcProvider, Wallet } from 'ethers'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
 
-// Configure the adapter once
-const provider = new JsonRpcProvider('YOUR_RPC_URL')
-const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
-const adapter = new EthersV6Adapter({ provider, signer: wallet })
+// Create and configure adapter
+// There are EthersV5Adapter and EthersV6Adapter as well
+// @cowprotocol/sdk-ethers-v5-adapter, @cowprotocol/sdk-ethers-v6-adapter
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Initialize the unified SDK
 const sdk = new CowSdk({
@@ -118,13 +125,20 @@ Import modules directly from the umbrella package without the unified instance:
 
 ```typescript
 import { TradingSdk, OrderBookApi, SupportedChainId, OrderKind, TradeParameters } from '@cowprotocol/cow-sdk'
-import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
-import { JsonRpcProvider, Wallet } from 'ethers'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
 
-// Configure adapter
-const provider = new JsonRpcProvider('YOUR_RPC_URL')
-const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
-const adapter = new EthersV6Adapter({ provider, signer: wallet })
+// Create and configure adapter
+// There are EthersV5Adapter and EthersV6Adapter as well
+// @cowprotocol/sdk-ethers-v5-adapter, @cowprotocol/sdk-ethers-v6-adapter
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Use modules individually - adapter configuration is handled automatically
 const trading = new TradingSdk({ appCode: 'YOUR_APP_CODE' }, { chainId: SupportedChainId.SEPOLIA }, adapter)
@@ -142,13 +156,21 @@ Set up the adapter once and use modules without explicit adapter passing:
 
 ```typescript
 import { TradingSdk, OrderBookApi, OrderSigningUtils, setGlobalAdapter, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
-import { JsonRpcProvider, Wallet } from 'ethers'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
 
-// Configure adapter globally
-const provider = new JsonRpcProvider('YOUR_RPC_URL')
-const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
-const adapter = new EthersV6Adapter({ provider, signer: wallet })
+// Create and configure adapter
+// There are EthersV5Adapter and EthersV6Adapter as well
+// @cowprotocol/sdk-ethers-v5-adapter, @cowprotocol/sdk-ethers-v6-adapter
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
+
 setGlobalAdapter(adapter)
 
 // Now use modules without passing adapter each time

--- a/packages/trading/README.md
+++ b/packages/trading/README.md
@@ -64,13 +64,19 @@ You need:
 
 ```typescript
 import { SupportedChainId, OrderKind, TradeParameters, TradingSdk } from '@cowprotocol/sdk-trading'
-import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
-import { JsonRpcProvider, Wallet } from 'ethers'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
 
-// Configure the adapter
-const provider = new JsonRpcProvider('YOUR_RPC_URL')
-const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
-const adapter = new EthersV6Adapter({ provider, signer: wallet })
+// There are EthersV5Adapter and EthersV6Adapter as well
+// @cowprotocol/sdk-ethers-v5-adapter, @cowprotocol/sdk-ethers-v6-adapter
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Initialize the SDK
 const sdk = new TradingSdk(
@@ -102,13 +108,17 @@ console.log('Order created, id: ', orderId)
 
 ```typescript
 import { CowSdk, SupportedChainId, OrderKind, TradeParameters } from '@cowprotocol/cow-sdk'
-import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
-import { JsonRpcProvider, Wallet } from 'ethers'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
 
-// Configure the adapter
-const provider = new JsonRpcProvider('YOUR_RPC_URL')
-const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
-const adapter = new EthersV6Adapter({ provider, signer: wallet })
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Initialize the unified SDK
 const sdk = new CowSdk({
@@ -148,15 +158,26 @@ const sdk = new CowSdk({
 // Other file:
 import { TradingSdk } from '@cowprotocol/cow-sdk'
 // parameters without passing the adapter. the adapter will be controlled by the umbrella
-const trading = TradingSdk(...)
+const trading = new TradingSdk(...)
 ```
 
 ### Options
 
-For detailed information about trading steps you can enable the SDK logging and configure UTM tracking:
+For detailed information about trading steps you can enable the SDK logging:
 
 ```typescript
 import { SupportedChainId, TradingSdk, TradingSdkOptions } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 const traderParams = {
   chainId: SupportedChainId.SEPOLIA,
@@ -166,11 +187,10 @@ const traderParams = {
 
 const sdkOptions: TradingSdkOptions = {
   enableLogging: true, // enables detailed logging of trading steps
-  utmContent: '🐮 moo-ving to defi 🐮', // custom UTM content for tracking
   disableUtm: false, // set to true to disable UTM tracking completely
 }
 
-const sdk = new TradingSdk(traderParams, sdkOptions)
+const sdk = new TradingSdk(traderParams, sdkOptions, adapter)
 ```
 
 ### getQuote
@@ -195,12 +215,23 @@ It can be used to create an order from the received quote.
 
 ```typescript
 import { SupportedChainId, OrderKind, TradeParameters, TradingSdk } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Proper adapter initialization (see setup example above)
 const sdk = new TradingSdk({
   chainId: SupportedChainId.SEPOLIA,
   appCode: '<YOUR_APP_CODE>',
-})
+}, {}, adapter)
 
 const parameters: TradeParameters = {
   kind: OrderKind.BUY,
@@ -241,12 +272,23 @@ The parameters required are:
 
 ```typescript
 import { SupportedChainId, OrderKind, TradeParameters, TradingSdk } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Proper adapter initialization (see setup example above)
 const sdk = new TradingSdk({
   chainId: SupportedChainId.SEPOLIA,
   appCode: '<YOUR_APP_CODE>',
-})
+}, {}, adapter)
 
 const parameters: TradeParameters = {
   kind: OrderKind.BUY,
@@ -283,12 +325,23 @@ And optional parameters:
 
 ```typescript
 import { SupportedChainId, OrderKind, LimitTradeParameters, TradingSdk } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Proper adapter initialization (see setup example above)
 const sdk = new TradingSdk({
   chainId: SupportedChainId.SEPOLIA,
   appCode: '<YOUR_APP_CODE>',
-})
+}, {}, adapter)
 
 const limitOrderParameters: LimitTradeParameters = {
   kind: OrderKind.BUY,
@@ -316,12 +369,23 @@ But if you need more flexible way to create an order to sell native token, you c
 
 ```typescript
 import { SupportedChainId, OrderKind, TradeParameters, TradingSdk } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Proper adapter initialization (see setup example above)
 const sdk = new TradingSdk({
   chainId: SupportedChainId.SEPOLIA,
   appCode: '<YOUR_APP_CODE>',
-})
+}, {}, adapter)
 
 const parameters: TradeParameters = {
   kind: OrderKind.BUY,
@@ -353,12 +417,23 @@ import {
   SigningScheme,
   TradingSdk,
 } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Proper adapter initialization (see setup example above)
 const sdk = new TradingSdk({
   chainId: SupportedChainId.SEPOLIA,
   appCode: '<YOUR_APP_CODE>',
-})
+}, {}, adapter)
 
 const parameters: TradeParameters = {
   kind: OrderKind.BUY,
@@ -390,12 +465,23 @@ And then you need to send a transaction from `getPreSignTransaction` result in o
 
 ```typescript
 import { SupportedChainId, OrderKind, TradeParameters, TradingSdk } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Proper adapter initialization (see setup example above)
 const sdk = new TradingSdk({
   chainId: SupportedChainId.SEPOLIA,
   appCode: '<YOUR_APP_CODE>',
-})
+}, {}, adapter)
 
 const parameters: TradeParameters = {
   kind: OrderKind.BUY,
@@ -432,12 +518,23 @@ import {
   SigningScheme,
   TradingSdk,
 } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Proper adapter initialization (see setup example above)
 const sdk = new TradingSdk({
   chainId: SupportedChainId.SEPOLIA,
   appCode: '<YOUR_APP_CODE>',
-})
+}, {}, adapter)
 
 const smartContractWalletAddress = '0x<smartContractWalletAddress>'
 
@@ -486,12 +583,23 @@ See `TradeOptionalParameters` type for more details.
 
 ```typescript
 import { SupportedChainId, OrderKind, TradeParameters, TradingSdk } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Proper adapter initialization (see setup example above)
 const sdk = new TradingSdk({
   chainId: SupportedChainId.SEPOLIA,
   appCode: '<YOUR_APP_CODE>',
-})
+}, {}, adapter)
 
 const parameters: TradeParameters = {
   kind: OrderKind.BUY,
@@ -532,12 +640,23 @@ import {
   SwapAdvancedSettings,
   PriceQuality,
 } from '@cowprotocol/cow-sdk'
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http, privateKeyToAccount } from 'viem'
+import { sepolia } from 'viem/chains'
+
+const adapter = new ViemAdapter({
+  provider: createPublicClient({
+    chain: sepolia,
+    transport: http('YOUR_RPC_URL')
+  }),
+  signer: privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
+})
 
 // Proper adapter initialization (see setup example above)
 const sdk = new TradingSdk({
   chainId: SupportedChainId.SEPOLIA,
   appCode: '<YOUR_APP_CODE>',
-})
+}, {}, adapter)
 
 const parameters: TradeParameters = {
   kind: OrderKind.BUY,


### PR DESCRIPTION
1. Added `adapter` parameter to `BridgingSdk` constructor
2. Updated `common`, `umbrella`, and `TradingSDK` docs to use `ViemAdapter` by default in the examples