### PR TITLE
feat: improve order priority

### DIFF
--- a/packages/bridging/src/BridgingSdk/utils.ts
+++ b/packages/bridging/src/BridgingSdk/utils.ts
@@ -8,6 +8,7 @@ import {
   BridgeProvider,
   DefaultBridgeProvider,
 } from '../types'
+import { OrderBookApiError } from '@cowprotocol/sdk-order-book'
 
 /**
  * Validates that the request is for cross-chain bridging
@@ -149,6 +150,10 @@ export function resolveProvidersToQuery(
 
 function getErrorPriority(error: Error | undefined): number {
   if (!error) return 0
+
+  if (error instanceof OrderBookApiError) {
+    return 10
+  }
 
   if (error instanceof BridgeProviderQuoteError) {
     return BridgeQuoteErrorPriorities[error.message as keyof typeof BridgeQuoteErrorPriorities] ?? 0


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/cowswap/pull/6658#issuecomment-3641255352

This change gives more priority to `OrderBookApiError` than `BridgeProviderQuoteError`, because they are more actionable.

In my case, Across bridge was returning "no routes found"
<img width="639" height="473" alt="image" src="https://github.com/user-attachments/assets/d0cfe9b1-4f01-4812-90d1-9862ac6875a7" />

Even though, Near Intents had a route, but was failing with `OrderBookApiError` : fee exceeds from amount.

For the same swap now the error is better:

<img width="620" height="495" alt="image" src="https://github.com/user-attachments/assets/21a075ef-ce2c-4f49-b4b1-d553261fbf48" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling by prioritizing Order Book API errors appropriately in the bridging system, ensuring they are treated with higher importance during error comparison and resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->