### PR TITLE
fix(bridge): fix Across tx explorer link

### DIFF
--- a/packages/bridging/src/providers/across/AcrossBridgeProvider.test.ts
+++ b/packages/bridging/src/providers/across/AcrossBridgeProvider.test.ts
@@ -197,7 +197,7 @@ adapterNames.forEach((adapterName) => {
 
     describe('getExplorerUrl', () => {
       it('should return explorer url', () => {
-        expect(provider.getExplorerUrl('123')).toEqual('https://app.across.to/transactions/123')
+        expect(provider.getExplorerUrl('123')).toEqual('https://app.across.to/transactions')
       })
     })
 

--- a/packages/bridging/src/providers/across/AcrossBridgeProvider.ts
+++ b/packages/bridging/src/providers/across/AcrossBridgeProvider.ts
@@ -216,9 +216,8 @@ export class AcrossBridgeProvider implements BridgeProvider<AcrossQuoteResult> {
     }
   }
 
-  getExplorerUrl(bridgingId: string): string {
-    // TODO: Review with across how we get the explorer url based on the bridgingId
-    return `https://app.across.to/transactions/${bridgingId}`
+  getExplorerUrl(_: string): string {
+    return `https://app.across.to/transactions`
   }
 
   async getStatus(bridgingId: string, originChainId: SupportedChainId): Promise<BridgeStatusResult> {


### PR DESCRIPTION
It turned out they don't have a link to a specific transaction, only to the list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explorer links now point to the Transactions overview page (https://app.across.to/transactions) for consistent access to bridge activity.
  * Eliminates cases where per-transfer links could lead to missing or unavailable pages.
  * Improves navigation so users can reliably open the explorer and locate recent bridging activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->