### PR TITLE
feat(flash-loans): support flexible gasLimit options

### DIFF
--- a/packages/flash-loans/README.md
+++ b/packages/flash-loans/README.md
@@ -352,6 +352,64 @@ const result = await flashLoanSdk.collateralSwap(
 )
 ```
 
+## Custom Hook Gas Limits
+
+The SDK uses default gas limits for pre and post-execution hooks (300,000 and 600,000 respectively). You can customize these limits per operation if needed.
+
+### Default Gas Limits
+
+- **Pre-hook**: 300,000 gas (deploys adapter and sets up flash loan)
+- **Post-hook**: 600,000 gas (executes swap and repays flash loan)
+
+### Customizing Gas Limits
+
+You can override gas limits in two ways:
+
+#### 1. Per-Operation Override
+
+Pass `hooksGasLimit` in the trade parameters:
+
+```typescript
+const result = await flashLoanSdk.collateralSwap(
+  {
+    chainId: SupportedChainId.GNOSIS_CHAIN,
+    tradeParameters: {
+      sellToken: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
+      sellTokenDecimals: 18,
+      buyToken: '0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0',
+      buyTokenDecimals: 6,
+      amount: '20000000000000000000',
+      kind: OrderKind.SELL,
+      validFor: 600,
+      slippageBps: 50,
+    },
+    settings: {
+      hooksGasLimit: {
+        preHookGasLimit: 500000n,  // Custom pre-hook gas limit
+        postHookGasLimit: 800000n, // Custom post-hook gas limit
+      },
+    },
+    collateralToken: '0xd0Dd6cEF72143E22cCED4867eb0d5F2328715533',
+  },
+  tradingSdk
+)
+```
+
+#### 2. SDK-Wide Default Override
+
+Set custom defaults when initializing the SDK:
+
+```typescript
+const flashLoanSdk = new AaveCollateralSwapSdk({
+  hooksGasLimit: {
+    pre: 500000n,  // Custom default pre-hook gas limit
+    post: 800000n, // Custom default post-hook gas limit
+  },
+})
+
+// All operations will now use these defaults unless overridden per-operation
+```
+
 ## How Hooks Work
 
 The SDK uses CoW Protocol hooks to orchestrate the flash loan:

--- a/packages/flash-loans/src/aave/AaveCollateralSwapSdk.test.ts
+++ b/packages/flash-loans/src/aave/AaveCollateralSwapSdk.test.ts
@@ -355,6 +355,58 @@ adapterNames.forEach((adapterName) => {
           gasLimit: '600000',
         })
       })
+
+      test(`should use custom preHookGasLimit when provided`, async () => {
+        const customPreHookGasLimit = 500000n
+
+        await flashLoanSdk.collateralSwap(
+          {
+            chainId: SupportedChainId.GNOSIS_CHAIN,
+            tradeParameters: {
+              ...mockTradeParameters,
+            },
+            settings: {
+              hooksGasLimit: {
+                preHookGasLimit: customPreHookGasLimit,
+              },
+            },
+            collateralToken,
+          },
+          mockTradingSdk,
+        )
+
+        const callArgs = (mockPostSwapOrderFromQuote as jest.Mock).mock.calls[0][0]
+        const preHooks = callArgs.appData.metadata.hooks.pre
+
+        expect(preHooks).toBeDefined()
+        expect(preHooks[0].gasLimit).toBe(customPreHookGasLimit.toString())
+      })
+
+      test(`should use custom postHookGasLimit when provided`, async () => {
+        const customPostHookGasLimit = 800000n
+
+        await flashLoanSdk.collateralSwap(
+          {
+            chainId: SupportedChainId.GNOSIS_CHAIN,
+            tradeParameters: {
+              ...mockTradeParameters,
+            },
+            collateralToken,
+            settings: {
+              hooksGasLimit: {
+                postHookGasLimit: customPostHookGasLimit,
+              },
+            },
+          },
+          mockTradingSdk,
+        )
+
+        const callArgs = (mockPostSwapOrderFromQuote as jest.Mock).mock.calls[0][0]
+        const postHooks = callArgs.appData.metadata.hooks.post
+
+        expect(postHooks).toBeDefined()
+        expect(postHooks[0].gasLimit).toBe(customPostHookGasLimit.toString())
+      })
     })
 
     describe('getCollateralAllowance', () => {

--- a/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
+++ b/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
@@ -17,6 +17,7 @@ import {
   CollateralOrderData,
   CollateralParameters,
   CollateralPermitData,
+  CollateralSwapHooksGasLimit,
   CollateralSwapOrder,
   CollateralSwapParams,
   CollateralSwapPostParams,
@@ -219,6 +220,7 @@ export class AaveCollateralSwapSdk {
       owner: trader,
       amount: sellAmountToSign.toString(),
       validTo,
+      hooksGasLimit: params.settings?.hooksGasLimit,
     }
   }
 
@@ -299,6 +301,7 @@ export class AaveCollateralSwapSdk {
         receiver: instanceAddress,
       },
       collateralPermit,
+      params.hooksGasLimit,
     )
 
     const swapSettings: SwapAdvancedSettings = {
@@ -532,6 +535,7 @@ export class AaveCollateralSwapSdk {
     hookAmounts: FlashLoanHookAmounts,
     order: EncodedOrder,
     collateralPermit?: CollateralPermitData,
+    hooksGasLimit?: CollateralSwapHooksGasLimit,
   ): Promise<LatestAppDataDocVersion['metadata']['hooks']> {
     const preHookCallData = this.getPreHookCallData(
       flashLoanType,
@@ -549,7 +553,7 @@ export class AaveCollateralSwapSdk {
         {
           target: this.aaveAdapterFactory[chainId],
           callData: preHookCallData,
-          gasLimit: this.hooksGasLimit.pre.toString(),
+          gasLimit: (hooksGasLimit?.preHookGasLimit ?? this.hooksGasLimit.pre).toString(),
           dappId,
         },
       ],
@@ -557,7 +561,7 @@ export class AaveCollateralSwapSdk {
         {
           target: expectedInstanceAddress,
           callData: postHookCallData,
-          gasLimit: this.hooksGasLimit.post.toString(),
+          gasLimit: (hooksGasLimit?.postHookGasLimit ?? this.hooksGasLimit.post).toString(),
           dappId,
         },
       ],

--- a/packages/flash-loans/src/aave/types.ts
+++ b/packages/flash-loans/src/aave/types.ts
@@ -35,6 +35,10 @@ export interface CollateralOrderData {
 
 export type EncodedOrder = Record<string, string | number>
 
+export interface CollateralSwapHooksGasLimit {
+  preHookGasLimit?: bigint
+  postHookGasLimit?: bigint
+}
 /**
  * Parameters for executing a collateral swap using Aave flash loans.
  */
@@ -53,6 +57,7 @@ export interface CollateralSwapParams {
     preventApproval?: boolean
     /** EIP-2612 permit data for gasless approval. If provided, uses permit instead of approve. */
     collateralPermit?: CollateralPermitData
+    hooksGasLimit?: CollateralSwapHooksGasLimit
   }
 }
 
@@ -61,6 +66,7 @@ export interface CollateralSwapTradeParams {
   validTo: number
   owner: AccountAddress
   flashLoanFeeAmount: bigint
+  hooksGasLimit?: CollateralSwapHooksGasLimit
 }
 
 export interface CollateralSwapOrder {


### PR DESCRIPTION
There is a need to specify `gasLimit` per order, to satisfy that, I added `CollateralSwapHooksGasLimit` which can be passed to the methods:
 - `collateralSwap()
 - `getOrderPostingSettings()`
 - `getOrderHooks()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom hook gas limits configuration for collateral swaps, allowing users to override pre- and post-hook gas limits either SDK-wide or per-operation.
  * Default gas limits set to 300,000 for pre-hooks and 600,000 for post-hooks.

* **Documentation**
  * Updated documentation with examples and guidance for configuring custom hook gas limits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->