### PR TITLE
fix: remove isUnderDevelopment flag from plasma

### DIFF
--- a/packages/config/src/chains/details/plasma.ts
+++ b/packages/config/src/chains/details/plasma.ts
@@ -51,5 +51,4 @@ export const plasma: ChainInfo = {
   //     url: '',
   //   },
   // ],
-  isUnderDevelopment: true, // TODO: Remove when ready for production
 }


### PR DESCRIPTION
# Summary

Remove `inUnderDevelopment` flag from Plasma chain config

# Testing

Nothing relevant to test, mostly for communication purposes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plasma chain configuration by removing the development status indicator, reflecting changes to the chain's deployment status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->