### PR TITLE
chore: remove release-as after major release

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,83 +6,67 @@
   "packages": {
     "packages/app-data": {
       "package-name": "@cowprotocol/sdk-app-data",
-      "release-type": "node",
-      "release-as": "4.0.0"
+      "release-type": "node"
     },
     "packages/bridging": {
       "package-name": "@cowprotocol/sdk-bridging",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/common": {
       "package-name": "@cowprotocol/sdk-common",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/composable": {
       "package-name": "@cowprotocol/sdk-composable",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/config": {
       "package-name": "@cowprotocol/sdk-config",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/contracts-ts": {
       "package-name": "@cowprotocol/sdk-contracts-ts",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/cow-shed": {
       "package-name": "@cowprotocol/sdk-cow-shed",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/order-book": {
       "package-name": "@cowprotocol/sdk-order-book",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/order-signing": {
       "package-name": "@cowprotocol/sdk-order-signing",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/subgraph": {
       "package-name": "@cowprotocol/sdk-subgraph",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/trading": {
       "package-name": "@cowprotocol/sdk-trading",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/weiroll": {
       "package-name": "@cowprotocol/sdk-weiroll",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/providers/ethers-v5-adapter": {
       "package-name": "@cowprotocol/sdk-ethers-v5-adapter",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/providers/ethers-v6-adapter": {
       "package-name": "@cowprotocol/sdk-ethers-v6-adapter",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/providers/viem-adapter": {
       "package-name": "@cowprotocol/sdk-viem-adapter",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/sdk": {
       "package-name": "@cowprotocol/cow-sdk",
-      "release-type": "node",
-      "release-as": "7.0.0"
+      "release-type": "node"
     }
   },
   "plugins": ["node-workspace"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized release configuration across all packages by removing per-package version pins, relying on automated versioning.
  * Streamlines the release process and reduces maintenance overhead for future releases.
  * No changes to application behavior or user experience.

* **Refactor**
  * Consolidated configuration to a consistent release type for all packages, simplifying setup.

* **Notes**
  * No user action required; this change only affects the release pipeline and has no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->