### PR TITLE
Remove Unnecessary Adapter Instance

### DIFF
--- a/packages/contracts-ts/src/order.ts
+++ b/packages/contracts-ts/src/order.ts
@@ -1,4 +1,4 @@
-import { Bytes, getGlobalAdapter, TypedDataDomain, TypedDataTypes } from '@cowprotocol/sdk-common'
+import { Bytes, getGlobalAdapter, TypedDataDomain, TypedDataTypes, ZERO_ADDRESS } from '@cowprotocol/sdk-common'
 import { Order } from './types'
 
 /**
@@ -140,15 +140,14 @@ export type NormalizedOrder = Omit<Order, 'validTo' | 'appData' | 'kind' | 'sell
  * @returns A 32-byte hash encoded as a hex-string.
  */
 export function normalizeOrder(order: Order): NormalizedOrder {
-  const adapter = getGlobalAdapter()
-  if (order.receiver === adapter.ZERO_ADDRESS) {
+  if (order.receiver === ZERO_ADDRESS) {
     throw new Error('receiver cannot be address(0)')
   }
 
   const normalizedOrder = {
     ...order,
     sellTokenBalance: order.sellTokenBalance ?? OrderBalance.ERC20,
-    receiver: order.receiver ?? adapter.ZERO_ADDRESS,
+    receiver: order.receiver ?? ZERO_ADDRESS,
     validTo: timestamp(order.validTo),
     appData: hashify(order.appData),
     buyTokenBalance: normalizeBuyTokenBalance(order.buyTokenBalance),


### PR DESCRIPTION
Closes https://github.com/cowprotocol/cow-sdk/issues/522

Uses the exported ZERO_ADDRESS from common instead of adapter instance. Reduces burden on developer to set an adapter just to construct an OrderUid.

Note that all Adapters use the same ZeroAddress anyway. 

Longer term approach would be to remove the zero address from the adapter instance entirely so there is no confusion. Curious to know why its there to begin with.

