### PR TITLE
feat(trading): use suggested slippage from BFF

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -150,30 +150,39 @@ jobs:
         run: |
           echo "Updating inter-package dependencies to use new versions..."
 
-          # Create a map of package names to their new versions
-          declare -A package_versions
-
-          # Read all package.json files and extract name and version
+          # Create a temporary JSON file with package version mappings
+          echo "{" > package_versions.json
+          first=true
           for package_json in packages/*/package.json; do
             if [ -f "$package_json" ]; then
-              # Extract package name and version using node
               name=$(node -p "require('./$package_json').name")
               version=$(node -p "require('./$package_json').version")
               echo "Found package: $name@$version"
-              package_versions["$name"]="$version"
+
+              if [ "$first" = true ]; then
+                first=false
+              else
+                echo "," >> package_versions.json
+              fi
+              echo -n "  \"$name\": \"$version\"" >> package_versions.json
             fi
           done
+          echo "" >> package_versions.json
+          echo "}" >> package_versions.json
 
-          # Update dependencies in all package.json files
+          echo "=== Package version mappings ==="
+          cat package_versions.json
+          echo "================================="
+
+          # Update dependencies in all package.json files using the JSON file
           for package_json in packages/*/package.json; do
             if [ -f "$package_json" ]; then
               echo "Updating dependencies in $package_json"
 
-              # Create a temporary Node.js script to update dependencies
               node -e "
                 const fs = require('fs');
                 const packageJson = JSON.parse(fs.readFileSync('$package_json', 'utf8'));
-                const packageVersions = $(declare -p package_versions | sed 's/declare -A package_versions=//' | sed 's/\[\([^]]*\)\]=/[\"\1\"]=/g' | sed 's/^(/{\"/; s/$/}/' | sed 's/ \[\"/,\"/g' | sed 's/\]=/\":/g' | sed 's/ /,\"/g');
+                const packageVersions = JSON.parse(fs.readFileSync('package_versions.json', 'utf8'));
 
                 let updated = false;
 
@@ -196,10 +205,12 @@ jobs:
                 } else {
                   console.log('No updates needed for $package_json');
                 }
-              " 2>/dev/null || echo "Warning: Could not update $package_json"
+              " || echo "Warning: Could not update $package_json"
             fi
           done
 
+          # Clean up temporary file
+          rm -f package_versions.json
           echo "Inter-package dependency update completed."
 
       - name: Publish packages to GitHub Packages

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -95,12 +95,6 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Run tests
-        run: pnpm test
-
-      - name: Run linting
-        run: pnpm lint
-
       - name: Configure npm for GitHub Packages
         run: |
           # Override registry for @cowprotocol scope to use GitHub Packages
@@ -145,73 +139,6 @@ jobs:
             cd - > /dev/null
           done
           ' _ {} \;
-
-      - name: Update inter-package dependencies
-        run: |
-          echo "Updating inter-package dependencies to use new versions..."
-
-          # Create a temporary JSON file with package version mappings
-          echo "{" > package_versions.json
-          first=true
-          for package_json in packages/*/package.json; do
-            if [ -f "$package_json" ]; then
-              name=$(node -p "require('./$package_json').name")
-              version=$(node -p "require('./$package_json').version")
-              echo "Found package: $name@$version"
-
-              if [ "$first" = true ]; then
-                first=false
-              else
-                echo "," >> package_versions.json
-              fi
-              echo -n "  \"$name\": \"$version\"" >> package_versions.json
-            fi
-          done
-          echo "" >> package_versions.json
-          echo "}" >> package_versions.json
-
-          echo "=== Package version mappings ==="
-          cat package_versions.json
-          echo "================================="
-
-          # Update dependencies in all package.json files using the JSON file
-          for package_json in packages/*/package.json; do
-            if [ -f "$package_json" ]; then
-              echo "Updating dependencies in $package_json"
-
-              node -e "
-                const fs = require('fs');
-                const packageJson = JSON.parse(fs.readFileSync('$package_json', 'utf8'));
-                const packageVersions = JSON.parse(fs.readFileSync('package_versions.json', 'utf8'));
-
-                let updated = false;
-
-                // Update dependencies
-                ['dependencies', 'devDependencies', 'peerDependencies'].forEach(depType => {
-                  if (packageJson[depType]) {
-                    Object.keys(packageJson[depType]).forEach(depName => {
-                      if (packageVersions[depName]) {
-                        console.log(\`Updating \${depType}.\${depName} from \${packageJson[depType][depName]} to \${packageVersions[depName]}\`);
-                        packageJson[depType][depName] = packageVersions[depName];
-                        updated = true;
-                      }
-                    });
-                  }
-                });
-
-                if (updated) {
-                  fs.writeFileSync('$package_json', JSON.stringify(packageJson, null, 2) + '\n');
-                  console.log('Updated $package_json');
-                } else {
-                  console.log('No updates needed for $package_json');
-                }
-              " || echo "Warning: Could not update $package_json"
-            fi
-          done
-
-          # Clean up temporary file
-          rm -f package_versions.json
-          echo "Inter-package dependency update completed."
 
       - name: Publish packages to GitHub Packages
         run: |

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -146,6 +146,62 @@ jobs:
           done
           ' _ {} \;
 
+      - name: Update inter-package dependencies
+        run: |
+          echo "Updating inter-package dependencies to use new versions..."
+
+          # Create a map of package names to their new versions
+          declare -A package_versions
+
+          # Read all package.json files and extract name and version
+          for package_json in packages/*/package.json; do
+            if [ -f "$package_json" ]; then
+              # Extract package name and version using node
+              name=$(node -p "require('./$package_json').name")
+              version=$(node -p "require('./$package_json').version")
+              echo "Found package: $name@$version"
+              package_versions["$name"]="$version"
+            fi
+          done
+
+          # Update dependencies in all package.json files
+          for package_json in packages/*/package.json; do
+            if [ -f "$package_json" ]; then
+              echo "Updating dependencies in $package_json"
+
+              # Create a temporary Node.js script to update dependencies
+              node -e "
+                const fs = require('fs');
+                const packageJson = JSON.parse(fs.readFileSync('$package_json', 'utf8'));
+                const packageVersions = $(declare -p package_versions | sed 's/declare -A package_versions=//' | sed 's/\[\([^]]*\)\]=/[\"\1\"]=/g' | sed 's/^(/{\"/; s/$/}/' | sed 's/ \[\"/,\"/g' | sed 's/\]=/\":/g' | sed 's/ /,\"/g');
+
+                let updated = false;
+
+                // Update dependencies
+                ['dependencies', 'devDependencies', 'peerDependencies'].forEach(depType => {
+                  if (packageJson[depType]) {
+                    Object.keys(packageJson[depType]).forEach(depName => {
+                      if (packageVersions[depName]) {
+                        console.log(\`Updating \${depType}.\${depName} from \${packageJson[depType][depName]} to \${packageVersions[depName]}\`);
+                        packageJson[depType][depName] = packageVersions[depName];
+                        updated = true;
+                      }
+                    });
+                  }
+                });
+
+                if (updated) {
+                  fs.writeFileSync('$package_json', JSON.stringify(packageJson, null, 2) + '\n');
+                  console.log('Updated $package_json');
+                } else {
+                  console.log('No updates needed for $package_json');
+                }
+              " 2>/dev/null || echo "Warning: Could not update $package_json"
+            fi
+          done
+
+          echo "Inter-package dependency update completed."
+
       - name: Publish packages to GitHub Packages
         run: |
           # Publish all packages and capture versions

--- a/packages/trading/src/consts.ts
+++ b/packages/trading/src/consts.ts
@@ -1,5 +1,10 @@
 import { EcdsaSigningScheme, SigningScheme } from '@cowprotocol/sdk-order-book'
-import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/sdk-config'
+import { CowEnv, mapSupportedNetworks, SupportedChainId } from '@cowprotocol/sdk-config'
+
+export const BFF_ENDPOINTS: Record<CowEnv, string> = {
+  prod: 'https://bff.cow.fi',
+  staging: 'https://bff.barn.cow.fi',
+}
 
 export const DEFAULT_QUOTE_VALIDITY = 60 * 30 // 30 min
 

--- a/packages/trading/src/cowBffClient.test.ts
+++ b/packages/trading/src/cowBffClient.test.ts
@@ -1,0 +1,214 @@
+import { CoWBFFClient } from './cowBffClient'
+
+// Mock fetch globally
+const mockFetch = jest.fn()
+global.fetch = mockFetch
+
+describe('CoWBFFClient', () => {
+  beforeEach(() => {
+    mockFetch.mockClear()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('constructor', () => {
+    it('should use prod base URL when env is prod', () => {
+      const client = new CoWBFFClient('prod')
+      expect((client as any).baseUrl).toBe('https://bff.cow.fi')
+    })
+
+    it('should use barn base URL when env is staging', () => {
+      const client = new CoWBFFClient('staging')
+      expect((client as any).baseUrl).toBe('https://bff.barn.cow.fi')
+    })
+
+    it('should default to prod when no env provided', () => {
+      const client = new CoWBFFClient()
+      expect((client as any).baseUrl).toBe('https://bff.cow.fi')
+    })
+  })
+
+  describe('getSlippageTolerance', () => {
+    const sellToken = '0x6b175474e89094c44da98b954eedeac495271d0f'
+    const buyToken = '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
+    const chainId = 1
+
+    it('should return slippage tolerance on successful API response', async () => {
+      const client = new CoWBFFClient('prod')
+      const mockResponse = { slippageBps: 150 }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+
+      const result = await client.getSlippageTolerance({ sellToken, buyToken, chainId })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://bff.cow.fi/${chainId}/markets/${sellToken}-${buyToken}/slippageTolerance`,
+        {
+          method: 'GET',
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          signal: expect.any(AbortSignal),
+        }
+      )
+      expect(result).toEqual({ slippageBps: 150 })
+    })
+
+    it('should use staging URL when env is staging', async () => {
+      const client = new CoWBFFClient('staging')
+      const mockResponse = { slippageBps: 200 }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+
+      await client.getSlippageTolerance({ sellToken, buyToken, chainId })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://bff.barn.cow.fi/${chainId}/markets/${sellToken}-${buyToken}/slippageTolerance`,
+        expect.any(Object)
+      )
+    })
+
+    it('should return null on HTTP error response', async () => {
+      const client = new CoWBFFClient()
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+
+      const result = await client.getSlippageTolerance({ sellToken, buyToken, chainId })
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null on invalid response structure', async () => {
+      const client = new CoWBFFClient()
+      const mockResponse = { invalidField: 'value' }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+
+      const result = await client.getSlippageTolerance({ sellToken, buyToken, chainId })
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null when slippageBps is not a number', async () => {
+      const client = new CoWBFFClient()
+      const mockResponse = { slippageBps: 'invalid' }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+
+      const result = await client.getSlippageTolerance({ sellToken, buyToken, chainId })
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null on network error', async () => {
+      const client = new CoWBFFClient()
+      mockFetch.mockRejectedValue(new Error('Network error'))
+
+      const result = await client.getSlippageTolerance({ sellToken, buyToken, chainId })
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null when response is null', async () => {
+      const client = new CoWBFFClient()
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(null),
+      })
+
+      const result = await client.getSlippageTolerance({ sellToken, buyToken, chainId })
+
+      expect(result).toBeNull()
+    })
+
+    it('should construct correct URL for different chain IDs', async () => {
+      const client = new CoWBFFClient()
+      const mockResponse = { slippageBps: 100 }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+
+      await client.getSlippageTolerance({ sellToken, buyToken, chainId: 137 })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://bff.cow.fi/137/markets/${sellToken}-${buyToken}/slippageTolerance`,
+        expect.any(Object)
+      )
+    })
+
+    it('should apply timeout to fetch request', async () => {
+      const client = new CoWBFFClient()
+
+      // Mock fetch to simulate timeout by throwing AbortError
+      mockFetch.mockRejectedValue(new Error('The operation was aborted'))
+
+      const customTimeoutMs = 100
+      const result = await client.getSlippageTolerance({
+        sellToken,
+        buyToken,
+        chainId,
+        timeoutMs: customTimeoutMs,
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('should use default timeout of 2000ms when not specified', async () => {
+      const client = new CoWBFFClient()
+      const mockResponse = { slippageBps: 150 }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+
+      await client.getSlippageTolerance({ sellToken, buyToken, chainId })
+
+      // Verify the call was made with signal (indicates timeout setup)
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        })
+      )
+    })
+
+    it('should use custom timeout when specified', async () => {
+      const client = new CoWBFFClient()
+      const mockResponse = { slippageBps: 150 }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+
+      await client.getSlippageTolerance({
+        sellToken,
+        buyToken,
+        chainId,
+        timeoutMs: 5000,
+      })
+
+      // Verify the call was made with signal (indicates timeout setup)
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        })
+      )
+    })
+  })
+})

--- a/packages/trading/src/cowBffClient.ts
+++ b/packages/trading/src/cowBffClient.ts
@@ -1,0 +1,78 @@
+import { log } from '@cowprotocol/sdk-common'
+import { SupportedChainId, CowEnv } from '@cowprotocol/sdk-config'
+import { BFF_ENDPOINTS } from './consts'
+
+const DEFAULT_TIMEOUT = 2000 // 2 sec
+
+export interface SlippageToleranceResponse {
+  slippageBps: number
+}
+
+export interface SlippageToleranceRequest {
+  chainId: SupportedChainId
+  sellToken: string
+  buyToken: string
+  timeoutMs?: number
+}
+
+export class CoWBFFClient {
+  private readonly baseUrl: string
+
+  constructor(env: CowEnv = 'prod') {
+    this.baseUrl = BFF_ENDPOINTS[env]
+  }
+
+  /**
+   * Fetches slippage tolerance from the API for a given token pair
+   * @param sellToken - Address of the token to sell (e.g., '0x6b175474e89094c44da98b954eedeac495271d0f')
+   * @param buyToken - Address of the token to buy (e.g., '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599')
+   * @param chainId - Chain ID for the API request
+   * @param timeoutMs - Request timeout in milliseconds (default: 2000ms)
+   * @returns Promise<SlippageToleranceResponse | null> - Returns null if API call fails
+   */
+  async getSlippageTolerance({
+    sellToken,
+    buyToken,
+    chainId,
+    timeoutMs = DEFAULT_TIMEOUT,
+  }: SlippageToleranceRequest): Promise<SlippageToleranceResponse | null> {
+    try {
+      const url = `${this.baseUrl}/${chainId}/markets/${sellToken}-${buyToken}/slippageTolerance`
+
+      log(`Fetching slippage tolerance from API: ${url} (timeout: ${timeoutMs}ms)`)
+
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        signal: controller.signal,
+      })
+
+      clearTimeout(timeoutId)
+
+      if (!response.ok) {
+        log(`Slippage tolerance API error: ${response.status} ${response.statusText}`)
+        return null
+      }
+
+      const data = await response.json()
+
+      // Validate response structure
+      if (typeof data !== 'object' || data === null || typeof data.slippageBps !== 'number') {
+        log('Invalid slippage tolerance API response structure')
+        return null
+      }
+
+      log(`Retrieved slippage tolerance from API: ${data.slippageBps} BPS`)
+      return { slippageBps: data.slippageBps }
+    } catch (error) {
+      log(`Failed to fetch slippage tolerance from API: ${error instanceof Error ? error.message : 'Unknown error'}`)
+      return null
+    }
+  }
+}

--- a/packages/trading/src/getQuote.test.ts
+++ b/packages/trading/src/getQuote.test.ts
@@ -57,6 +57,7 @@ const defaultOrderParams: SwapParameters = {
 }
 
 const getQuoteMock = jest.fn()
+
 const orderBookApiMock = {
   getQuote: getQuoteMock,
 } as unknown as OrderBookApi

--- a/packages/trading/src/getQuote.ts
+++ b/packages/trading/src/getQuote.ts
@@ -23,7 +23,7 @@ import {
 import { buildAppData } from './appDataUtils'
 import { getOrderToSign } from './getOrderToSign'
 import { getOrderTypedData } from './getOrderTypedData'
-import { suggestSlippageBps } from './suggestSlippageBps'
+import { suggestSlippageBpsWithApi } from './suggestSlippageBpsWithApi'
 import { getPartnerFeeBps } from './utils/getPartnerFeeBps'
 import { adjustEthFlowOrderParams, getIsEthFlowOrder, swapParamsToLimitOrderParams } from './utils/misc'
 import { getDefaultSlippageBps } from './utils/slippage'
@@ -125,12 +125,13 @@ export async function getQuoteRaw(
   const quote = await orderBookApi.getQuote(quoteRequest)
 
   // Get the suggested slippage based on the quote
-  const suggestedSlippageBps = suggestSlippageBps({
+  const suggestedSlippageBps = await suggestSlippageBpsWithApi({
     isEthFlow,
     quote,
     tradeParameters,
     trader,
     advancedSettings,
+    bffEnv: env,
   })
 
   const commonResult = {

--- a/packages/trading/src/getQuote.ts
+++ b/packages/trading/src/getQuote.ts
@@ -23,10 +23,11 @@ import {
 import { buildAppData } from './appDataUtils'
 import { getOrderToSign } from './getOrderToSign'
 import { getOrderTypedData } from './getOrderTypedData'
-import { suggestSlippageBpsWithApi } from './suggestSlippageBpsWithApi'
+import { SuggestSlippageBpsWithApi, suggestSlippageBpsWithApi } from './suggestSlippageBpsWithApi'
 import { getPartnerFeeBps } from './utils/getPartnerFeeBps'
 import { adjustEthFlowOrderParams, getIsEthFlowOrder, swapParamsToLimitOrderParams } from './utils/misc'
 import { getDefaultSlippageBps } from './utils/slippage'
+import { suggestSlippageBps } from './suggestSlippageBps'
 
 // ETH-FLOW orders require different quote params
 // check the isEthFlow flag and set in quote req obj
@@ -124,15 +125,20 @@ export async function getQuoteRaw(
 
   const quote = await orderBookApi.getQuote(quoteRequest)
 
-  // Get the suggested slippage based on the quote
-  const suggestedSlippageBps = await suggestSlippageBpsWithApi({
+  const suggestSlippageParams: SuggestSlippageBpsWithApi = {
     isEthFlow,
     quote,
     tradeParameters,
     trader,
     advancedSettings,
     bffEnv: env,
-  })
+  }
+
+  // Get the suggested slippage based on the quote
+  const suggestedSlippageBps =
+    quoteRequest.priceQuality === PriceQuality.FAST
+      ? suggestSlippageBps(suggestSlippageParams)
+      : await suggestSlippageBpsWithApi(suggestSlippageParams)
 
   const commonResult = {
     isEthFlow,

--- a/packages/trading/src/suggestSlippageBpsWithApi.test.ts
+++ b/packages/trading/src/suggestSlippageBpsWithApi.test.ts
@@ -1,0 +1,224 @@
+import { suggestSlippageBpsWithApi } from './suggestSlippageBpsWithApi'
+import { suggestSlippageBps } from './suggestSlippageBps'
+import { CoWBFFClient } from './cowBffClient'
+import { SupportedChainId } from '@cowprotocol/sdk-config'
+import { OrderKind, OrderQuoteResponse } from '@cowprotocol/sdk-order-book'
+
+// Mock the dependencies
+jest.mock('./suggestSlippageBps')
+jest.mock('./cowBffClient')
+
+const mockSuggestSlippageBps = suggestSlippageBps as jest.MockedFunction<typeof suggestSlippageBps>
+const MockCoWBFFClient = CoWBFFClient as jest.MockedClass<typeof CoWBFFClient>
+
+const mockQuote: OrderQuoteResponse = {
+  quote: {
+    sellToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    buyToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+    receiver: '0x123',
+    sellAmount: '1000000000000000000',
+    buyAmount: '100000000',
+    validTo: 1234567890,
+    appData: '{}',
+    appDataHash: '0x123',
+    feeAmount: '1000000000000000',
+    kind: 'sell',
+    partiallyFillable: false,
+    sellTokenBalance: 'erc20',
+    buyTokenBalance: 'erc20',
+    signingScheme: 'eip712',
+  },
+  from: '0x123',
+  expiration: '2024-01-01T00:00:00Z',
+  id: 1,
+  verified: true,
+} as OrderQuoteResponse
+
+const baseParams = {
+  quote: mockQuote,
+  tradeParameters: {
+    sellToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    buyToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+    sellTokenDecimals: 18,
+    buyTokenDecimals: 8,
+    kind: OrderKind.SELL,
+    amount: '1000000000000000000',
+  },
+  trader: {
+    chainId: SupportedChainId.MAINNET,
+    appCode: '0x007',
+    account: '0x123' as const,
+  },
+  isEthFlow: false,
+}
+
+describe('suggestSlippageBpsWithApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSuggestSlippageBps.mockReturnValue(100) // Default fallback value
+  })
+
+  it('should use API slippage when API call succeeds', async () => {
+    const mockApiClient = {
+      getSlippageTolerance: jest.fn().mockResolvedValue({ slippageBps: 250 }),
+    }
+    MockCoWBFFClient.mockImplementation(() => mockApiClient as any)
+
+    const result = await suggestSlippageBpsWithApi(baseParams)
+
+    expect(MockCoWBFFClient).toHaveBeenCalledWith('prod')
+    expect(mockApiClient.getSlippageTolerance).toHaveBeenCalledWith({
+      sellToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      buyToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+      chainId: SupportedChainId.MAINNET,
+      timeoutMs: 2000,
+    })
+    expect(result).toBe(250)
+    expect(mockSuggestSlippageBps).not.toHaveBeenCalled()
+  })
+
+  it('should use staging environment when provided', async () => {
+    const mockApiClient = {
+      getSlippageTolerance: jest.fn().mockResolvedValue({ slippageBps: 200 }),
+    }
+    MockCoWBFFClient.mockImplementation(() => mockApiClient as any)
+
+    const paramsWithStagingEnv = {
+      ...baseParams,
+      bffEnv: 'staging' as const,
+    }
+
+    const result = await suggestSlippageBpsWithApi(paramsWithStagingEnv)
+
+    expect(MockCoWBFFClient).toHaveBeenCalledWith('staging')
+    expect(result).toBe(200)
+  })
+
+  it('should fallback to calculation when API returns null', async () => {
+    const mockApiClient = {
+      getSlippageTolerance: jest.fn().mockResolvedValue(null),
+    }
+    MockCoWBFFClient.mockImplementation(() => mockApiClient as any)
+
+    const result = await suggestSlippageBpsWithApi(baseParams)
+
+    expect(mockSuggestSlippageBps).toHaveBeenCalledWith(baseParams)
+    expect(result).toBe(100)
+  })
+
+  it('should fallback to calculation when API throws error', async () => {
+    const mockApiClient = {
+      getSlippageTolerance: jest.fn().mockRejectedValue(new Error('API error')),
+    }
+    MockCoWBFFClient.mockImplementation(() => mockApiClient as any)
+
+    const result = await suggestSlippageBpsWithApi(baseParams)
+
+    expect(mockSuggestSlippageBps).toHaveBeenCalledWith(baseParams)
+    expect(result).toBe(100)
+  })
+
+  it('should fallback when API slippage is too low (below minimum)', async () => {
+    const mockApiClient = {
+      getSlippageTolerance: jest.fn().mockResolvedValue({ slippageBps: 10 }), // Below default minimum of 50
+    }
+    MockCoWBFFClient.mockImplementation(() => mockApiClient as any)
+
+    const result = await suggestSlippageBpsWithApi(baseParams)
+
+    expect(mockSuggestSlippageBps).toHaveBeenCalledWith(baseParams)
+    expect(result).toBe(100)
+  })
+
+  it('should fallback when API slippage is too high (above maximum)', async () => {
+    const mockApiClient = {
+      getSlippageTolerance: jest.fn().mockResolvedValue({ slippageBps: 15000 }), // Above max of 10000
+    }
+    MockCoWBFFClient.mockImplementation(() => mockApiClient as any)
+
+    const result = await suggestSlippageBpsWithApi(baseParams)
+
+    expect(mockSuggestSlippageBps).toHaveBeenCalledWith(baseParams)
+    expect(result).toBe(100)
+  })
+
+  it('should handle EthFlow orders correctly', async () => {
+    const mockApiClient = {
+      getSlippageTolerance: jest.fn().mockResolvedValue({ slippageBps: 300 }),
+    }
+    MockCoWBFFClient.mockImplementation(() => mockApiClient as any)
+
+    const ethFlowParams = {
+      ...baseParams,
+      isEthFlow: true,
+    }
+
+    const result = await suggestSlippageBpsWithApi(ethFlowParams)
+
+    expect(result).toBe(300)
+    expect(mockApiClient.getSlippageTolerance).toHaveBeenCalledWith({
+      sellToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      buyToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+      chainId: SupportedChainId.MAINNET,
+      timeoutMs: 2000,
+    })
+  })
+
+  it('should validate API response has correct structure', async () => {
+    const mockApiClient = {
+      getSlippageTolerance: jest.fn().mockResolvedValue({ slippageBps: 'invalid' }), // Invalid type
+    }
+    MockCoWBFFClient.mockImplementation(() => mockApiClient as any)
+
+    const result = await suggestSlippageBpsWithApi(baseParams)
+
+    expect(mockSuggestSlippageBps).toHaveBeenCalledWith(baseParams)
+    expect(result).toBe(100)
+  })
+
+  it('should handle different chain IDs correctly', async () => {
+    const mockApiClient = {
+      getSlippageTolerance: jest.fn().mockResolvedValue({ slippageBps: 180 }),
+    }
+    MockCoWBFFClient.mockImplementation(() => mockApiClient as any)
+
+    const gnosisParams = {
+      ...baseParams,
+      trader: {
+        ...baseParams.trader,
+        chainId: SupportedChainId.GNOSIS_CHAIN,
+      },
+    }
+
+    const result = await suggestSlippageBpsWithApi(gnosisParams)
+
+    expect(mockApiClient.getSlippageTolerance).toHaveBeenCalledWith({
+      sellToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      buyToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+      chainId: SupportedChainId.GNOSIS_CHAIN,
+      timeoutMs: 2000,
+    })
+    expect(result).toBe(180)
+  })
+
+  it('should pass custom timeout to API client', async () => {
+    const mockApiClient = {
+      getSlippageTolerance: jest.fn().mockResolvedValue({ slippageBps: 200 }),
+    }
+    MockCoWBFFClient.mockImplementation(() => mockApiClient as any)
+
+    const customTimeoutParams = {
+      ...baseParams,
+      slippageApiTimeoutMs: 5000,
+    }
+
+    await suggestSlippageBpsWithApi(customTimeoutParams)
+
+    expect(mockApiClient.getSlippageTolerance).toHaveBeenCalledWith({
+      sellToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      buyToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+      chainId: SupportedChainId.MAINNET,
+      timeoutMs: 5000,
+    })
+  })
+})

--- a/packages/trading/src/suggestSlippageBpsWithApi.test.ts
+++ b/packages/trading/src/suggestSlippageBpsWithApi.test.ts
@@ -71,7 +71,6 @@ describe('suggestSlippageBpsWithApi', () => {
       sellToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
       buyToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
       chainId: SupportedChainId.MAINNET,
-      timeoutMs: 2000,
     })
     expect(result).toBe(250)
     expect(mockSuggestSlippageBps).not.toHaveBeenCalled()
@@ -160,7 +159,6 @@ describe('suggestSlippageBpsWithApi', () => {
       sellToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
       buyToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
       chainId: SupportedChainId.MAINNET,
-      timeoutMs: 2000,
     })
   })
 
@@ -196,7 +194,6 @@ describe('suggestSlippageBpsWithApi', () => {
       sellToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
       buyToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
       chainId: SupportedChainId.GNOSIS_CHAIN,
-      timeoutMs: 2000,
     })
     expect(result).toBe(180)
   })

--- a/packages/trading/src/suggestSlippageBpsWithApi.ts
+++ b/packages/trading/src/suggestSlippageBpsWithApi.ts
@@ -1,0 +1,63 @@
+import { log } from '@cowprotocol/sdk-common'
+import { SuggestSlippageBps, suggestSlippageBps } from './suggestSlippageBps'
+import { CoWBFFClient } from './cowBffClient'
+import { getDefaultSlippageBps } from './utils/slippage'
+import { CowEnv } from '@cowprotocol/sdk-config'
+
+const MAX_SLIPPAGE_BPS = 10_000 // 100% in BPS (max slippage)
+
+export interface SuggestSlippageBpsWithApi extends SuggestSlippageBps {
+  bffEnv?: CowEnv
+  slippageApiTimeoutMs?: number
+}
+
+/**
+ * Enhanced slippage suggestion that uses API slippage tolerance with fallback to existing logic
+ *
+ * This function:
+ * 1. Attempts to get slippage tolerance from the API using the sellToken/buyToken pair
+ * 2. Falls back to the existing suggestSlippageBps calculation if API fails
+ * 3. Clamps the result between minimum (default) and maximum (100%) slippage
+ *
+ * @param params - Parameters including tokens, quote, optional BFF environment, and API timeout
+ * @returns Suggested slippage in basis points
+ */
+export async function suggestSlippageBpsWithApi(params: SuggestSlippageBpsWithApi): Promise<number> {
+  const { trader, isEthFlow, bffEnv = 'prod', slippageApiTimeoutMs } = params
+  const { sellToken, buyToken } = params.quote.quote
+
+  // Try to get slippage from API first
+  try {
+    const apiClient = new CoWBFFClient(bffEnv)
+    const apiResponse = await apiClient.getSlippageTolerance({
+      sellToken,
+      buyToken,
+      chainId: trader.chainId,
+      timeoutMs: slippageApiTimeoutMs,
+    })
+
+    if (apiResponse && typeof apiResponse.slippageBps === 'number') {
+      const apiSlippageBps = apiResponse.slippageBps
+
+      // Validate API response is reasonable (between min and max)
+      const minSlippageBps = getDefaultSlippageBps(trader.chainId, isEthFlow)
+
+      if (apiSlippageBps >= minSlippageBps && apiSlippageBps <= MAX_SLIPPAGE_BPS) {
+        log(`Using API slippage tolerance: ${apiSlippageBps} BPS`)
+        return apiSlippageBps
+      } else {
+        log(
+          `API slippage tolerance ${apiSlippageBps} BPS is outside valid range [${minSlippageBps}, ${MAX_SLIPPAGE_BPS}], falling back to calculation`,
+        )
+      }
+    }
+  } catch (error) {
+    log(
+      `Failed to get slippage from API, falling back to calculation: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    )
+  }
+
+  // Fallback to existing calculation
+  log('Falling back to existing slippage calculation')
+  return suggestSlippageBps(params)
+}


### PR DESCRIPTION
Uses API from: https://github.com/cowprotocol/bff/pull/97

API example: https://bff.barn.cow.fi/1/markets/0x6b175474e89094c44da98b954eedeac495271d0f-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/slippageTolerance

Before this PR, we were using simplified, hardcoded function to suggest slippage:
https://github.com/cowprotocol/cow-sdk/blob/main/packages/trading/src/suggestSlippageBps.ts

In this PR I added `/slippageTolerance` API into `Trading SDK`.
The API specification: https://www.notion.so/cownation/Speed-Finish-slippage-based-on-market-volatility-2168da5f04ca80e3987bf42b9d6c8a22?source=copy_link
The API is enabled by default and will be used as slippage value when `slippageBps` is not specified in parameters (same logic as before).

The `/slippageTolerance` call has 2 sec timeout and will fallback to existing `suggestSlippageBps.ts` logic if any network or other errors.