### PR TITLE
fix: avoid protocol fee double-count in sell quotes

### DIFF
--- a/packages/order-book/package.json
+++ b/packages/order-book/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/sdk-order-book",
-  "version": "0.3.2",
+  "version": "0.3.1",
   "description": "CowProtocol Order Book package",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cow-sdk",
-  "version": "7.1.5",
+  "version": "7.1.4",
   "license": "(MIT OR Apache-2.0)",
   "description": "CoW Protocol SDK - get quote, configure your order, and trade",
   "main": "./dist/index.js",


### PR DESCRIPTION
# Summary

Fixes a UI-facing math bug: SELL quotes were double-counting protocol fee when computing beforeAllFees.buyAmount, so the “Before costs” tooltip subtracted protocol twice. The bug was in getQuoteAmountsAndCosts: we already reconstruct the pre-fee buy amount via quotePrice, but then added protocol fee again for SELL. 

The fix drops that extra addition, and regression tests now assert SELL and BUY flows only apply protocol fee once. Versions bumped for release (@cowprotocol/sdk-order-book 0.3.2, @cowprotocol/cow-sdk 7.1.5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fee calculation for Sell orders to ensure accurate cost breakdowns.

* **Tests**
  * Added test cases to verify protocol and network fee calculations for both Sell and Buy orders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->