### PR TITLE
chore: update links to use cow.finance domain

### DIFF
--- a/examples/react/ethers5/src/components/SwapForm/index.tsx
+++ b/examples/react/ethers5/src/components/SwapForm/index.tsx
@@ -16,7 +16,7 @@ const WETH_SEPOLIA = WRAPPED_NATIVE_CURRENCIES[chainId]
 
 const USDC_SEPOLIA: TokenInfo = {
   logoUrl:
-    'https://files.cow.fi/token-lists/images/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/logo.png',
+    'https://files.cow.finance/token-lists/images/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/logo.png',
   chainId: SupportedChainId.SEPOLIA,
   address: '0xbe72E441BF55620febc26715db68d3494213D8Cb',
   decimals: 18,
@@ -126,7 +126,7 @@ export function SwapForm() {
         <div className="box">
           <h4>Order has been posted</h4>
           <p>
-            <a href={`https://explorer.cow.fi/sepolia/orders/${postedOrderHash}`}>See details in Explorer</a>
+            <a href={`https://explorer.cow.finance/sepolia/orders/${postedOrderHash}`}>See details in Explorer</a>
           </p>
         </div>
       )}

--- a/examples/react/ethers6/src/components/SwapForm/index.tsx
+++ b/examples/react/ethers6/src/components/SwapForm/index.tsx
@@ -16,7 +16,7 @@ const WETH_SEPOLIA = WRAPPED_NATIVE_CURRENCIES[chainId]
 
 const USDC_SEPOLIA: TokenInfo = {
   logoUrl:
-    'https://files.cow.fi/token-lists/images/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/logo.png',
+    'https://files.cow.finance/token-lists/images/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/logo.png',
   chainId: SupportedChainId.SEPOLIA,
   address: '0xbe72E441BF55620febc26715db68d3494213D8Cb',
   decimals: 18,
@@ -128,7 +128,7 @@ export function SwapForm() {
         <div className="box">
           <h4>Order has been posted</h4>
           <p>
-            <a href={`https://explorer.cow.fi/sepolia/orders/${postedOrderHash}`}>See details in Explorer</a>
+            <a href={`https://explorer.cow.finance/sepolia/orders/${postedOrderHash}`}>See details in Explorer</a>
           </p>
         </div>
       )}

--- a/examples/react/viem/src/components/SwapForm/index.tsx
+++ b/examples/react/viem/src/components/SwapForm/index.tsx
@@ -17,7 +17,7 @@ const WETH_SEPOLIA = WRAPPED_NATIVE_CURRENCIES[chainId]
 
 const USDC_SEPOLIA: TokenInfo = {
   logoUrl:
-    'https://files.cow.fi/token-lists/images/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/logo.png',
+    'https://files.cow.finance/token-lists/images/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/logo.png',
   chainId: SupportedChainId.SEPOLIA,
   address: '0xbe72E441BF55620febc26715db68d3494213D8Cb',
   decimals: 18,
@@ -136,7 +136,7 @@ export function SwapForm() {
         <div className="box">
           <h4>Order has been posted</h4>
           <p>
-            <a href={`https://explorer.cow.fi/sepolia/orders/${postedOrderHash}`}>See details in Explorer</a>
+            <a href={`https://explorer.cow.finance/sepolia/orders/${postedOrderHash}`}>See details in Explorer</a>
           </p>
         </div>
       )}

--- a/examples/react/wagmi/src/components/SwapForm/index.tsx
+++ b/examples/react/wagmi/src/components/SwapForm/index.tsx
@@ -171,7 +171,7 @@ export function SwapForm({ isSdkReady }: { isSdkReady: boolean }) {
             <code style={{ wordBreak: 'break-all', fontSize: '0.9em' }}>{postedOrderHash}</code>
           </p>
           <p>
-            <a href={`https://explorer.cow.fi/orders/${postedOrderHash}`} target="_blank" rel="noopener noreferrer">
+            <a href={`https://explorer.cow.finance/orders/${postedOrderHash}`} target="_blank" rel="noopener noreferrer">
               View in CoW Explorer
             </a>
           </p>


### PR DESCRIPTION
## Summary

  Replace remaining `cow.fi` links with `cow.finance`.

  ## Changes

  - update example Explorer links
  - update example token image/CDN links
  - fix SDK file path references to `files.cow.finance`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external domain references from `cow.fi` to `cow.finance` across example components for token logos and explorer links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->