### PR TITLE
fix: change applyCostsSlippageAndFees default for limit orders

### DIFF
--- a/packages/trading/src/postLimitOrder.test.ts
+++ b/packages/trading/src/postLimitOrder.test.ts
@@ -85,7 +85,7 @@ describe('postLimitOrder', () => {
         orderBookApiMock,
         appDataMock,
         { ...defaultOrderParams, signer: adapters[adapterName], env: 'prod' },
-        undefined,
+        { applyCostsSlippageAndFees: false },
         expect.anything(),
       )
       postCoWProtocolTradeMock.mockReset()

--- a/packages/trading/src/postLimitOrder.ts
+++ b/packages/trading/src/postLimitOrder.ts
@@ -34,5 +34,10 @@ export async function postLimitOrder(
     advancedSettings?.appData,
   )
 
-  return postCoWProtocolTrade(orderBookApi, appDataInfo, params, advancedSettings?.additionalParams, params.signer)
+  const additionalParams = {
+    ...(advancedSettings?.additionalParams ?? {}),
+    applyCostsSlippageAndFees: advancedSettings?.additionalParams?.applyCostsSlippageAndFees ?? false,
+  }
+
+  return postCoWProtocolTrade(orderBookApi, appDataInfo, params, additionalParams, params.signer)
 }


### PR DESCRIPTION
Related to https://github.com/cowprotocol/cowswap/pull/6743

It makes more sense for `applyCostsSlippageAndFees` to be false when posting a limit order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated limit order processing to properly exclude costs and slippage calculations from the trade execution, ensuring more accurate order handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->