### PR TITLE
fix: update npm publish CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
     types: [published]
 
 env:
-  NODE_VERSION: lts/*
+  NODE_VERSION: lts/jod
 
 jobs:
   build:
@@ -28,9 +28,9 @@ jobs:
       - name: Remove broken apt repos [Ubuntu]
         run: |
           for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,16 +2,16 @@ name: 'ESLint check'
 on: [pull_request]
 
 env:
-  NODE_VERSION: lts/*
+  NODE_VERSION: lts/jod
 
 jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,20 @@
 name: Publish packages to NPM
 
 on:
-  release:
-    types: [published]
+  repository_dispatch:
+    types: [publish]
 
 env:
-  NODE_VERSION: lts/*
+  NODE_VERSION: lts/jod
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  NODE_VERSION: lts/jod
+
 permissions:
   contents: write
   pull-requests: write
@@ -23,33 +26,11 @@ jobs:
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-          default-branch: main
           target-branch: main
-
-  publish:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Dispatch publish workflow
+        if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+        uses: peter-evans/repository-dispatch@v3
         with:
-          node-version: '18'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Install dependencies
-        run: npm install
-      - name: Build all packages
-        run: npm run build
-      - name: Publish packages
-        run: npm run publish:all
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Log published packages
-        run: |
-          if [ -n "${{ needs.release-please.outputs.paths_released }}" ]; then
-            echo "Published packages: ${{ needs.release-please.outputs.paths_released }}"
-          else
-            echo "No packages published"
-          fi
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          event-type: publish


### PR DESCRIPTION
1. Bumped nodejs version to 22 across all GH actions
2.  Bumped actions/setup-node, actions/checkout to v4 across all GH actions
3. Fixed NPM publishing action trigger using https://github.com/peter-evans/repository-dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded CI to use Node.js LTS “jod” across workflows.
  * Updated GitHub Actions to latest major versions for improved reliability and security.
  * Revised release process: publishing is now triggered via a repository dispatch event after a release is created, decoupling publish from the release workflow.
  * Publish workflow now listens to a custom “publish” event instead of release-published.
  * No changes to application functionality; build and lint behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->