### PR TITLE
fix: deploy to s3 release trigger

### DIFF
--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -2,8 +2,7 @@ name: Deploy to S3
 # Workflow copied from https://github.com/cowprotocol/token-lists/blob/main/.github/workflows/s3Deploy.yml
 
 on:
-  release:
-    types: [created]
+  workflow_call:
   # Allow manual trigger
   workflow_dispatch:
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       # 1️⃣ Checkout the repo
       - uses: actions/checkout@v4
@@ -56,3 +58,12 @@ jobs:
       - name: Publish changed packages
         if: steps.release.outputs.releases_created == 'true'
         run: pnpm publish -r --filter="./packages/**" --tag latest --no-git-checks
+
+  deploy-to-s3:
+    needs: release-please
+    if: needs.release-please.result == 'success' && needs.release-please.outputs.releases_created == 'true'
+    uses: ./.github/workflows/deploy-to-s3.yml
+    permissions:
+      id-token: write
+      contents: read
+    secrets: inherit


### PR DESCRIPTION
## Summary

Fix S3 deploy not firing by invoking deploy workflow from release-please via workflow_call.

## Issue

Releases created by release-please use `GITHUB_TOKEN`; GitHub blocks downstream workflow triggers from `GITHUB_TOKEN` release events, so `on: release` never fired.

As [per docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow):
> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflows to automatically trigger when releases are created, improving release automation and eliminating manual workflow dispatch requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->