### PR TITLE
fix(bridge): relax multi-quote errors wrapping

### DIFF
--- a/packages/bridging/src/BridgingSdk/strategies/BestQuoteStrategy.ts
+++ b/packages/bridging/src/BridgingSdk/strategies/BestQuoteStrategy.ts
@@ -9,8 +9,8 @@ import {
   validateCrossChainRequest,
 } from '../utils'
 import { getQuoteWithBridge } from '../getQuoteWithBridge'
-import { BridgeProviderError, BridgeProviderQuoteError } from '../../errors'
 import { BestQuoteStrategy, MultiQuoteRequest } from './QuoteStrategy'
+import { BridgeProviderError } from '../../errors'
 
 const DEFAULT_TOTAL_TIMEOUT_MS = 40_000 // 40 seconds
 const DEFAULT_PROVIDER_TIMEOUT_MS = 20_000 // 20 seconds
@@ -100,7 +100,7 @@ export class BestQuoteStrategyImpl implements BestQuoteStrategy {
         const errorResult: MultiQuoteResult = {
           providerDappId: provider.info.dappId,
           quote: null,
-          error: error instanceof BridgeProviderQuoteError ? error : new BridgeProviderError(String(error), {}),
+          error: error instanceof Error ? error : new BridgeProviderError(String(error), {}),
         }
 
         // Store the first error if we don't have one yet

--- a/packages/bridging/src/BridgingSdk/strategies/MultiQuoteStrategy.ts
+++ b/packages/bridging/src/BridgingSdk/strategies/MultiQuoteStrategy.ts
@@ -10,7 +10,7 @@ import {
   validateCrossChainRequest,
 } from '../utils'
 import { getQuoteWithBridge } from '../getQuoteWithBridge'
-import { BridgeProviderError, BridgeProviderQuoteError } from '../../errors'
+import { BridgeProviderError } from '../../errors'
 import { MultiQuoteStrategy, MultiQuoteRequest } from './QuoteStrategy'
 
 const DEFAULT_TOTAL_TIMEOUT_MS = 40_000 // 40 seconds
@@ -113,7 +113,7 @@ export class MultiQuoteStrategyImpl implements MultiQuoteStrategy {
         const result: MultiQuoteResult = {
           providerDappId: provider.info.dappId,
           quote: null,
-          error: error instanceof BridgeProviderQuoteError ? error : new BridgeProviderError(String(error), {}),
+          error: error instanceof Error ? error : new BridgeProviderError(String(error), {}),
         }
 
         // Store result for final return

--- a/packages/bridging/src/types.ts
+++ b/packages/bridging/src/types.ts
@@ -12,7 +12,6 @@ import type {
   TraderParameters,
 } from '@cowprotocol/sdk-trading'
 import type { AccountAddress, SignerLike } from '@cowprotocol/sdk-common'
-import { BridgeProviderError, BridgeProviderQuoteError } from './errors'
 
 export interface BridgeProviderInfo {
   name: string
@@ -412,7 +411,7 @@ export interface CrossChainOrder {
 export interface MultiQuoteResult {
   providerDappId: string
   quote: BridgeQuoteAndPost | null
-  error?: BridgeProviderQuoteError | BridgeProviderError
+  error?: Error
 }
 
 /**


### PR DESCRIPTION
Multi-quote error might be any error in fact, so we don't need to wrap into `BridgeProviderError` if it's an Error instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when fetching best or multi-provider bridge quotes by handling a broader range of provider errors.
  * Standardized error reporting to avoid missed or misclassified failures and provide clearer feedback when a quote cannot be obtained.

* **Refactor**
  * Unified quote error handling to a single, generic error type, reducing inconsistencies across providers and simplifying error interpretation for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->