### PR TITLE
chore: use a better name for main packages

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -133,8 +133,7 @@ jobs:
             echo "is_pr=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create pre-release versions for PRs
-        if: steps.version.outputs.is_pr == 'true'
+      - name: Create pre-release versions
         run: |
           # Create pre-release versions for all packages
           find packages -name "package.json" -exec sh -c '
@@ -163,8 +162,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Restore original versions (PR only)
-        if: steps.version.outputs.is_pr == 'true'
+      - name: Restore original versions
         run: |
           # Restore original package.json versions
           git checkout -- packages/*/package.json

--- a/packages/bridging/src/BridgingSdk/strategies/BestQuoteStrategy.test.ts
+++ b/packages/bridging/src/BridgingSdk/strategies/BestQuoteStrategy.test.ts
@@ -24,7 +24,7 @@ const adapters = createAdapters()
 const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
 
 adapterNames.forEach((adapterName) => {
-  describe.skip(`BestQuoteStrategy with ${adapterName}`, () => {
+  describe(`BestQuoteStrategy with ${adapterName}`, () => {
     let strategy: BestQuoteStrategyImpl
     let config: BridgingSdkConfig
     let tradingSdk: TradingSdk
@@ -122,7 +122,7 @@ adapterNames.forEach((adapterName) => {
       }
     })
 
-    describe.skip('execute', () => {
+    describe('execute', () => {
       it('should return the best quote from all providers', async () => {
         const request = {
           quoteBridgeRequest,

--- a/packages/bridging/src/BridgingSdk/strategies/MultiQuoteStrategy.test.ts
+++ b/packages/bridging/src/BridgingSdk/strategies/MultiQuoteStrategy.test.ts
@@ -25,7 +25,7 @@ const adapters = createAdapters()
 const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
 
 adapterNames.forEach((adapterName) => {
-  describe.skip(`MultiQuoteStrategy with ${adapterName}`, () => {
+  describe(`MultiQuoteStrategy with ${adapterName}`, () => {
     let strategy: MultiQuoteStrategyImpl
     let config: BridgingSdkConfig
     let tradingSdk: TradingSdk
@@ -254,19 +254,23 @@ adapterNames.forEach((adapterName) => {
 
         mockProvider.getQuote = jest.fn().mockImplementation(async () => {
           provider1Called = true
-          await new Promise((resolve) => setTimeout(() => {
-            provider1Resolved = true
-            resolve(bridgeQuoteResult)
-          }, 100))
+          await new Promise((resolve) =>
+            setTimeout(() => {
+              provider1Resolved = true
+              resolve(bridgeQuoteResult)
+            }, 100),
+          )
           return bridgeQuoteResult
         })
 
         mockProvider2.getQuote = jest.fn().mockImplementation(async () => {
           provider2Called = true
-          await new Promise((resolve) => setTimeout(() => {
-            provider2Resolved = true
-            resolve(bridgeQuoteResult)
-          }, 100))
+          await new Promise((resolve) =>
+            setTimeout(() => {
+              provider2Resolved = true
+              resolve(bridgeQuoteResult)
+            }, 100),
+          )
           return bridgeQuoteResult
         })
 


### PR DESCRIPTION
Attempt to fix the name used in the main branch when publishing packages to GH packages.

<img width="3330" height="1728" alt="image" src="https://github.com/user-attachments/assets/bc0e9b19-33ce-490c-a39c-cbcdcb75b849" />

This is a follow up on: https://github.com/cowprotocol/cow-sdk/pull/539

The goal is to use `<version>-main-<hash>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Publishing workflow now always creates pre-release packages and restores original versions in every run, providing consistent pre-release builds.
  - Users may see more frequent pre-release packages available for early testing; no change to app features or APIs.

- **Tests**
  - Previously skipped unit test suites have been re-enabled, restoring fuller test execution coverage. No functional behavior or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->