### PR TITLE
fix: improve unknown type

### DIFF
--- a/packages/common/src/adapters/AbstractProviderAdapter.ts
+++ b/packages/common/src/adapters/AbstractProviderAdapter.ts
@@ -21,7 +21,7 @@ import {
 export abstract class AbstractProviderAdapter<T extends AdapterTypes = AdapterTypes> {
   public abstract utils: AdapterUtils
 
-  public ZERO_ADDRESS!: T['Address']
+  public ZERO_ADDRESS!: Address
 
   public abstract TypedDataVersionedSigner: new (signer: any, version: any) => AbstractSigner<T['Provider']>
   public abstract TypedDataV3Signer: new (signer: any) => AbstractSigner<T['Provider']>
@@ -38,7 +38,7 @@ export abstract class AbstractProviderAdapter<T extends AdapterTypes = AdapterTy
     signerOrPrivateKey: Signer | PrivateKey | AbstractSigner<T['Provider']>,
   ): AbstractSigner<T['Provider']>
   // reading functionality
-  abstract getStorageAt(address: T['Address'], slot: string | number | bigint): Promise<unknown>
+  abstract getStorageAt(address: Address, slot: string | number | bigint): Promise<unknown>
 
   // blockcahin interaction
   abstract call(txParams: TransactionParams, provider?: T['Provider']): Promise<string>

--- a/packages/common/src/adapters/types/AdapterUtils.ts
+++ b/packages/common/src/adapters/types/AdapterUtils.ts
@@ -4,11 +4,11 @@ import {
   TypedDataDomain,
   BigIntish,
   SignatureLike,
-  ContractInterface,
   TypedDataTypes,
   Address,
   Provider,
   GenericContractInterface,
+  ParamType,
 } from '.'
 
 /**
@@ -95,11 +95,6 @@ export abstract class AdapterUtils {
    * Converts a value to a BigIntish
    */
   abstract toBigIntish(value: BigIntish): BigIntish
-
-  /**
-   * Creates a new BigIntish from a number or string
-   */
-  abstract newBigintish(value: number | string): BigIntish
 
   /**
    * Slices a portion of hex data
@@ -225,12 +220,12 @@ export abstract class AdapterUtils {
   /**
    * Creates a ParamType from a string type
    */
-  abstract getParamTypeFromString(type: string): ContractInterface
+  abstract getParamTypeFromString(type: string): ParamType
 
   /**
    * Creates a ParamType from a string type
    */
-  abstract getParamType(type: string): ContractInterface
+  abstract getParamType(type: string): ParamType
 
   /**
    * Verifies if a value is an Interface instance

--- a/packages/common/src/adapters/types/AdapterUtils.ts
+++ b/packages/common/src/adapters/types/AdapterUtils.ts
@@ -94,7 +94,7 @@ export abstract class AdapterUtils {
   /**
    * Converts a value to a BigIntish
    */
-  abstract toBigIntish(value: string | number | BigIntish): BigIntish
+  abstract toBigIntish(value: BigIntish): BigIntish
 
   /**
    * Creates a new BigIntish from a number or string

--- a/packages/common/src/adapters/types/index.ts
+++ b/packages/common/src/adapters/types/index.ts
@@ -111,3 +111,12 @@ export interface Block {
 }
 
 export type ContractValue = string | number | boolean | bigint
+
+export type ParamType = {
+  type?: string
+  name?: string
+  baseType?: string
+  arrayLength?: number | null
+  components?: ReadonlyArray<ParamType> | null
+  [key: string]: unknown
+}

--- a/packages/common/src/adapters/types/index.ts
+++ b/packages/common/src/adapters/types/index.ts
@@ -14,9 +14,15 @@ export type Bytes = unknown
 
 export type ContractInterface = unknown
 
-export type TypedDataDomain = unknown
+export interface TypedDataDomain {
+  name?: string
+  version?: string
+  chainId?: number
+  verifyingContract?: string
+  salt?: string | Uint8Array // Flexible for different formats
+}
 
-export type TypedDataTypes = unknown
+export type TypedDataTypes = Record<string, Array<{ name: string; type: string }>>
 
 export interface Provider {
   getStorageAt?: (...args: any[]) => unknown
@@ -29,15 +35,11 @@ export type SignatureLike = unknown
 
 export type AdapterTypes = {
   Abi: Abi
-  Address: Address
-  BigIntish: BigIntish
   Bytes: Bytes
   ContractInterface: ContractInterface
   Provider: Provider
   Signer: Signer
   SignatureLike: SignatureLike
-  TypedDataDomain: TypedDataDomain
-  TypedDataTypes: TypedDataTypes
 }
 
 /**

--- a/packages/contracts-ts/src/settlement.ts
+++ b/packages/contracts-ts/src/settlement.ts
@@ -444,7 +444,6 @@ export class SettlementEncoder {
       return []
     }
 
-    //@ts-expect-error: TypedDataDomain is unknown
     const settlement = this.domain.verifyingContract
     if (settlement === undefined) {
       throw new Error('domain missing settlement contract address')
@@ -551,7 +550,6 @@ export class SettlementEncoder {
    * @param orderRefunds The order refunds to encode.
    */
   public encodeOrderRefunds(orderRefunds: Partial<OrderRefunds>): void {
-    //@ts-expect-error:TypedDataDomain is unknown
     if (this.domain.verifyingContract === undefined) {
       throw new Error('domain missing settlement contract address')
     }

--- a/packages/providers/ether-v5-adapter/src/EthersV5Adapter.ts
+++ b/packages/providers/ether-v5-adapter/src/EthersV5Adapter.ts
@@ -2,6 +2,7 @@ import { BigNumberish, BytesLike, ethers } from 'ethers'
 import type { TypedDataSigner } from '@ethersproject/abstract-signer'
 import {
   AbstractProviderAdapter,
+  AdapterTypes,
   ContractValue,
   CowError,
   GenericContract,
@@ -18,14 +19,22 @@ import {
 } from './EthersV5SignerAdapter'
 
 type Abi = ConstructorParameters<typeof ethers.utils.Interface>[0]
+type Interface = ethers.utils.Interface
 type RpcProvider = ethers.providers.Provider
 
+export interface EthersV5Types extends AdapterTypes {
+  Abi: Abi
+  Bytes: BytesLike
+  ContractInterface: Interface
+  Provider: RpcProvider
+  Signer: ethers.Signer
+}
 export interface EthersV5AdapterOptions {
   provider: RpcProvider | string // RPC URL or Provider instance
   signer?: ethers.Signer | PrivateKey // Optional signer or private key
 }
 
-export class EthersV5Adapter extends AbstractProviderAdapter {
+export class EthersV5Adapter extends AbstractProviderAdapter<EthersV5Types> {
   private _provider: RpcProvider
   private _signerAdapter?: EthersV5SignerAdapter
 

--- a/packages/providers/ether-v5-adapter/src/EthersV5Utils.ts
+++ b/packages/providers/ether-v5-adapter/src/EthersV5Utils.ts
@@ -1,6 +1,12 @@
-import { AdapterUtils, Address, BigIntish, ContractValue, GenericContractInterface } from '@cowprotocol/sdk-common'
+import {
+  AdapterUtils,
+  Address,
+  BigIntish,
+  ContractValue,
+  GenericContractInterface,
+  ParamType as CommonParamType,
+} from '@cowprotocol/sdk-common'
 import { BytesLike, ethers, TypedDataDomain, TypedDataField } from 'ethers'
-import { ParamType } from 'ethers/lib/utils'
 
 type Abi = ConstructorParameters<typeof ethers.utils.Interface>[0]
 
@@ -269,12 +275,12 @@ export class EthersV5Utils implements AdapterUtils {
     return ethers.utils.parseUnits(value, decimals).toBigInt()
   }
 
-  getParamType(type: string): ParamType {
-    return ethers.utils.ParamType.from(type)
+  getParamType(type: string): CommonParamType {
+    return ethers.utils.ParamType.from(type) as unknown as CommonParamType
   }
 
-  getParamTypeFromString(type: string): ParamType {
-    return ethers.utils.ParamType.fromString(type)
+  getParamTypeFromString(type: string): CommonParamType {
+    return ethers.utils.ParamType.fromString(type) as unknown as CommonParamType
   }
 
   isInterface(value: any): boolean {

--- a/packages/providers/ether-v5-adapter/src/EthersV5Utils.ts
+++ b/packages/providers/ether-v5-adapter/src/EthersV5Utils.ts
@@ -120,10 +120,6 @@ export class EthersV5Utils implements AdapterUtils {
     return ethers.BigNumber.from(value).toBigInt()
   }
 
-  newBigintish(value: number | string): BigIntish {
-    return ethers.BigNumber.from(value).toBigInt()
-  }
-
   hexDataSlice(data: BytesLike, offset: number, endOffset?: number): BytesLike {
     return ethers.utils.hexDataSlice(data, offset, endOffset)
   }

--- a/packages/providers/ether-v6-adapter/src/EthersV6Adapter.ts
+++ b/packages/providers/ether-v6-adapter/src/EthersV6Adapter.ts
@@ -18,6 +18,7 @@ import {
   CowError,
   GenericContract,
   TransactionReceipt,
+  AdapterTypes,
 } from '@cowprotocol/sdk-common'
 import { EthersV6Utils } from './EthersV6Utils'
 import {
@@ -28,13 +29,20 @@ import {
 } from './EthersV6SignerAdapter'
 
 type Abi = ConstructorParameters<typeof Interface>[0]
+export interface EthersV6Types extends AdapterTypes {
+  Abi: Abi
+  Bytes: BytesLike
+  ContractInterface: Interface
+  Provider: Provider
+  Signer: Signer
+}
 
 export interface EthersV6AdapterOptions {
   provider: Provider | string // RPC URL or Provider instance
   signer?: Signer | PrivateKey // Optional signer or private key
 }
 
-export class EthersV6Adapter extends AbstractProviderAdapter {
+export class EthersV6Adapter extends AbstractProviderAdapter<EthersV6Types> {
   private _provider: Provider
   private _signerAdapter?: EthersV6SignerAdapter
 

--- a/packages/providers/ether-v6-adapter/src/EthersV6Utils.ts
+++ b/packages/providers/ether-v6-adapter/src/EthersV6Utils.ts
@@ -1,4 +1,4 @@
-import { AdapterUtils, ContractValue, CowError } from '@cowprotocol/sdk-common'
+import { AdapterUtils, ContractValue, CowError, ParamType as CommonParamType } from '@cowprotocol/sdk-common'
 import {
   Interface,
   TypedDataField,
@@ -309,12 +309,12 @@ export class EthersV6Utils implements AdapterUtils {
     return parseUnits(value, decimals)
   }
 
-  getParamType(type: string): ParamType {
-    return ParamType.from(type)
+  getParamType(type: string): CommonParamType {
+    return ParamType.from(type) as unknown as CommonParamType
   }
 
-  getParamTypeFromString(type: string): ParamType {
-    return ParamType.from(type)
+  getParamTypeFromString(type: string): CommonParamType {
+    return ParamType.from(type) as unknown as CommonParamType
   }
 
   isInterface(value: any): boolean {

--- a/packages/providers/ether-v6-adapter/src/EthersV6Utils.ts
+++ b/packages/providers/ether-v6-adapter/src/EthersV6Utils.ts
@@ -143,10 +143,6 @@ export class EthersV6Utils implements AdapterUtils {
     return toBigInt(value)
   }
 
-  newBigintish(value: number | string): BigNumberish {
-    return toBigInt(value)
-  }
-
   hexDataSlice(data: BytesLike, offset: number, endOffset?: number): BytesLike {
     return dataSlice(data, offset, endOffset)
   }

--- a/packages/providers/viem-adapter/src/ViemAdapter.ts
+++ b/packages/providers/viem-adapter/src/ViemAdapter.ts
@@ -1,7 +1,6 @@
 import {
   PublicClient,
   Account,
-  TypedDataDomain,
   WalletClient,
   createWalletClient,
   Address,
@@ -38,14 +37,10 @@ import { Hash } from 'viem/types/misc'
 
 export interface ViemTypes extends AdapterTypes {
   Abi: Abi
-  Address: Address
   Bytes: `0x${string}`
-  BigIntish: bigint
   ContractInterface: Abi
   Provider: PublicClient
   Signer: WalletClient
-  TypedDataDomain: TypedDataDomain
-  TypedDataTypes: Record<string, unknown>
 }
 
 export interface ViemAdapterOptions {

--- a/packages/providers/viem-adapter/src/ViemUtils.ts
+++ b/packages/providers/viem-adapter/src/ViemUtils.ts
@@ -1,4 +1,9 @@
-import { AdapterUtils, ContractValue, CowError } from '@cowprotocol/sdk-common'
+import {
+  AdapterUtils,
+  ContractValue,
+  CowError,
+  TypedDataDomain as TypedDataDomainCommon,
+} from '@cowprotocol/sdk-common'
 import {
   encodeDeployData,
   Abi,
@@ -125,14 +130,14 @@ export class ViemUtils implements AdapterUtils {
     return encodePacked(types, values)
   }
 
-  hashTypedData(domain: TypedDataDomain, types: Record<string, unknown>, data: Record<string, unknown>): string {
+  hashTypedData(domain: TypedDataDomainCommon, types: Record<string, unknown>, data: Record<string, unknown>): string {
     const primaryType = Object.keys(types)[0]
     if (!primaryType) {
       throw new Error('No primary type found in types')
     }
-
+    const domainTypedDataDomain = domain as TypedDataDomain
     return hashTypedData({
-      domain,
+      domain: domainTypedDataDomain,
       types: types as Record<string, unknown>,
       primaryType,
       message: data,
@@ -170,10 +175,6 @@ export class ViemUtils implements AdapterUtils {
       return BigInt(value)
     }
     return hexToBigInt(value)
-  }
-
-  newBigintish(value: number | string): bigint {
-    return BigInt(value)
   }
 
   hexDataSlice(data: `0x${string}`, offset: number, endOffset?: number): `0x${string}` {
@@ -219,7 +220,7 @@ export class ViemUtils implements AdapterUtils {
   }
 
   async verifyTypedData(
-    domain: TypedDataDomain,
+    domain: TypedDataDomainCommon,
     types: Record<string, Array<{ name: string; type: string }>>,
     value: Record<string, unknown>,
     signature: `0x${string}`,
@@ -228,9 +229,9 @@ export class ViemUtils implements AdapterUtils {
     if (!primaryType) {
       throw new Error('No primary type found in types')
     }
-
+    const domainTypedDataDomain = domain as TypedDataDomain
     return recoverTypedDataAddress({
-      domain,
+      domain: domainTypedDataDomain,
       types,
       primaryType,
       message: value,
@@ -303,18 +304,19 @@ export class ViemUtils implements AdapterUtils {
     return new ViemInterfaceWrapper(abi)
   }
 
-  hashDomain(domain: TypedDataDomain): string {
+  hashDomain(domain: TypedDataDomainCommon): string {
+    const domainTypedDataDomain = domain as TypedDataDomain
     // 1. Define the EIP712Domain type hash
     const EIP712_DOMAIN_TYPEHASH = keccak256(
       toHex('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'),
     )
 
     // 2. Hash individual domain fields
-    const nameHash = domain.name
-      ? keccak256(toHex(domain.name))
+    const nameHash = domainTypedDataDomain.name
+      ? keccak256(toHex(domainTypedDataDomain.name))
       : '0x0000000000000000000000000000000000000000000000000000000000000000'
-    const versionHash = domain.version
-      ? keccak256(toHex(domain.version))
+    const versionHash = domainTypedDataDomain.version
+      ? keccak256(toHex(domainTypedDataDomain.version))
       : '0x0000000000000000000000000000000000000000000000000000000000000000'
 
     // 3. Encode the domain struct according to EIP-712
@@ -330,8 +332,8 @@ export class ViemUtils implements AdapterUtils {
         EIP712_DOMAIN_TYPEHASH,
         nameHash,
         versionHash,
-        BigInt(domain.chainId || 0),
-        (domain.verifyingContract as `0x${string}`) || '0x0000000000000000000000000000000000000000',
+        BigInt(domainTypedDataDomain.chainId || 0),
+        (domainTypedDataDomain.verifyingContract as `0x${string}`) || '0x0000000000000000000000000000000000000000',
       ],
     )
 

--- a/packages/providers/viem-adapter/src/ViemUtils.ts
+++ b/packages/providers/viem-adapter/src/ViemUtils.ts
@@ -3,6 +3,7 @@ import {
   ContractValue,
   CowError,
   TypedDataDomain as TypedDataDomainCommon,
+  ParamType as CommonParamType,
 } from '@cowprotocol/sdk-common'
 import {
   encodeDeployData,
@@ -451,11 +452,11 @@ export class ViemUtils implements AdapterUtils {
     return parseUnits(value, decimals)
   }
 
-  getParamType(type: string): ViemParamType {
-    return new ViemParamType(type)
+  getParamType(type: string): CommonParamType {
+    return new ViemParamType(type) as unknown as CommonParamType
   }
-  getParamTypeFromString(type: string): ViemParamType {
-    return new ViemParamType(type)
+  getParamTypeFromString(type: string): CommonParamType {
+    return new ViemParamType(type) as unknown as CommonParamType
   }
 
   isInterface(value: any): boolean {

--- a/turbo.json
+++ b/turbo.json
@@ -35,7 +35,8 @@
     },
     "typecheck": {
       "outputs": [],
-      "cache": true
+      "cache": true,
+      "dependsOn": ["build"]
     }
   }
 }


### PR DESCRIPTION
## ✅ Successfully Converted Types

### `Address: string`
### `TypedDataTypes: Record<string, Array<{ name: string; type: string }>>`
### `TypedDataDomain: Interface`
- **Adapter Handling**: 
  - Ethers v5/v6: Work directly with common interface (permissive)
  - Viem: Requires boundary conversion in adapter (strict branded types)
- **Impact**: Improved documentation while maintaining adapter flexibility through boundary conversion pattern
- 
## ❌ Types That Remain `unknown`

### `SignatureLike`
**Problem**: When changed from `unknown` to specific type, breaks compatibility at multiple levels:

- **AdapterUtils Interface Conflict**: Methods like `verifyMessage(signature: SignatureLike)` and `verifyTypedData(signature: SignatureLike)` narrow the contract
- **Implementation Mismatch**: 
  - EthersV5/V6Utils expect `BytesLike` (string | Uint8Array | ArrayLike<number>)
  - Viem expects `0x${string}` format
  - No single union type satisfies all adapters without compatibility issues
- **Call-site Breaks**: Code that passes `Uint8Array` or `Bytes` to signature methods fails compilation when `SignatureLike = string`

### `Bytes`
**Problem**: Single `Bytes` type cannot serve both inputs and outputs due to fundamental differences:

- **Input/Output Mismatch**: 
  - **Inputs** need flexibility: `string | Uint8Array | ArrayLike<number>`
  - **Outputs** need consistency: `string` (hex format)
- **Cross-Adapter Conflicts**:
  - Ethers v5/v6: Methods return `BytesLike`, accept flexible inputs
  - Viem: Stricter about `0x${string}` format, different input/output expectations
  - Union types that work for one adapter break another
- **Method Signature Cascade**: Changing `Bytes` affects ALL `AdapterUtils` methods (keccak256, hexlify, encodeAbi, etc.), creating compatibility matrix explosion

**Analysis**: Methods like `keccak256()`, `encodeAbi()`, `hexDataSlice()` return hex strings, but if `Bytes` includes `ArrayLike<number>`, some adapters can't assign their `BytesLike` returns to this type.

**Potential Solution (Future)**: Separate input/output types:
```typescript
type BytesInput = string | Uint8Array
type HexOutput = string
// Then use specifically in method signatures
```

**Current Decision**:  Testing this....

### `Abi`, `ContractInterface`, `Signer`, `Provider`
**Problem**: Fundamentally different implementations across adapters:
- **Abi**: Ethers uses `ConstructorParameters<typeof Interface>[0]`, Viem uses recursive `Abi` type
- **ContractInterface**: Different classes (`ethers.utils.Interface` vs `Interface` vs Viem's direct Abi usage)
- **Signer**: Different architectures (`ethers.Signer` vs `WalletClient`)
- **Provider**: Different APIs (`ethers.providers.Provider` vs `PublicClient`)

**Decision**: These remain `unknown` and are handled via adapter-specific implementations in `AdapterUtils`

[EDIT] - 
### `Bytes`
**Problem**: Tested input/output separation approach - technically viable but impractical.

**Testing Results**: 
- `BytesInput/HexOutput` separation compiles in common interface
- Requires adapter modifications: ethers adapters need return type adjustments (`BytesLike` → `string`)
- Creates cascading changes across all utility methods

**Core Issues**:
- **Library Differences**: Ethers returns `BytesLike`, viem expects `0x${string}`, each has different input tolerances
- **Complexity Cost**: Type safety gains outweighed by maintenance burden and adapter coupling
- **Boundary Pattern**: `unknown` at adapter boundary with internal conversion is established pattern for multi-provider SDKs
