### PR TITLE
feat(chain-info): add isUnderDevelopment flag to chain info

### DIFF
--- a/packages/config/src/chains/types.ts
+++ b/packages/config/src/chains/types.ts
@@ -154,4 +154,11 @@ export interface ChainInfo {
    * Whether the chain is zkSync based.
    */
   readonly isZkSync?: boolean
+
+  /**
+   * Whether the chain is under development.
+   * A chain might show up already as a supported chain, but still be under development (not all features are ready,
+   * related services running, contracts deployed, etc).
+   */
+  readonly isUnderDevelopment?: boolean
 }

--- a/packages/config/src/chains/utils.ts
+++ b/packages/config/src/chains/utils.ts
@@ -42,3 +42,11 @@ export function isTargetChainId(chainId: ChainId): chainId is TargetChainId {
 export function isZkSyncChain(chainId: ChainId): boolean {
   return Boolean(getChainInfo(chainId)?.isZkSync)
 }
+
+/**
+ * Check if the chain is under development.
+ * @param chainId
+ */
+export function isChainUnderDevelopment(chainId: ChainId): boolean {
+  return Boolean(getChainInfo(chainId)?.isUnderDevelopment)
+}


### PR DESCRIPTION
# Summary

Add `isUnderDevelopment` flag to chain info, so we can clearly indicate chains that are/will be supported by the protocol, but are not yet ready.

Will add chains that use this feature next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying blockchain chains in development status. The system can now mark and check which chains are under active development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->