### PR TITLE
fix: unify spelling for chain explorers

### DIFF
--- a/packages/config/src/chains/details/avalanche.ts
+++ b/packages/config/src/chains/details/avalanche.ts
@@ -41,7 +41,7 @@ export const avalanche: ChainInfo = {
     url: 'https://build.avax.network/docs',
   },
   blockExplorer: {
-    name: 'SnowScan',
+    name: 'Snowscan',
     url: 'https://snowscan.xyz',
   },
 }

--- a/packages/config/src/chains/details/base.ts
+++ b/packages/config/src/chains/details/base.ts
@@ -42,7 +42,7 @@ export const base: ChainInfo = {
     url: 'https://docs.base.org',
   },
   blockExplorer: {
-    name: 'BaseScan',
+    name: 'Basescan',
     url: 'https://basescan.org',
   },
   bridges: [

--- a/packages/config/src/chains/details/bnb.ts
+++ b/packages/config/src/chains/details/bnb.ts
@@ -41,7 +41,7 @@ export const bnb: ChainInfo = {
     url: 'https://docs.bnbchain.org',
   },
   blockExplorer: {
-    name: 'BscScan',
+    name: 'Bscscan',
     url: 'https://bscscan.com',
   },
   bridges: [

--- a/packages/config/src/chains/details/linea.ts
+++ b/packages/config/src/chains/details/linea.ts
@@ -38,7 +38,7 @@ export const linea: ChainInfo = {
     url: 'https://docs.linea.build',
   },
   blockExplorer: {
-    name: 'LineaScan',
+    name: 'Lineascan',
     url: 'https://lineascan.build',
   },
   bridges: [
@@ -46,5 +46,5 @@ export const linea: ChainInfo = {
       name: 'Linea Bridge',
       url: 'https://linea.build/hub/bridge',
     },
-  ]
+  ],
 }

--- a/packages/config/src/chains/details/plasma.ts
+++ b/packages/config/src/chains/details/plasma.ts
@@ -41,7 +41,7 @@ export const plasma: ChainInfo = {
     url: 'https://docs.plasma.to',
   },
   blockExplorer: {
-    name: 'PlasmaScan',
+    name: 'Plasmascan',
     url: 'https://plasmascan.to',
   },
   // No native bridge available AFAICT


### PR DESCRIPTION
Issue at [cowprotocol/cowswap6827](https://github.com/cowprotocol/cowswap/issues/6827)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated block explorer display names across multiple blockchain networks (Avalanche, Base, BNB Chain, Linea, and Plasma).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->