### PR TITLE
feat: add new workflow that uploads the src dir to s3 on release

### DIFF
--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -1,4 +1,5 @@
 name: Deploy to S3
+# Workflow copied from https://github.com/cowprotocol/token-lists/blob/main/.github/workflows/s3Deploy.yml
 
 on:
   release:


### PR DESCRIPTION
# Summary

This change adds a new github workflow, which on each release uploads the src folder to `files.cow.fi/cow-sdk` so that we can use the chain images in `swap.cow.fi` and in the sdk.

## Testing

We after merging we can see if the worflow works successfuly and if we can access https://files.cow.fi/cow-sdk/bridging/providers/across/across-logo.png. There might be some secrets that need to be set up.

## Background

This PR is part of https://linear.app/cowswap/issue/COW-136/token-lists-cdn

Moving away from our reliance on github CDN.
This is no longer viable as Github recently changed their rate limiting policy for non-logged in users.

Related PRs: 
https://github.com/cowprotocol/cowswap/pull/6591
https://github.com/cowprotocol/cow-sdk/pull/724 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated deployment workflow to publish library updates to distribution network upon release creation or manual trigger.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->