### PR TITLE
fix(COW-163): remove --delete param from aws s3 sync

### DIFF
--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -29,8 +29,10 @@ jobs:
           aws-region: eu-central-1
 
       - name: Upload to S3
+        # We do not use --delete so that old assets (e.g. chain images) remain in S3.
+        # Deleting them on deploy would break previous SDK versions still in use until the new version is live.
         run: |
-          aws s3 sync src s3://files.cow.fi/cow-sdk --delete
+          aws s3 sync src s3://files.cow.fi/cow-sdk
 
       - name: Invalidate CloudFront cache
         run: |


### PR DESCRIPTION
We do not use --delete so that old assets (e.g. chain images) remain in S3.
Deleting them on deploy would break previous SDK versions still in use until the new version is live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment process to preserve existing assets during releases, ensuring backward compatibility with previous SDK versions and preventing unintended removal of resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->