### PR TITLE
fix(config): make native token address lower in url

### DIFF
--- a/packages/config/src/constants/tokens.ts
+++ b/packages/config/src/constants/tokens.ts
@@ -98,5 +98,5 @@ export const nativeCurrencyTemplate: Omit<TokenInfo, 'chainId'> = {
   decimals: 18,
   name: 'Ether',
   symbol: 'ETH',
-  logoUrl: `${TOKEN_LIST_IMAGES_PATH}/1/${NATIVE_CURRENCY_ADDRESS}/logo.png`,
+  logoUrl: `${TOKEN_LIST_IMAGES_PATH}/1/${NATIVE_CURRENCY_ADDRESS.toLowerCase()}/logo.png`,
 }


### PR DESCRIPTION
Fixes: https://github.com/cowprotocol/cowswap/issues/6253

Github is case sensitive in file URL resolving, so we need to lowercase the native token address