### PR TITLE
 add opt-out flag for quote adjustments in getOrderToSign

### DIFF
--- a/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
+++ b/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
@@ -250,7 +250,7 @@ export class AaveCollateralSwapSdk {
         customEIP1271Signature: (orderToSign: UnsignedOrder, signer: AbstractSigner<Provider>) => {
           return this.adapterEIP1271Signature(chainId, instanceAddress, orderToSign, signer)
         },
-        applyQuoteAdjustments: false,
+        applyCostsSlippageAndFees: false,
       },
       appData: {
         metadata: {

--- a/packages/trading/src/getOrderToSign.test.ts
+++ b/packages/trading/src/getOrderToSign.test.ts
@@ -47,11 +47,7 @@ describe('getOrderToSign', () => {
 
   it('When validTo is set, then should use exact validTo value', () => {
     const exactValidTo = 2524608000 // January 1, 2050 00:00:00 UTC
-    const result = getOrderToSign(
-      params,
-      { ...defaultOrderParams, validTo: exactValidTo },
-      appDataKeccak256,
-    )
+    const result = getOrderToSign(params, { ...defaultOrderParams, validTo: exactValidTo }, appDataKeccak256)
 
     expect(result.validTo).toBe(exactValidTo)
   })
@@ -72,9 +68,9 @@ describe('getOrderToSign', () => {
     expect(result.buyAmount).toBe('1990000000000000000')
   })
 
-  it('When sell order and quote adjustments disabled, then buy amount should remain unchanged', () => {
+  it('When sell order and cost/slippage adjustments disabled, then buy amount should remain unchanged', () => {
     const result = getOrderToSign(
-      { ...params, applyQuoteAdjustments: false },
+      { ...params, applyCostsSlippageAndFees: false },
       { ...defaultOrderParams, kind: OrderKind.SELL },
       appDataKeccak256,
     )
@@ -88,9 +84,9 @@ describe('getOrderToSign', () => {
     expect(result.sellAmount).toBe('1005000000000000000')
   })
 
-  it('When buy order and quote adjustments disabled, then sell amount should remain unchanged', () => {
+  it('When buy order and cost/slippage adjustments disabled, then sell amount should remain unchanged', () => {
     const result = getOrderToSign(
-      { ...params, applyQuoteAdjustments: false },
+      { ...params, applyCostsSlippageAndFees: false },
       { ...defaultOrderParams, kind: OrderKind.BUY },
       appDataKeccak256,
     )

--- a/packages/trading/src/getOrderToSign.ts
+++ b/packages/trading/src/getOrderToSign.ts
@@ -17,11 +17,11 @@ interface OrderToSignParams {
   isEthFlow: boolean
   from: string
   networkCostsAmount?: string
-  applyQuoteAdjustments?: boolean
+  applyCostsSlippageAndFees?: boolean
 }
 
 export function getOrderToSign(
-  { chainId, from, networkCostsAmount = '0', isEthFlow, applyQuoteAdjustments = true }: OrderToSignParams,
+  { chainId, from, networkCostsAmount = '0', isEthFlow, applyCostsSlippageAndFees = true }: OrderToSignParams,
   limitOrderParams: LimitTradeParameters,
   appDataKeccak256: string,
 ): UnsignedOrder {
@@ -58,7 +58,7 @@ export function getOrderToSign(
   let sellAmountToUse = sellAmount
   let buyAmountToUse = buyAmount
 
-  if (applyQuoteAdjustments) {
+  if (applyCostsSlippageAndFees) {
     const { afterSlippage } = getQuoteAmountsAndCosts({
       orderParams,
       slippagePercentBps: slippageBps,

--- a/packages/trading/src/getQuote.test.ts
+++ b/packages/trading/src/getQuote.test.ts
@@ -279,7 +279,11 @@ describe('getQuote', () => {
 
       for (const adapterName of adapterNames) {
         setGlobalAdapter(adapters[adapterName])
-        await getQuoteWithSigner({ ...defaultOrderParams, signer: adapters[adapterName].signer, validTo: exactValidTo }, {}, orderBookApiMock)
+        await getQuoteWithSigner(
+          { ...defaultOrderParams, signer: adapters[adapterName].signer, validTo: exactValidTo },
+          {},
+          orderBookApiMock,
+        )
 
         const call = getQuoteMock.mock.calls[0][0]
         expect(call.validTo).toBe(exactValidTo)
@@ -294,8 +298,14 @@ describe('getQuote', () => {
       for (const adapterName of adapterNames) {
         setGlobalAdapter(adapters[adapterName])
         await expect(
-          getQuoteWithSigner({ ...defaultOrderParams, signer: adapters[adapterName].signer, validTo: exactValidTo, validFor: 600 }, {}, orderBookApiMock)
-        ).rejects.toThrow('Cannot specify both validFor and validTo. Use validFor for relative time or validTo for absolute time.')
+          getQuoteWithSigner(
+            { ...defaultOrderParams, signer: adapters[adapterName].signer, validTo: exactValidTo, validFor: 600 },
+            {},
+            orderBookApiMock,
+          ),
+        ).rejects.toThrow(
+          'Cannot specify both validFor and validTo. Use validFor for relative time or validTo for absolute time.',
+        )
       }
     })
   })

--- a/packages/trading/src/getQuote.ts
+++ b/packages/trading/src/getQuote.ts
@@ -79,7 +79,9 @@ export async function getQuoteRaw(
 
   // Validate that both validFor and validTo are not provided at the same time
   if (validTo !== undefined && validFor !== undefined) {
-    throw new Error('Cannot specify both validFor and validTo. Use validFor for relative time or validTo for absolute time.')
+    throw new Error(
+      'Cannot specify both validFor and validTo. Use validFor for relative time or validTo for absolute time.',
+    )
   }
 
   // Apply default value for validFor after validation

--- a/packages/trading/src/postCoWProtocolTrade.ts
+++ b/packages/trading/src/postCoWProtocolTrade.ts
@@ -20,7 +20,7 @@ export async function postCoWProtocolTrade(
     networkCostsAmount = '0',
     signingScheme: _signingScheme = SigningScheme.EIP712,
     customEIP1271Signature,
-    applyQuoteAdjustments,
+    applyCostsSlippageAndFees,
   } = additionalParams
 
   const isEthFlow = getIsEthFlowOrder(params)
@@ -42,7 +42,7 @@ export async function postCoWProtocolTrade(
   const from = owner || (await signer.getAddress())
 
   const orderToSign = getOrderToSign(
-    { chainId, from, networkCostsAmount, isEthFlow, applyQuoteAdjustments },
+    { chainId, from, networkCostsAmount, isEthFlow, applyCostsSlippageAndFees },
     params,
     appData.appDataKeccak256,
   )

--- a/packages/trading/src/types.ts
+++ b/packages/trading/src/types.ts
@@ -284,8 +284,9 @@ export interface PostTradeAdditionalParams {
   customEIP1271Signature?: (orderToSign: UnsignedOrder, signer: AbstractSigner<Provider>) => Promise<string>
 
   /**
-   * By default, the quote adjustments are applied to the order.
-   * You might want to disable this to send limit orders forcing amounts without costs included.
+   * By default, we adjust the quoted sell/buy amounts to include network gas costs, slippage buffer,
+   * partner fees, and similar extras. Disable this when you prefer to post the raw amounts provided
+   * by the caller (for example, for limit orders that should not include these costs).
    */
-  applyQuoteAdjustments?: boolean
+  applyCostsSlippageAndFees?: boolean
 }


### PR DESCRIPTION
## Description

  Adds an `applyQuoteAdjustments` flag to `getOrderToSign` so callers can opt out of slippage/partner-fee amount adjustments when reusing raw quote values. Includes unit tests that cover both SELL and BUY flows with
  the flag disabled.

## Context

  Some downstream consumers need to preserve the original quote amounts (e.g., when custom adjustments are applied elsewhere). Without a way to bypass the internal `getQuoteAmountsAndCosts` call, they must duplicate logic or patch results manually. This flag keeps the existing default behavior while enabling those advanced use cases.

## Out of Scope
N/A

## Testing Instructions

```bash
pnpm --filter @cowprotocol/sdk-trading test -- --runTestsByPath src/getOrderToSign.test.ts
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to disable quote adjustments when preparing orders for signing.

* **Updates**
  * Flash loan fee input now uses basis-points and applies Aave-style rounding (ceil on remainder), yielding more accurate fee and signed amounts.
  * Signing payload now includes the order-to-sign flag to opt out of quote adjustments.

* **Tests**
  * Expanded tests covering flash loan fee edge cases, rounding behaviors, and quote-adjustment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->