### PR TITLE
feat(flash-loans): add dappId to aave hooks

### DIFF
--- a/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
+++ b/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
@@ -28,6 +28,7 @@ import {
 } from './types'
 import {
   AAVE_ADAPTER_FACTORY,
+  AAVE_DAPP_ID_PER_TYPE,
   AAVE_HOOK_ADAPTER_PER_TYPE,
   AAVE_POOL_ADDRESS,
   AaveFlashLoanType,
@@ -480,6 +481,7 @@ export class AaveCollateralSwapSdk {
       expectedInstanceAddress,
     )
     const postHookCallData = this.getFlashLoanPostHook(flashLoanType, collateralPermit)
+    const dappId = AAVE_DAPP_ID_PER_TYPE[flashLoanType]
 
     return {
       pre: [
@@ -487,6 +489,7 @@ export class AaveCollateralSwapSdk {
           target: AAVE_ADAPTER_FACTORY[chainId],
           callData: preHookCallData,
           gasLimit: DEFAULT_HOOK_GAS_LIMIT.pre.toString(),
+          dappId,
         },
       ],
       post: [
@@ -494,6 +497,7 @@ export class AaveCollateralSwapSdk {
           target: expectedInstanceAddress,
           callData: postHookCallData,
           gasLimit: DEFAULT_HOOK_GAS_LIMIT.post.toString(),
+          dappId,
         },
       ],
     }

--- a/packages/flash-loans/src/aave/const.ts
+++ b/packages/flash-loans/src/aave/const.ts
@@ -62,3 +62,9 @@ export const EMPTY_PERMIT: CollateralPermitData = {
   r: HASH_ZERO,
   s: HASH_ZERO,
 }
+
+export const AAVE_DAPP_ID_PER_TYPE: Record<AaveFlashLoanType, string> = {
+  [AaveFlashLoanType.CollateralSwap]: 'cow-sdk://flashloans/aave/v3/collateral-swap',
+  [AaveFlashLoanType.DebtSwap]: 'cow-sdk://flashloans/aave/v3/debt-swap',
+  [AaveFlashLoanType.RepayCollateral]: 'cow-sdk://flashloans/aave/v3/repay-with-collateral',
+}


### PR DESCRIPTION
Added hook dappIds for AAVE flash-loans.
Actually copied and fixed https://github.com/cowprotocol/cow-sdk/pull/640/files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Improvements**
  * Enhanced dApp identification for AAVE flash loan transactions, enabling better tracking and categorization of CollateralSwap, DebtSwap, and RepayCollateral operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->