### PR TITLE
feat: add from/to fields for receipt

### DIFF
--- a/packages/common/src/adapters/types/index.ts
+++ b/packages/common/src/adapters/types/index.ts
@@ -73,7 +73,7 @@ export interface Log {
  */
 export interface TransactionReceipt {
   from: string
-  to: string
+  to: string | null
   transactionHash: string
   blockNumber: bigint
   blockHash: string

--- a/packages/providers/ethers-v5-adapter/src/EthersV5SignerAdapter.ts
+++ b/packages/providers/ethers-v5-adapter/src/EthersV5SignerAdapter.ts
@@ -54,6 +54,8 @@ export class EthersV5SignerAdapter extends AbstractSigner<RpcProvider> {
       wait: async (confirmations?: number) => {
         const receipt = await tx.wait(confirmations)
         return {
+          from: receipt.from,
+          to: receipt.to,
           transactionHash: receipt.transactionHash,
           blockNumber: BigInt(receipt.blockNumber),
           blockHash: receipt.blockHash,

--- a/packages/providers/ethers-v6-adapter/src/EthersV6SignerAdapter.ts
+++ b/packages/providers/ethers-v6-adapter/src/EthersV6SignerAdapter.ts
@@ -48,6 +48,8 @@ export class EthersV6SignerAdapter extends AbstractSigner<Provider> {
           throw new Error('Transaction failed')
         }
         return {
+          from: receipt.from,
+          to: receipt.to,
           transactionHash: receipt.hash,
           blockNumber: BigInt(receipt.blockNumber),
           blockHash: receipt.blockHash || '',

--- a/packages/providers/viem-adapter/src/ViemSignerAdapter.ts
+++ b/packages/providers/viem-adapter/src/ViemSignerAdapter.ts
@@ -96,6 +96,8 @@ export class ViemSignerAdapter extends AbstractSigner<PublicClient> {
         })
 
         return {
+          from: receipt.from,
+          to: receipt.to,
           transactionHash: receipt.transactionHash,
           blockNumber: BigInt(receipt.blockNumber),
           blockHash: receipt.blockHash,


### PR DESCRIPTION
Add missing `from` and `to` field to the `TransactionReceipt`.

## Context
The `TransactionReceipt` models a Etherem tx receipt. These 2 fields are important part of the receipts (RPC response) and all adapters provide them in their own receipt type.

This is why  this PR was so trivial to do, I just added the fields in the type, and those were automatically copied for `ethers5`, `ethers6` and `viem`.

## Test
Test pass

```
pnpm test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction receipts now include sender ("from") and optional recipient ("to") fields.

* **Updates**
  * Receipt data returned by transaction operations has been expanded across adapters to include the new sender and recipient fields, ensuring these values are available wherever transaction receipts are exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->