### PR TITLE
feat: use trades v2 for pagination support

### DIFF
--- a/packages/order-book/src/api.spec.ts
+++ b/packages/order-book/src/api.spec.ts
@@ -292,7 +292,7 @@ describe('CoW Api', () => {
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.fi/xdai/api/v1/trades?owner=${TRADE_RESPONSE.owner}&offset=0&limit=10`,
+      `https://api.cow.fi/xdai/api/v2/trades?owner=${TRADE_RESPONSE.owner}&offset=0&limit=10`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(trades.length).toEqual(5)
@@ -307,7 +307,7 @@ describe('CoW Api', () => {
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.fi/xdai/api/v1/trades?orderUid=${TRADE_RESPONSE.orderUid}&offset=0&limit=10`,
+      `https://api.cow.fi/xdai/api/v2/trades?orderUid=${TRADE_RESPONSE.orderUid}&offset=0&limit=10`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(trades.length).toEqual(5)
@@ -348,7 +348,7 @@ describe('CoW Api', () => {
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.cow.fi/xdai/api/v1/trades?owner=invalidOwner&offset=0&limit=10',
+      'https://api.cow.fi/xdai/api/v2/trades?owner=invalidOwner&offset=0&limit=10',
       FETCH_RESPONSE_PARAMETERS,
     )
   })
@@ -502,7 +502,7 @@ describe('CoW Api', () => {
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.fi/xdai/api/v1/trades?owner=${TRADE_RESPONSE.owner}&offset=0&limit=10`,
+      `https://api.cow.fi/xdai/api/v2/trades?owner=${TRADE_RESPONSE.owner}&offset=0&limit=10`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(trades.length).toEqual(5)

--- a/packages/order-book/src/api.ts
+++ b/packages/order-book/src/api.ts
@@ -204,7 +204,7 @@ export class OrderBookApi {
 
     const query = new URLSearchParams(cleanObjectFromUndefinedValues(params))
 
-    return this.fetch({ path: '/api/v1/trades', method: 'GET', query }, contextOverride)
+    return this.fetch({ path: '/api/v2/trades', method: 'GET', query }, contextOverride)
   }
 
   /**


### PR DESCRIPTION
Pagination is live and supported on the `v2` route.

Testing steps described in https://github.com/cowprotocol/cowswap/pull/6567


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated order book API to use the latest version of the trades endpoint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->