### PR TITLE
fix: migrate lens eth-flow contract address

### DIFF
--- a/packages/config/src/chains/const/contracts.ts
+++ b/packages/config/src/chains/const/contracts.ts
@@ -28,19 +28,26 @@ export const EXTENSIBLE_FALLBACK_HANDLER_CONTRACT_ADDRESS = mapAddressToSupporte
  */
 export const COMPOSABLE_COW_CONTRACT_ADDRESS = mapAddressToSupportedNetworks(COMPOSABLE_COW)
 
-export const ETH_FLOW_ADDRESS = '0xba3cb449bd2b4adddbc894d8697f5170800eadec'
-export const BARN_ETH_FLOW_ADDRESS = '0x04501b9b1d52e67f6862d157e00d13419d2d6e95'
+const ETH_FLOW_ADDRESS = '0xba3cb449bd2b4adddbc894d8697f5170800eadec'
+const BARN_ETH_FLOW_ADDRESS = '0x04501b9b1d52e67f6862d157e00d13419d2d6e95'
+// Lens does not uses the same deterministic address for the EthFlow contract as other chains.
+const ETH_FLOW_ADDRESS_LENS = '0x5A5b8aE7a0b4C0EAf453d10DCcfbA413f07ebdC2'
+const BARN_ETH_FLOW_ADDRESS_LENS = '0xFb337f8a725A142f65fb9ff4902d41cc901de222'
 
 /**
- * An object containing the addresses of ETH flow contracts for each supported chain.
- * @deprecated use ETH_FLOW_ADDRESS instead
+ * An object containing the addresses of ETH flow contracts for each supported chain for production.
  */
-export const ETH_FLOW_ADDRESSES: Record<SupportedChainId, string> = mapAddressToSupportedNetworks(ETH_FLOW_ADDRESS)
+export const ETH_FLOW_ADDRESSES: Record<SupportedChainId, string> = {
+  ...mapAddressToSupportedNetworks(ETH_FLOW_ADDRESS),
+  [SupportedChainId.LENS]: ETH_FLOW_ADDRESS_LENS,
+}
 
 /**
- * @deprecated use BARN_ETH_FLOW_ADDRESS instead
+ * An object containing the addresses of ETH flow contracts for each supported chain for barn.
  */
-export const BARN_ETH_FLOW_ADDRESSES: Record<SupportedChainId, string> =
-  mapAddressToSupportedNetworks(BARN_ETH_FLOW_ADDRESS)
+export const BARN_ETH_FLOW_ADDRESSES: Record<SupportedChainId, string> = {
+  ...mapAddressToSupportedNetworks(BARN_ETH_FLOW_ADDRESS),
+  [SupportedChainId.LENS]: BARN_ETH_FLOW_ADDRESS_LENS,
+}
 
 export const MAX_VALID_TO_EPOCH = 4294967295 // Max uint32 (Feb 07 2106 07:28:15 GMT+0100)


### PR DESCRIPTION
I lost this change while migrating from v6 to v7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the Lens network, enabling interactions on Lens alongside existing chains.
  - Expanded address mappings to include Lens-specific endpoints for seamless routing.
- Refactor
  - Streamlined configuration by limiting exposure of internal addresses to reduce public surface area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->