### PR TITLE
chore: remove `under development` comment from Linea and Plasma

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ CoW Swap is currently available on the following chains:
 - **Polygon** (137)
 - **Lens** (232)
 - **Base** (8453)
-- **Plasma** (9745) (Under development)
+- **Plasma** (9745)
 - **Arbitrum One** (42161)
 - **Avalanche** (43114)
-- **Linea** (59144) (Under development)
+- **Linea** (59144)
 - **Sepolia** (11155111) (Testnet)
 
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -25,8 +25,8 @@ The SDK supports all CoW Protocol enabled networks:
 - **Avalanche** (43114) - `SupportedChainId.AVALANCHE`
 - **Lens** (232) - `SupportedChainId.LENS`
 - **BNB** (56) - `SupportedChainId.BNB`
-- **Linea** (59144) - `SupportedChainId.LINEA` (Under development)
-- **Plasma** (9745) - `SupportedChainId.PLASMA` (Under development)
+- **Linea** (59144) - `SupportedChainId.LINEA`
+- **Plasma** (9745) - `SupportedChainId.PLASMA`
 - **Sepolia** (11155111) - `SupportedChainId.SEPOLIA` (Testnet)
 
 ## 🔗 **Related Resources**


### PR DESCRIPTION
# Summary

No code changes, just update readme notes for Linea and Plasma

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Plasma and Linea network entries have been updated to reflect their release status, removing the "under development" annotation from both the main README and SDK documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->