### PR TITLE
feat(bridge): add method to get best result from multiple providers

### DIFF
--- a/packages/bridging/README.md
+++ b/packages/bridging/README.md
@@ -302,6 +302,118 @@ const results = await sdk.bridging.getMultiQuotes({
 - `timeout`: The total time to wait for all providers. After this time, any remaining providers are marked as timed out.
 - Providers that complete within their individual timeout but after the global timeout will still be included in the final results.
 
+## Best Quote Selection
+
+The `getBestQuote()` method provides an optimized way to get only the best quote from multiple providers, with progressive updates as better quotes are found. This is perfect for applications that only need the single best result.
+
+### Basic Best Quote Usage
+
+```typescript
+import { MultiQuoteRequest } from '@cowprotocol/sdk-bridging'
+
+// Get the best quote from all available providers
+const bestQuote = await sdk.bridging.getBestQuote({
+  quoteBridgeRequest: parameters, // Same parameters as above
+  providerDappIds: ['provider1', 'provider2'], // Optional: specify which providers to query
+  advancedSettings: {
+    slippageBps: 100, // 1% slippage tolerance
+  },
+  options: {
+    totalTimeout: 15000,       // 15 seconds total timeout
+    providerTimeout: 8000,     // 8 seconds per provider timeout
+  }
+})
+
+if (bestQuote?.quote) {
+  console.log(`Best quote from ${bestQuote.providerDappId}:`, bestQuote.quote)
+  const { buyAmount } = bestQuote.quote.bridge.amountsAndCosts.afterSlippage
+  console.log(`You will receive: ${buyAmount} tokens`)
+} else if (bestQuote?.error) {
+  console.log('All providers failed, first error:', bestQuote.error.message)
+} else {
+  console.log('No quotes available')
+}
+```
+
+### Progressive Best Quote Updates
+
+For real-time updates, you can receive notifications each time a better quote is found:
+
+```typescript
+let currentBest: MultiQuoteResult | null = null
+
+const bestQuote = await sdk.bridging.getBestQuote({
+  quoteBridgeRequest: parameters,
+  options: {
+    // Called whenever a better quote is found
+    onQuoteResult: (result) => {
+      currentBest = result
+      console.log(`🚀 New best quote from ${result.providerDappId}!`)
+
+      if (result.quote) {
+        const buyAmount = result.quote.bridge.amountsAndCosts.afterSlippage.buyAmount
+        console.log(`Better quote found: ${buyAmount} tokens`)
+
+        // Update UI immediately with the new best quote
+        updateBestQuoteInUI(result)
+      }
+    },
+    totalTimeout: 20000,      // 20 seconds total timeout
+    providerTimeout: 5000     // 5 seconds per provider timeout
+  }
+})
+
+console.log('Final best quote:', bestQuote)
+```
+
+### Error Handling with Best Quote
+
+When all providers fail, `getBestQuote()` returns the first provider's error:
+
+```typescript
+const bestQuote = await sdk.bridging.getBestQuote({
+  quoteBridgeRequest: parameters,
+  options: {
+    onQuoteResult: (result) => {
+      // Only called for successful quotes that are better than current best
+      console.log(`✅ Better quote from ${result.providerDappId}`)
+    }
+  }
+})
+
+if (bestQuote?.quote) {
+  // Success: we have the best available quote
+  console.log('Best quote found:', bestQuote.quote)
+} else if (bestQuote?.error) {
+  // All providers failed, this is the first error encountered
+  console.error('All providers failed:', bestQuote.error.message)
+  console.log('Failed provider:', bestQuote.providerDappId)
+} else {
+  // This should never happen, but good to handle
+  console.log('No quote or error returned')
+}
+```
+
+### Comparison: getBestQuote vs getMultiQuotes
+
+| Feature | `getBestQuote()` | `getMultiQuotes()` |
+|---------|------------------|-------------------|
+| **Returns** | Single best result | Array of all results |
+| **Progressive Callbacks** | Only for better quotes | For all results (success & error) |
+| **Error Handling** | Returns first error if all fail | Returns all errors in array |
+| **Performance** | Optimized for best result only | Returns complete data set |
+| **Use Case** | When you only need the best quote | When you need to compare all options |
+
+Choose `getBestQuote()` when:
+- You only need the single best quote
+- You want real-time updates as better quotes are found
+- You want to minimize callback overhead (only called for improvements)
+
+Choose `getMultiQuotes()` when:
+- You need to display all available options to users
+- You want to analyze all provider responses
+- You need to show provider-specific errors or statuses
+
 ## Supported Bridge Providers
 
 - Additional bridge providers are being integrated

--- a/packages/bridging/src/BridgingSdk/BridgingSdk.ts
+++ b/packages/bridging/src/BridgingSdk/BridgingSdk.ts
@@ -8,8 +8,9 @@ import {
   GetProviderBuyTokens,
   MultiQuoteRequest,
   MultiQuoteResult,
-  MultiQuoteProgressCallback,
   QuoteBridgeRequest,
+  ProviderQuoteContext,
+  BestQuoteProviderContext,
 } from '../types'
 import { getQuoteWithoutBridge } from './getQuoteWithoutBridge'
 import { getQuoteWithBridge } from './getQuoteWithBridge'
@@ -24,6 +25,8 @@ import {
   createProviderTimeoutPromise,
   executeProviderQuotes,
   fillTimeoutResults,
+  isBetterQuote,
+  safeCallBestQuoteCallback,
   safeCallProgressiveCallback,
   validateCrossChainRequest,
 } from './utils'
@@ -216,16 +219,17 @@ export class BridgingSdk {
         continue
       }
 
-      const promise = this.createProviderQuotePromise(
+      const context: ProviderQuoteContext = {
         provider,
         quoteBridgeRequest,
         advancedSettings,
         providerTimeout,
         onQuoteResult,
         results,
-        i,
-      )
+        index: i,
+      }
 
+      const promise = this.createProviderQuotePromise(context)
       promises.push(promise)
     }
 
@@ -237,21 +241,73 @@ export class BridgingSdk {
 
     // Sort results by buyAmount after slippage (descending, best quotes first)
     results.sort((a, b) => {
-      // Put successful quotes before failed ones
-      if (a.quote && !b.quote) return -1
-      if (!a.quote && b.quote) return 1
-      if (!a.quote && !b.quote) return 0
-      // Not possible due to previous check
-      // but Typescript cannot understand that a and b not falsy in the followingcode
-      if (!a.quote || !b.quote) return 0
-
-      // Both have quotes, sort by buyAmount after slippage (descending)
-      const aBuyAmount = a.quote.bridge.amountsAndCosts.afterSlippage.buyAmount
-      const bBuyAmount = b.quote.bridge.amountsAndCosts.afterSlippage.buyAmount
-      return aBuyAmount > bBuyAmount ? -1 : aBuyAmount < bBuyAmount ? 1 : 0
+      // Use the same comparison logic as getBestQuote
+      if (isBetterQuote(a, b)) return -1
+      if (isBetterQuote(b, a)) return 1
+      return 0
     })
 
     return results
+  }
+
+  /**
+   * Get the best quote from multiple bridge providers with progressive updates.
+   *
+   * This method is specifically for cross-chain bridging quotes. For single-chain swaps, use getQuote() instead.
+   *
+   * Features:
+   * - Returns only the best quote based on buyAmount after slippage
+   * - Progressive updates: Use the `onQuoteResult` callback to receive updates whenever a better quote is found
+   * - Timeout support: Configure maximum wait time for all providers and individual provider timeouts
+   * - Parallel execution: All providers are queried simultaneously for best performance
+   *
+   * @param request - The best quote request containing quote parameters, provider dappIds, and options
+   * @returns The best quote result found, or null if no successful quotes were obtained
+   * @throws Error if the request is for a single-chain swap (sellTokenChainId === buyTokenChainId)
+   */
+  async getBestQuote(request: MultiQuoteRequest): Promise<MultiQuoteResult | null> {
+    const { quoteBridgeRequest, providerDappIds, advancedSettings, options } = request
+    const { sellTokenChainId, buyTokenChainId } = quoteBridgeRequest
+
+    // Validate that this is a cross-chain request
+    validateCrossChainRequest(sellTokenChainId, buyTokenChainId)
+
+    // Determine which providers to query
+    const providersToQuery = this.resolveProvidersToQuery(providerDappIds)
+
+    // Extract options with defaults
+    const {
+      onQuoteResult,
+      totalTimeout = DEFAULT_TOTAL_TIMEOUT_MS,
+      providerTimeout = DEFAULT_PROVIDER_TIMEOUT_MS,
+    } = options || {}
+
+    // Keep track of the current best result and first error using mutable containers
+    const bestResult = { current: null as MultiQuoteResult | null }
+    const firstError = { current: null as MultiQuoteResult | null }
+    const promises: Promise<void>[] = []
+
+    // Create a promise for each provider that handles both progressive callbacks and best result tracking
+    for (const provider of providersToQuery) {
+      const context: BestQuoteProviderContext = {
+        provider,
+        quoteBridgeRequest,
+        advancedSettings,
+        providerTimeout,
+        onQuoteResult,
+        bestResult,
+        firstError,
+      }
+
+      const promise = this.createBestQuoteProviderPromise(context)
+      promises.push(promise)
+    }
+
+    // Execute all provider quotes with timeout handling
+    await executeProviderQuotes(promises, totalTimeout, this.config)
+
+    // Return best result if available, otherwise return first error
+    return bestResult.current || firstError.current
   }
 
   async getOrder(params: GetOrderParams): Promise<CrossChainOrder | null> {
@@ -301,17 +357,59 @@ export class BridgingSdk {
   }
 
   /**
+   * Creates a promise that handles quote fetching for a single provider in getBestQuote
+   */
+  private createBestQuoteProviderPromise(context: BestQuoteProviderContext): Promise<void> {
+    const { provider, quoteBridgeRequest, advancedSettings, providerTimeout, onQuoteResult, bestResult, firstError } =
+      context
+
+    return (async (): Promise<void> => {
+      try {
+        // Race between the actual quote request and the provider timeout
+        const quote = await Promise.race([
+          getQuoteWithBridge({
+            swapAndBridgeRequest: quoteBridgeRequest,
+            advancedSettings,
+            tradingSdk: this.config.tradingSdk,
+            provider,
+            bridgeHookSigner: advancedSettings?.quoteSigner,
+          }),
+          createProviderTimeoutPromise(providerTimeout, provider.info.dappId),
+        ])
+
+        const result: MultiQuoteResult = {
+          providerDappId: provider.info.dappId,
+          quote,
+          error: undefined,
+        }
+
+        // Check if this quote is better than the current best
+        if (isBetterQuote(result, bestResult.current)) {
+          bestResult.current = result
+          // Call callback only for better quotes
+          safeCallBestQuoteCallback(onQuoteResult, result)
+        }
+      } catch (error) {
+        const errorResult: MultiQuoteResult = {
+          providerDappId: provider.info.dappId,
+          quote: null,
+          error: error instanceof BridgeProviderError ? error : new BridgeProviderError(String(error), {}),
+        }
+
+        // Store the first error if we don't have one yet
+        if (!firstError.current) {
+          firstError.current = errorResult
+        }
+      }
+    })()
+  }
+
+  /**
    * Creates a promise that handles quote fetching for a single provider
    */
-  private createProviderQuotePromise(
-    provider: BridgeProvider<BridgeQuoteResult>,
-    quoteBridgeRequest: QuoteBridgeRequest,
-    advancedSettings: SwapAdvancedSettings | undefined,
-    providerTimeout: number,
-    onQuoteResult: MultiQuoteProgressCallback | undefined,
-    results: MultiQuoteResult[],
-    index: number,
-  ): Promise<void> {
+  private createProviderQuotePromise(context: ProviderQuoteContext): Promise<void> {
+    const { provider, quoteBridgeRequest, advancedSettings, providerTimeout, onQuoteResult, results, index } = context
+
     return (async (): Promise<void> => {
       try {
         // Race between the actual quote request and the provider timeout

--- a/packages/bridging/src/types.ts
+++ b/packages/bridging/src/types.ts
@@ -421,6 +421,11 @@ export interface MultiQuoteResult {
 export type MultiQuoteProgressCallback = (result: MultiQuoteResult) => void
 
 /**
+ * Callback function called when a better quote is found
+ */
+export type BestQuoteProgressCallback = (result: MultiQuoteResult) => void
+
+/**
  * Options for controlling the behavior of getMultiQuotes
  */
 export interface MultiQuoteOptions {
@@ -449,4 +454,22 @@ export interface MultiQuoteRequest {
   providerDappIds?: string[]
   advancedSettings?: SwapAdvancedSettings
   options?: MultiQuoteOptions
+}
+
+interface MultiQuoteContext {
+  provider: BridgeProvider<BridgeQuoteResult>
+  quoteBridgeRequest: QuoteBridgeRequest
+  advancedSettings: SwapAdvancedSettings | undefined
+  providerTimeout: number
+  onQuoteResult: MultiQuoteProgressCallback | undefined
+}
+
+export interface ProviderQuoteContext extends MultiQuoteContext {
+  results: MultiQuoteResult[]
+  index: number
+}
+
+export interface BestQuoteProviderContext extends MultiQuoteContext {
+  bestResult: { current: MultiQuoteResult | null }
+  firstError: { current: MultiQuoteResult | null }
 }


### PR DESCRIPTION
Added a new `getBestQuote()` method similar to [getMultiQuotes()](https://github.com/cowprotocol/cow-sdk/pull/526), but it only returns the best quote. It also supports progressive execution, so the best quote will be streamed with `onQuoteResult` callback.