### PR TITLE
chore: fix TypeDoc Entry Point

### DIFF
--- a/packages/sdk/src/typedoc-entry.ts
+++ b/packages/sdk/src/typedoc-entry.ts
@@ -1,0 +1,14 @@
+/**
+ * TypeDoc Entry Point
+ *
+ * This file serves as the primary documentation entry point for TypeDoc.
+ * It re-exports only the main SDK components to avoid duplicate documentation
+ * of types from other packages in the generated docs.
+ *
+ * IMPORTANT: This file is specifically created for TypeDoc documentation generation.
+ * For actual SDK usage, import from the main index.ts file which contains all exports.
+ *
+ * @packageDocumentation
+ */
+
+export * from '@cowprotocol/sdk-trading'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation by introducing a dedicated entry point that focuses on the main SDK components.
  * Streamlines navigation and reduces noise from cross-package types, making it easier to browse and understand the public API.
  * No changes to runtime behavior or the SDK’s public interface; installation and usage remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->