### PR TITLE
fix: send Bungee affiliate header only for Bungee private endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "license": "(MIT OR Apache-2.0)",
   "files": [
     "/dist"

--- a/src/bridging/providers/bungee/BungeeApi.ts
+++ b/src/bridging/providers/bungee/BungeeApi.ts
@@ -50,6 +50,8 @@ export interface BungeeApiOptions {
   affiliate?: string
 }
 
+type BungeeApiType = 'bungee' | 'events' | 'across' | 'bungee-manual'
+
 interface IntermediateTokensParams {
   fromChainId: SupportedChainId
   toChainId: TargetChainId
@@ -362,8 +364,14 @@ export class BungeeApi {
     return bridges ?? this.options.includeBridges ?? SUPPORTED_BRIDGES
   }
 
+  private shouldAddAffiliate(apiType: BungeeApiType, baseUrl: string): boolean {
+    const isBungeeApi = apiType === 'bungee' || apiType === 'bungee-manual'
+
+    return !baseUrl.includes(BUNGEE_BASE_URL) && isBungeeApi
+  }
+
   private async makeApiCall<T>(
-    apiType: 'bungee' | 'events' | 'across' | 'bungee-manual',
+    apiType: BungeeApiType,
     path: string,
     params: Record<string, string> | URLSearchParams,
     isValidResponse?: (response: unknown) => response is T,
@@ -379,7 +387,7 @@ export class BungeeApi {
     const url = `${baseUrl}${path}?${new URLSearchParams(params).toString()}`
     const headers: Record<string, string> = {}
 
-    if (this.options.affiliate && !baseUrl.includes(BUNGEE_BASE_URL)) {
+    if (this.shouldAddAffiliate(apiType, baseUrl) && this.options.affiliate) {
       headers['affiliate'] = this.options.affiliate
     }
 


### PR DESCRIPTION
#Bug Fixes

- Affiliate header now applied only to specific Bungee endpoints and non-public base URLs, preventing unintended header usage.

- Centralized and streamlined logic for deciding when to attach affiliate headers, improving consistency across API calls.
