### PR TITLE
fix(bridge): use real WETH addresses in README example

### DIFF
--- a/packages/bridging/README.md
+++ b/packages/bridging/README.md
@@ -45,12 +45,12 @@ const parameters: QuoteBridgeRequest = {
 
   // Sell token (and source chain)
   sellTokenChainId: SupportedChainId.ARBITRUM_ONE,
-  sellTokenAddress: '0xfff9976782d46cc05630d1f6ebab18b2324d6b14',
+  sellTokenAddress: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
   sellTokenDecimals: 18,
 
   // Buy token (and target chain)
   buyTokenChainId: SupportedChainId.BASE,
-  buyTokenAddress: '0x0625afb445c3b6b7b929342a04a22599fd5dbb59',
+  buyTokenAddress: '0x4200000000000000000000000000000000000006',
   buyTokenDecimals: 18,
 
   // Amount to sell
@@ -115,12 +115,12 @@ const parameters: QuoteBridgeRequest = {
 
   // Sell token (and source chain)
   sellTokenChainId: SupportedChainId.ARBITRUM_ONE,
-  sellTokenAddress: '0xfff9976782d46cc05630d1f6ebab18b2324d6b14',
+  sellTokenAddress: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
   sellTokenDecimals: 18,
 
   // Buy token (and target chain)
   buyTokenChainId: SupportedChainId.BASE,
-  buyTokenAddress: '0x0625afb445c3b6b7b929342a04a22599fd5dbb59',
+  buyTokenAddress: '0x4200000000000000000000000000000000000006',
   buyTokenDecimals: 18,
 
   // Amount to sell


### PR DESCRIPTION
## Summary
Fixes #341

The bridge SDK README example uses non-token addresses as sample tokens, causing users to get "No path found" when running the example. This replaces them with real WETH contract addresses on Arbitrum and Base.

## Test plan
- [x] Verified the replacement addresses are valid WETH contracts on their respective chains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bridging request example code with revised token contract addresses for supported blockchain networks to ensure accuracy across usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->