### PR TITLE
fix: fix gnosis native token url

### DIFF
--- a/packages/config/src/chains/details/gnosis.ts
+++ b/packages/config/src/chains/details/gnosis.ts
@@ -18,7 +18,7 @@ export const gnosisChain: ChainInfo = {
     chainId: SupportedChainId.GNOSIS_CHAIN,
     name: 'xDAI',
     symbol: 'xDAI',
-    logoUrl: `${TOKEN_LIST_IMAGES_PATH}/100/${NATIVE_CURRENCY_ADDRESS}/logo.png`,
+    logoUrl: `${TOKEN_LIST_IMAGES_PATH}/100/${NATIVE_CURRENCY_ADDRESS.toLowerCase()}/logo.png`,
   },
   addressPrefix: 'gno',
   isTestnet: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent loading of the Gnosis native currency icon by normalizing the logo URL to use a lowercase address. This prevents missing or broken icons in environments with case-sensitive URL handling (e.g., CDNs or caches) and ensures consistent rendering across apps and integrations. No other changes to the Gnosis chain configuration or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->