### PR TITLE
fix(bridge): filter providers when do MultiQuote

### DIFF
--- a/packages/bridging/src/BridgingSdk/strategies/BestQuoteStrategy.test.ts
+++ b/packages/bridging/src/BridgingSdk/strategies/BestQuoteStrategy.test.ts
@@ -390,7 +390,7 @@ adapterNames.forEach((adapterName) => {
         const resultPromise = strategy.execute(request, config.tradingSdk, config.providers)
 
         // Advance timers past the fast provider delay but before slow providers
-        jest.advanceTimersByTime(50)
+        await jest.advanceTimersByTimeAsync(50)
 
         const result = await resultPromise
 

--- a/packages/bridging/src/BridgingSdk/strategies/utils.test.ts
+++ b/packages/bridging/src/BridgingSdk/strategies/utils.test.ts
@@ -1,0 +1,135 @@
+import { fetchMultiQuote } from './utils'
+import { MockHookBridgeProvider } from '../../providers/mock/HookMockBridgeProvider'
+import {
+  bridgeQuoteResult,
+  getMockSigner,
+  quoteBridgeRequest,
+  amountsAndCosts,
+  appDataInfo,
+  orderQuoteResponse,
+  orderToSign,
+  orderTypedData,
+  tradeParameters,
+} from '../mock/bridgeRequestMocks'
+import { QuoteResultsWithSigner, TradingSdk } from '@cowprotocol/sdk-trading'
+import { OrderBookApi } from '@cowprotocol/sdk-order-book'
+import { mainnet, optimism, sepolia, SupportedChainId } from '@cowprotocol/sdk-config'
+import { setGlobalAdapter } from '@cowprotocol/sdk-common'
+import { createAdapters } from '../../../tests/setup'
+import { MultiQuoteContext } from '../../types'
+import { getQuoteWithBridge } from '../getQuoteWithBridge'
+
+// Mock the getQuoteWithBridge function
+jest.mock('../getQuoteWithBridge')
+
+const adapters = createAdapters()
+const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
+
+adapterNames.forEach((adapterName) => {
+  describe(`fetchMultiQuote with ${adapterName}`, () => {
+    let mockProvider: MockHookBridgeProvider
+    let tradingSdk: TradingSdk
+    let orderBookApi: OrderBookApi
+    let quoteResult: QuoteResultsWithSigner
+
+    beforeEach(async () => {
+      jest.clearAllMocks()
+
+      const adapter = adapters[adapterName]
+      setGlobalAdapter(adapter)
+
+      const signer = getMockSigner(adapter)
+      quoteBridgeRequest.signer = signer
+
+      mockProvider = new MockHookBridgeProvider()
+      mockProvider.getQuote = jest.fn().mockResolvedValue(bridgeQuoteResult)
+
+      orderBookApi = {
+        context: {
+          chainId: SupportedChainId.GNOSIS_CHAIN,
+        },
+        getQuote: jest.fn().mockResolvedValue(orderQuoteResponse),
+        sendOrder: jest.fn().mockResolvedValue('0x01'),
+      } as unknown as OrderBookApi
+
+      tradingSdk = new TradingSdk({}, { orderBookApi })
+      quoteResult = {
+        orderBookApi,
+        result: {
+          tradeParameters,
+          orderToSign,
+          amountsAndCosts,
+          appDataInfo,
+          quoteResponse: orderQuoteResponse,
+          orderTypedData,
+          signer,
+          suggestedSlippageBps: 0,
+        },
+      }
+      tradingSdk.getQuoteResults = jest.fn().mockResolvedValue(quoteResult)
+
+      // Mock getQuoteWithBridge to return the bridge quote result
+      ;(getQuoteWithBridge as jest.Mock).mockResolvedValue(bridgeQuoteResult)
+    })
+
+    describe('Network Support Validation', () => {
+      it('should return undefined when provider does not support the requested buyTokenChainId', async () => {
+        // Mock getNetworks to return only mainnet, optimism, and sepolia (no BASE)
+        mockProvider.getNetworks = jest.fn().mockResolvedValue([mainnet, optimism, sepolia])
+
+        const context: MultiQuoteContext = {
+          provider: mockProvider,
+          quoteBridgeRequest, // uses SupportedChainId.BASE
+          advancedSettings: undefined,
+          providerTimeout: 10000,
+          onQuoteResult: undefined,
+        }
+
+        const result = await fetchMultiQuote(context, tradingSdk)
+
+        // Should return undefined because BASE is not supported
+        expect(result).toBeUndefined()
+
+        // getQuoteWithBridge should NOT have been called
+        expect(getQuoteWithBridge).not.toHaveBeenCalled()
+
+        // Provider's getNetworks should have been called
+        expect(mockProvider.getNetworks).toHaveBeenCalled()
+      })
+
+      it('should fetch quote when provider supports the requested buyTokenChainId', async () => {
+        // Mock getNetworks to include BASE
+        const baseNetwork = { id: SupportedChainId.BASE, name: 'Base', shortName: 'base' }
+        mockProvider.getNetworks = jest.fn().mockResolvedValue([mainnet, optimism, sepolia, baseNetwork])
+
+        const context: MultiQuoteContext = {
+          provider: mockProvider,
+          quoteBridgeRequest, // uses SupportedChainId.BASE
+          advancedSettings: undefined,
+          providerTimeout: 10000,
+          onQuoteResult: undefined,
+        }
+
+        const result = await fetchMultiQuote(context, tradingSdk)
+
+        // Should return a result with the quote
+        expect(result).toBeDefined()
+        expect(result?.providerDappId).toBe(mockProvider.info.dappId)
+        expect(result?.quote).toEqual(bridgeQuoteResult)
+        expect(result?.error).toBeUndefined()
+
+        // getQuoteWithBridge should have been called
+        expect(getQuoteWithBridge).toHaveBeenCalledWith(
+          mockProvider,
+          expect.objectContaining({
+            swapAndBridgeRequest: quoteBridgeRequest,
+            tradingSdk,
+          }),
+        )
+
+        // Provider's getNetworks should have been called
+        expect(mockProvider.getNetworks).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/packages/bridging/src/BridgingSdk/strategies/utils.ts
+++ b/packages/bridging/src/BridgingSdk/strategies/utils.ts
@@ -1,0 +1,48 @@
+import { TTLCache } from '@cowprotocol/sdk-common'
+import { TokenInfo } from '@cowprotocol/sdk-config'
+import { TradingSdk } from '@cowprotocol/sdk-trading'
+
+import { getQuoteWithBridge } from '../getQuoteWithBridge'
+import { GetQuoteWithBridgeParams } from '../types'
+import { createBridgeRequestTimeoutPromise } from '../utils'
+import { MultiQuoteContext, MultiQuoteResult } from '../../types'
+
+export async function fetchMultiQuote(
+  context: MultiQuoteContext,
+  tradingSdk: TradingSdk,
+  intermediateTokensCache?: TTLCache<TokenInfo[]>,
+): Promise<MultiQuoteResult | undefined> {
+  const { provider, quoteBridgeRequest, advancedSettings, providerTimeout } = context
+
+  const supportedNetworks = await provider.getNetworks()
+  const destinationNetwork = supportedNetworks.find((i) => i.id === quoteBridgeRequest.buyTokenChainId)
+
+  // Do not make a request if a provider doesn't support the network
+  if (!destinationNetwork) return
+
+  const baseParams: GetQuoteWithBridgeParams = {
+    swapAndBridgeRequest: quoteBridgeRequest,
+    advancedSettings,
+    tradingSdk,
+    quoteSigner: advancedSettings?.quoteSigner,
+  } as const
+
+  const request = intermediateTokensCache
+    ? {
+        ...baseParams,
+        intermediateTokensCache: intermediateTokensCache,
+      }
+    : baseParams
+
+  // Race between the actual quote request and the provider timeout
+  const quote = await Promise.race([
+    getQuoteWithBridge(provider, request),
+    createBridgeRequestTimeoutPromise(providerTimeout, `Provider ${provider.info.dappId}`),
+  ])
+
+  return {
+    providerDappId: provider.info.dappId,
+    quote,
+    error: undefined,
+  }
+}

--- a/packages/bridging/src/providers/mock/HookMockBridgeProvider.ts
+++ b/packages/bridging/src/providers/mock/HookMockBridgeProvider.ts
@@ -1,7 +1,7 @@
 import { cowAppDataLatestScheme as latestAppData } from '@cowprotocol/sdk-app-data'
 import { BridgeDeposit, BridgeHook, HookBridgeProvider, BridgeQuoteResult, QuoteBridgeRequest } from '../../types'
 import { HOOK_DAPP_BRIDGE_PROVIDER_PREFIX, RAW_PROVIDERS_FILES_PATH } from '../../const'
-import { EvmCall, SupportedChainId } from '@cowprotocol/sdk-config'
+import { ALL_SUPPORTED_CHAINS, EvmCall, SupportedChainId } from '@cowprotocol/sdk-config'
 import { OrderKind } from '@cowprotocol/sdk-order-book'
 import { MOCK_CALL } from './mockData'
 import { BaseMockBridgeProvider } from './BaseMockBridgeProvider'
@@ -60,5 +60,9 @@ export class MockHookBridgeProvider extends BaseMockBridgeProvider implements Ho
       signer: '',
       appCode: 'MOCK',
     }
+  }
+
+  async getNetworks() {
+    return ALL_SUPPORTED_CHAINS
   }
 }

--- a/packages/bridging/src/providers/mock/ReceiverAccountMockBridgeProvider.ts
+++ b/packages/bridging/src/providers/mock/ReceiverAccountMockBridgeProvider.ts
@@ -1,6 +1,7 @@
 import { ReceiverAccountBridgeProvider, BridgeQuoteResult, QuoteBridgeRequest } from '../../types'
 import { BaseMockBridgeProvider } from './BaseMockBridgeProvider'
 import { RAW_PROVIDERS_FILES_PATH } from '../../const'
+import { ALL_SUPPORTED_CHAINS } from '@cowprotocol/sdk-config'
 
 const name = 'ReceiverAccountBridgeProvider'
 const providerType = 'ReceiverAccountBridgeProvider' as const
@@ -32,5 +33,9 @@ export class MockReceiverAccountBridgeProvider
 
   async getBridgeReceiverOverride(_quoteRequest: QuoteBridgeRequest, _quoteResult: BridgeQuoteResult): Promise<string> {
     return this.mockReceiverAddress
+  }
+
+  async getNetworks() {
+    return ALL_SUPPORTED_CHAINS
   }
 }

--- a/packages/bridging/src/types.ts
+++ b/packages/bridging/src/types.ts
@@ -510,7 +510,7 @@ export interface MultiQuoteRequest {
   options?: MultiQuoteOptions
 }
 
-interface MultiQuoteContext {
+export interface MultiQuoteContext {
   provider: BridgeProvider<BridgeQuoteResult>
   quoteBridgeRequest: QuoteBridgeRequest
   advancedSettings: SwapAdvancedSettings | undefined


### PR DESCRIPTION
Since we have strategies with multi-quotes (BestQuoteStrategy, MultiQuoteStrategy), we should check if a provider supports destination token network and filter it out if a false case.

I extracted repeated code into `fetchMultiQuote` and only added `if (!destinationNetwork) return` check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized quote-fetching and timeout handling for more consistent multicall behavior.
  * Improved provider network validation to avoid unsupported-network lookups and skip unavailable providers.
  * Mock providers now report supported networks for more accurate behavior in multi-network flows.

* **Tests**
  * Expanded and stabilized test coverage for multi-quote flows, using dynamic provider validation and awaited timers to reduce order- and timing-related flakiness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->