### PR TITLE
fix(slippage): use volatility slippage to calculate volume slippage

### DIFF
--- a/packages/common/src/utils/math.ts
+++ b/packages/common/src/utils/math.ts
@@ -15,6 +15,10 @@ export function percentageToBps(percentage: number | bigint): number {
   return Math.round(bps)
 }
 
+export function bpsToPercentage(bps: number): number {
+  return bps / 100
+}
+
 /**
  * Apply a percentage to a bigint value
  *

--- a/packages/trading/src/suggestSlippageBps.ts
+++ b/packages/trading/src/suggestSlippageBps.ts
@@ -1,5 +1,6 @@
 import { percentageToBps } from '@cowprotocol/sdk-common'
 import { getQuoteAmountsWithCosts, OrderQuoteResponse } from '@cowprotocol/sdk-order-book'
+
 import { getSlippagePercent } from './utils/slippage'
 import { suggestSlippageFromFee } from './suggestSlippageFromFee'
 import { suggestSlippageFromVolume } from './suggestSlippageFromVolume'
@@ -17,13 +18,20 @@ export interface SuggestSlippageBps {
   quote: OrderQuoteResponse
   trader: QuoterParameters
   advancedSettings?: SwapAdvancedSettings
+  volumeMultiplierPercent?: number
 }
 
 /**
  * Return the slippage in BPS that would allow the fee to increase by the multiplying factor percent.
  */
 export function suggestSlippageBps(params: SuggestSlippageBps): number {
-  const { quote, tradeParameters, trader, isEthFlow } = params
+  const {
+    quote,
+    tradeParameters,
+    trader,
+    isEthFlow,
+    volumeMultiplierPercent = SLIPPAGE_VOLUME_MULTIPLIER_PERCENT,
+  } = params
   const { sellTokenDecimals, buyTokenDecimals } = tradeParameters
 
   // Calculate the amount of the sell token before and after network costs
@@ -46,7 +54,7 @@ export function suggestSlippageBps(params: SuggestSlippageBps): number {
     isSell,
     sellAmountBeforeNetworkCosts,
     sellAmountAfterNetworkCosts,
-    slippagePercent: SLIPPAGE_VOLUME_MULTIPLIER_PERCENT,
+    slippagePercent: volumeMultiplierPercent,
   })
 
   // Aggregate all slippages


### PR DESCRIPTION
There was hardcoded `SLIPPAGE_VOLUME_MULTIPLIER_PERCENT` which is 0.5% in volume based slippage formula.
Since we have volatility based slippage, we should use it instead of the hardcoded value.

Tested in corelated tokens and it works well.

<img width="960" height="834" alt="image" src="https://github.com/user-attachments/assets/c5705dfe-f551-41fd-8623-72c5a85c8422" />

<img width="1024" height="876" alt="image" src="https://github.com/user-attachments/assets/99ebfda2-043e-43fb-8450-0fa681ef8ec5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a utility to convert basis points to percentages for easier display and calculations.

* Improvements
  * Slippage suggestions now adapt to suggested values using a volume-based multiplier for more consistent quotes.
  * The volume multiplier can be overridden via configuration for finer control.
  * More robust handling when no slippage suggestion is available, falling back to sensible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->