### PR TITLE
fix: don't skip for manual triggers

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -27,8 +27,8 @@ jobs:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
 
-    # Security: Only run on internal PRs, main branch pushes, or external PRs with explicit approval
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository || contains(github.event.pull_request.labels.*.name, 'allow-publish')))
+    # Security: Only run on internal PRs, main branch pushes, external PRs with explicit approval, or manual triggers
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository || contains(github.event.pull_request.labels.*.name, 'allow-publish')))
 
     steps:
       - name: Security Check


### PR DESCRIPTION
This PR has a small fix for the GH action of publishing packages to Github. 

The issue is that it skips running the action if we trigger it manually, which is undesired. See https://github.com/cowprotocol/cow-sdk/actions/runs/19024556257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publish workflow to support manual triggering in addition to automatic pipeline triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->