### PR TITLE
feat!: bring cow.fi back

### DIFF
--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -31,7 +31,7 @@ jobs:
         # We do not use --delete so that old assets (e.g. chain images) remain in S3.
         # Deleting them on deploy would break previous SDK versions still in use until the new version is live.
         run: |
-          aws s3 sync src s3://files.cow.finance/cow-sdk
+          aws s3 sync src s3://files.cow.fi/cow-sdk
 
       - name: Invalidate CloudFront cache
         run: |

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "prerelease": true,
-  "prerelease-type": "cowfinance",
   "include-component-in-tag": true,
   "tag-separator": "-",
   "packages": {

--- a/README.md
+++ b/README.md
@@ -128,4 +128,4 @@ We welcome contributions to the CoW Protocol SDK! Here's how to get started:
 
 - Check existing [issues](https://github.com/cowprotocol/cow-sdk/issues) for similar problems
 - Join our [Discord](https://discord.gg/cowprotocol) for community support
-- Read the [CoW Protocol documentation](https://docs.cow.finance)
+- Read the [CoW Protocol documentation](https://docs.cow.fi)

--- a/packages/app-data/README.md
+++ b/packages/app-data/README.md
@@ -8,7 +8,7 @@ AppData schema definitions
 
 These schemas are used in the data encoded on `appData` field for CowProtocol orders.
 
-For more details, check [the docs](https://docs.cow.finance/cow-protocol/reference/core/intents/app-data).
+For more details, check [the docs](https://docs.cow.fi/cow-protocol/reference/core/intents/app-data).
 
 ## Installation
 

--- a/packages/bridging/src/PROVIDER_README.md
+++ b/packages/bridging/src/PROVIDER_README.md
@@ -569,7 +569,7 @@ export const YOUR_BRIDGE_CONTRACTS: Record<SupportedChainId, string> = {
 }
 
 // const/misc.ts
-export const HOOK_DAPP_BRIDGE_PROVIDER_PREFIX = 'cow-hooks.cow.finance'
+export const HOOK_DAPP_BRIDGE_PROVIDER_PREFIX = 'cow-hooks.cow.fi'
 export const YOUR_BRIDGE_SUPPORTED_TOKENS = {
   // Define supported token lists
 }

--- a/packages/bridging/src/PROVIDER_README.md
+++ b/packages/bridging/src/PROVIDER_README.md
@@ -569,7 +569,7 @@ export const YOUR_BRIDGE_CONTRACTS: Record<SupportedChainId, string> = {
 }
 
 // const/misc.ts
-export const HOOK_DAPP_BRIDGE_PROVIDER_PREFIX = 'cow-hooks.cow.fi'
+export const HOOK_DAPP_BRIDGE_PROVIDER_PREFIX = 'cow-sdk://bridging/providers'
 export const YOUR_BRIDGE_SUPPORTED_TOKENS = {
   // Define supported token lists
 }

--- a/packages/bridging/src/providers/mock/mockData.ts
+++ b/packages/bridging/src/providers/mock/mockData.ts
@@ -25,7 +25,7 @@ export const BUY_TOKENS = [
   {
     chainId: SupportedChainId.MAINNET,
     address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-    logoUrl: 'https://swap.cow.finance/assets/network-mainnet-logo-BJe1wK_m.svg',
+    logoUrl: 'https://swap.cow.fi/assets/network-mainnet-logo-BJe1wK_m.svg',
     name: 'USD Coin',
     symbol: 'USDC',
     decimals: 6,
@@ -33,7 +33,7 @@ export const BUY_TOKENS = [
   {
     chainId: SupportedChainId.MAINNET,
     address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-    logoUrl: 'https://swap.cow.finance/assets/network-gnosis-chain-logo-Do_DEWQv.svg',
+    logoUrl: 'https://swap.cow.fi/assets/network-gnosis-chain-logo-Do_DEWQv.svg',
     name: 'Wrapped Ether',
     symbol: 'WETH',
     decimals: 18,
@@ -41,7 +41,7 @@ export const BUY_TOKENS = [
   {
     chainId: SupportedChainId.SEPOLIA,
     address: '0x0625aFB445C3B6B7B929342a04A22599fd5dBB59',
-    logoUrl: 'https://swap.cow.finance/assets/network-mainnet-logo-BJe1wK_m.svg',
+    logoUrl: 'https://swap.cow.fi/assets/network-mainnet-logo-BJe1wK_m.svg',
     name: 'CoW Protocol Token',
     symbol: 'COW',
     decimals: 18,
@@ -49,7 +49,7 @@ export const BUY_TOKENS = [
   {
     chainId: AdditionalTargetChainId.OPTIMISM,
     address: '0x4200000000000000000000000000000000000006',
-    logoUrl: 'https://swap.cow.finance/assets/network-mainnet-logo-BJe1wK_m.svg',
+    logoUrl: 'https://swap.cow.fi/assets/network-mainnet-logo-BJe1wK_m.svg',
     name: 'Wrapped Ether',
     symbol: 'WETH',
     decimals: 18,

--- a/packages/composable/src/orderTypes/Twap.ts
+++ b/packages/composable/src/orderTypes/Twap.ts
@@ -77,7 +77,7 @@ export type TwapDataBase = {
   /**
    * Meta-data associated with the order. Normally would be the keccak256 hash of the document generated in http://github.com/cowprotocol/app-data
    *
-   * This hash should have been uploaded to the API https://api.cow.finance/docs/#/default/put_api_v1_app_data__app_data_hash_ and potentially to other data availability protocols like IPFS.
+   * This hash should have been uploaded to the API https://api.cow.fi/docs/#/default/put_api_v1_app_data__app_data_hash_ and potentially to other data availability protocols like IPFS.
    *
    */
   readonly appData: string

--- a/packages/config/src/constants/paths.ts
+++ b/packages/config/src/constants/paths.ts
@@ -1,8 +1,8 @@
 // Base CDN path for SDK files
-export const RAW_FILES_PATH = 'https://files.cow.finance/cow-sdk'
+export const RAW_FILES_PATH = 'https://files.cow.fi/cow-sdk'
 
 // CDN path for chain data
 export const RAW_CHAINS_FILES_PATH = `${RAW_FILES_PATH}/chains`
 
 // CDN path for token list images
-export const TOKEN_LIST_IMAGES_PATH = 'https://files.cow.finance/token-lists/images'
+export const TOKEN_LIST_IMAGES_PATH = 'https://files.cow.fi/token-lists/images'

--- a/packages/config/src/types/configs.ts
+++ b/packages/config/src/types/configs.ts
@@ -74,11 +74,11 @@ export type ApiBaseUrls = Record<SupportedChainId, string>
  * Each chain has it's own API, and each API has it's own base URL.
  *
  * Options may be selectively overridden by passing a {@link PartialApiContext} to the constructor.
- * @see {@link https://api.cow.finance/docs/#/}
+ * @see {@link https://api.cow.fi/docs/#/}
  * @property {SupportedChainId} chainId The `chainId`` corresponding to this CoW Protocol API instance.
  * @property {CowEnv} env The environment that this context corresponds to.
  * @property {ApiBaseUrls} [baseUrls] URls that may be used to connect to this context.
- * @property {string} [apiKey] API key for Partner API (partners.cow.finance). When set, requests use the partner gateway and include X-API-Key header.
+ * @property {string} [apiKey] API key for Partner API (partners.cow.fi). When set, requests use the partner gateway and include X-API-Key header.
  */
 export interface ApiContext {
   chainId: SupportedChainId

--- a/packages/contracts-ts/src/api.ts
+++ b/packages/contracts-ts/src/api.ts
@@ -10,17 +10,17 @@ export enum Environment {
 
 export const LIMIT_CONCURRENT_REQUESTS = 5
 
-const PARTNER_PROD_BASE_URL = 'https://partners.cow.finance'
-const PARTNER_DEV_BASE_URL = 'https://partners.barn.cow.finance'
+const PARTNER_PROD_BASE_URL = 'https://partners.cow.fi'
+const PARTNER_DEV_BASE_URL = 'https://partners.barn.cow.fi'
 
 export function apiUrl(environment: Environment, network: string, apiKey?: string): string {
   let baseUrl: string
   switch (environment) {
     case Environment.Dev:
-      baseUrl = apiKey ? PARTNER_DEV_BASE_URL : 'https://barn.api.cow.finance'
+      baseUrl = apiKey ? PARTNER_DEV_BASE_URL : 'https://barn.api.cow.fi'
       break
     case Environment.Prod:
-      baseUrl = apiKey ? PARTNER_PROD_BASE_URL : 'https://api.cow.finance'
+      baseUrl = apiKey ? PARTNER_PROD_BASE_URL : 'https://api.cow.fi'
       break
     default:
       throw new Error('Invalid environment')
@@ -134,7 +134,12 @@ function apiSigningScheme(scheme: SigningScheme): string {
   }
 }
 
-async function call<T>(route: string, baseUrl: string, init?: RequestInit, apiKey?: string): Promise<T> {
+async function call<T>(
+  route: string,
+  baseUrl: string,
+  init?: RequestInit,
+  apiKey?: string,
+): Promise<T> {
   const url = `${baseUrl}/api/v1/${route}`
   const headers: Record<string, string> = {
     ...((init?.headers as Record<string, string>) ?? {}),
@@ -195,31 +200,37 @@ async function estimateTradeAmount({
   return getGlobalAdapter().utils.toBigIntish(estimatedAmount)
 }
 
-async function placeOrder({ order, signature, baseUrl, from, apiKey }: PlaceOrderQuery & ApiCall): Promise<string> {
+async function placeOrder({
+  order,
+  signature,
+  baseUrl,
+  from,
+  apiKey,
+}: PlaceOrderQuery & ApiCall): Promise<string> {
   const normalizedOrder = normalizeOrder(order)
   const adapter = getGlobalAdapter()
   return await call(
     'orders',
     baseUrl,
     {
-      method: 'post',
-      body: JSON.stringify({
-        sellToken: normalizedOrder.sellToken,
-        buyToken: normalizedOrder.buyToken,
-        sellAmount: String(adapter.utils.toBigIntish(normalizedOrder.sellAmount)),
-        buyAmount: String(adapter.utils.toBigIntish(normalizedOrder.buyAmount)),
-        validTo: normalizedOrder.validTo,
-        appData: normalizedOrder.appData,
-        feeAmount: String(adapter.utils.toBigIntish(normalizedOrder.feeAmount)),
-        kind: apiKind(order.kind),
-        partiallyFillable: normalizedOrder.partiallyFillable,
-        signature: encodeSignatureData(signature),
-        signingScheme: apiSigningScheme(signature.scheme),
-        receiver: normalizedOrder.receiver,
-        from,
-      }),
-      headers: { 'Content-Type': 'application/json' },
-    },
+    method: 'post',
+    body: JSON.stringify({
+      sellToken: normalizedOrder.sellToken,
+      buyToken: normalizedOrder.buyToken,
+      sellAmount: String(adapter.utils.toBigIntish(normalizedOrder.sellAmount)),
+      buyAmount: String(adapter.utils.toBigIntish(normalizedOrder.buyAmount)),
+      validTo: normalizedOrder.validTo,
+      appData: normalizedOrder.appData,
+      feeAmount: String(adapter.utils.toBigIntish(normalizedOrder.feeAmount)),
+      kind: apiKind(order.kind),
+      partiallyFillable: normalizedOrder.partiallyFillable,
+      signature: encodeSignatureData(signature),
+      signingScheme: apiSigningScheme(signature.scheme),
+      receiver: normalizedOrder.receiver,
+      from,
+    }),
+    headers: { 'Content-Type': 'application/json' },
+  },
     apiKey,
   )
 }
@@ -233,7 +244,10 @@ async function getExecutedSellAmount({
   return getGlobalAdapter().utils.toBigIntish(response.executedSellAmount)
 }
 
-async function getQuote({ baseUrl, apiKey }: ApiCall, quote: QuoteQuery): Promise<GetQuoteResponse> {
+async function getQuote(
+  { baseUrl, apiKey }: ApiCall,
+  quote: QuoteQuery,
+): Promise<GetQuoteResponse> {
   // Convert BigNumber into JSON strings (native serialisation is a hex object)
   if ((<SellAmountBeforeFee>quote).sellAmountBeforeFee) {
     ;(<SellAmountBeforeFee>quote).sellAmountBeforeFee = String((<SellAmountBeforeFee>quote).sellAmountBeforeFee)

--- a/packages/contracts-ts/tests/api.test.ts
+++ b/packages/contracts-ts/tests/api.test.ts
@@ -79,14 +79,14 @@ describe('API Functions and Classes', () => {
   describe('apiUrl', () => {
     test('should generate correct URLs for different environments and networks', () => {
       // Test Dev environment
-      expect(apiUrl(Environment.Dev, 'mainnet')).toBe('https://barn.api.cow.finance/mainnet')
-      expect(apiUrl(Environment.Dev, 'goerli')).toBe('https://barn.api.cow.finance/goerli')
-      expect(apiUrl(Environment.Dev, 'sepolia')).toBe('https://barn.api.cow.finance/sepolia')
+      expect(apiUrl(Environment.Dev, 'mainnet')).toBe('https://barn.api.cow.fi/mainnet')
+      expect(apiUrl(Environment.Dev, 'goerli')).toBe('https://barn.api.cow.fi/goerli')
+      expect(apiUrl(Environment.Dev, 'sepolia')).toBe('https://barn.api.cow.fi/sepolia')
 
       // Test Prod environment
-      expect(apiUrl(Environment.Prod, 'mainnet')).toBe('https://api.cow.finance/mainnet')
-      expect(apiUrl(Environment.Prod, 'goerli')).toBe('https://api.cow.finance/goerli')
-      expect(apiUrl(Environment.Prod, 'sepolia')).toBe('https://api.cow.finance/sepolia')
+      expect(apiUrl(Environment.Prod, 'mainnet')).toBe('https://api.cow.fi/mainnet')
+      expect(apiUrl(Environment.Prod, 'goerli')).toBe('https://api.cow.fi/goerli')
+      expect(apiUrl(Environment.Prod, 'sepolia')).toBe('https://api.cow.fi/sepolia')
     })
 
     test('should throw error for invalid environment', () => {
@@ -131,11 +131,11 @@ describe('API Functions and Classes', () => {
 
       // All should have the same properties
       expect(ethersV5Api.network).toBe('mainnet')
-      expect(ethersV5Api.baseUrl).toBe('https://api.cow.finance/mainnet')
+      expect(ethersV5Api.baseUrl).toBe('https://api.cow.fi/mainnet')
       expect(ethersV6Api.network).toBe('mainnet')
-      expect(ethersV6Api.baseUrl).toBe('https://api.cow.finance/mainnet')
+      expect(ethersV6Api.baseUrl).toBe('https://api.cow.fi/mainnet')
       expect(viemApi.network).toBe('mainnet')
-      expect(viemApi.baseUrl).toBe('https://api.cow.finance/mainnet')
+      expect(viemApi.baseUrl).toBe('https://api.cow.fi/mainnet')
     })
   })
 
@@ -286,7 +286,7 @@ describe('API Functions and Classes', () => {
       // Verify fetch was called with correct parameters
       expect(mockFetch).toHaveBeenCalledTimes(3)
       const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]
-      expect(lastCall?.[0]).toBe('https://api.cow.finance/mainnet/api/v1/orders')
+      expect(lastCall?.[0]).toBe('https://api.cow.fi/mainnet/api/v1/orders')
       expect(lastCall?.[1]?.method).toBe('post')
       expect(lastCall?.[1]?.headers).toEqual({ 'Content-Type': 'application/json' })
     })

--- a/packages/flash-loans/README.md
+++ b/packages/flash-loans/README.md
@@ -47,7 +47,7 @@ npm install @cowprotocol/sdk-trading
 ## Setup
 
 You need:
-- `chainId` - Supported chain ID (see [SDK config](https://docs.cow.finance/cow-protocol/reference/sdks/core-utilities/sdk-config))
+- `chainId` - Supported chain ID (see [SDK config](https://docs.cow.fi/cow-protocol/reference/sdks/core-utilities/sdk-config))
 - `appCode` - Unique app identifier for tracking orders
 - `signer` - Private key, ethers signer, or `Eip1193` provider
 - `TradingSdk` instance - For getting quotes and posting orders
@@ -501,6 +501,6 @@ Adapter contracts are:
 ## Resources
 
 - [Aave Flash Loans Documentation](https://docs.aave.com/developers/guides/flash-loans)
-- [CoW Protocol Documentation](https://docs.cow.finance/)
-- [CoW Protocol Hooks](https://docs.cow.finance/cow-protocol/reference/core/intents/hooks)
+- [CoW Protocol Documentation](https://docs.cow.fi/)
+- [CoW Protocol Hooks](https://docs.cow.fi/cow-protocol/reference/core/intents/hooks)
 - [EIP-1271 Specification](https://eips.ethereum.org/EIPS/eip-1271)

--- a/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
+++ b/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
@@ -91,7 +91,7 @@ export type AaveCollateralSwapSdkConfig = {
  *          complex flow of flash loans, order creation, and hook configuration.
  *
  * @see https://docs.aave.com/developers/guides/flash-loans
- * @see https://docs.cow.finance/
+ * @see https://docs.cow.fi/
  */
 export class AaveCollateralSwapSdk {
   private readonly hookAdapterPerType: Record<AaveFlashLoanType, Record<SupportedChainId, string>>

--- a/packages/order-book/README.md
+++ b/packages/order-book/README.md
@@ -127,8 +127,8 @@ Partners can use the Partner API for authenticated, rate-limited access with hig
 
 | Environment | Partner API Base URL |
 |-------------|---------------------|
-| Production  | `https://partners.cow.finance` |
-| Staging     | `https://partners.barn.cow.finance` |
+| Production  | `https://partners.cow.fi` |
+| Staging     | `https://partners.barn.cow.fi` |
 
 ```typescript
 const orderBookApi = new OrderBookApi({

--- a/packages/order-book/src/api.spec.ts
+++ b/packages/order-book/src/api.spec.ts
@@ -117,13 +117,13 @@ describe('CoW Api', () => {
 
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(fetchMock).toHaveBeenCalledWith('https://api.cow.finance/xdai/api/v1/version', FETCH_RESPONSE_PARAMETERS)
+    expect(fetchMock).toHaveBeenCalledWith('https://api.cow.fi/xdai/api/v1/version', FETCH_RESPONSE_PARAMETERS)
     expect(version).toEqual('v1.2.3')
   })
 
   test('Valid: Get orders link', async () => {
     const orderLink = await orderBookApi.getOrderLink(ORDER_RESPONSE.uid)
-    expect(orderLink).toEqual(`https://api.cow.finance/xdai/api/v1/orders/${ORDER_RESPONSE.uid}`)
+    expect(orderLink).toEqual(`https://api.cow.fi/xdai/api/v1/orders/${ORDER_RESPONSE.uid}`)
   })
 
   test('Valid: Get an order', async () => {
@@ -139,7 +139,7 @@ describe('CoW Api', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v1/orders/${ORDER_RESPONSE.uid}`,
+      `https://api.cow.fi/xdai/api/v1/orders/${ORDER_RESPONSE.uid}`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(order?.uid).toEqual(ORDER_RESPONSE.uid)
@@ -158,7 +158,7 @@ describe('CoW Api', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/mainnet/api/v1/orders/${ORDER_RESPONSE.uid}`,
+      `https://api.cow.fi/mainnet/api/v1/orders/${ORDER_RESPONSE.uid}`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(order?.class).toEqual('limit')
@@ -188,7 +188,7 @@ describe('CoW Api', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.cow.finance/xdai/api/v1/orders/notValidOrderId',
+      'https://api.cow.fi/xdai/api/v1/orders/notValidOrderId',
       FETCH_RESPONSE_PARAMETERS,
     )
   })
@@ -203,7 +203,7 @@ describe('CoW Api', () => {
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.cow.finance/xdai/api/v1/account/0x00000000005ef87f8ca7014309ece7260bbcdaeb/orders?offset=0&limit=5',
+      'https://api.cow.fi/xdai/api/v1/account/0x00000000005ef87f8ca7014309ece7260bbcdaeb/orders?offset=0&limit=5',
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(orders.length).toEqual(5)
@@ -237,7 +237,7 @@ describe('CoW Api', () => {
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.cow.finance/xdai/api/v1/account/invalidOwner/orders?offset=0&limit=5',
+      'https://api.cow.fi/xdai/api/v1/account/invalidOwner/orders?offset=0&limit=5',
       FETCH_RESPONSE_PARAMETERS,
     )
   })
@@ -249,7 +249,7 @@ describe('CoW Api', () => {
     const txOrders = await orderBookApi.getTxOrders(txHash)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v1/transactions/${txHash}/orders`,
+      `https://api.cow.fi/xdai/api/v1/transactions/${txHash}/orders`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(txOrders.length).toEqual(5)
@@ -279,7 +279,7 @@ describe('CoW Api', () => {
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.cow.finance/xdai/api/v1/transactions/invalidTxHash/orders',
+      'https://api.cow.fi/xdai/api/v1/transactions/invalidTxHash/orders',
       FETCH_RESPONSE_PARAMETERS,
     )
   })
@@ -292,7 +292,7 @@ describe('CoW Api', () => {
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v2/trades?owner=${TRADE_RESPONSE.owner}&offset=0&limit=10`,
+      `https://api.cow.fi/xdai/api/v2/trades?owner=${TRADE_RESPONSE.owner}&offset=0&limit=10`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(trades.length).toEqual(5)
@@ -307,7 +307,7 @@ describe('CoW Api', () => {
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v2/trades?orderUid=${TRADE_RESPONSE.orderUid}&offset=0&limit=10`,
+      `https://api.cow.fi/xdai/api/v2/trades?orderUid=${TRADE_RESPONSE.orderUid}&offset=0&limit=10`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(trades.length).toEqual(5)
@@ -348,7 +348,7 @@ describe('CoW Api', () => {
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.cow.finance/xdai/api/v2/trades?owner=invalidOwner&offset=0&limit=10',
+      'https://api.cow.fi/xdai/api/v2/trades?owner=invalidOwner&offset=0&limit=10',
       FETCH_RESPONSE_PARAMETERS,
     )
   })
@@ -361,7 +361,7 @@ describe('CoW Api', () => {
     await orderBookApi.sendSignedOrderCancellations(body)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v1/orders`,
+      `https://api.cow.fi/xdai/api/v1/orders`,
       expect.objectContaining({
         ...RAW_FETCH_RESPONSE_PARAMETERS,
         body: JSON.stringify(body),
@@ -396,7 +396,7 @@ describe('CoW Api', () => {
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.cow.finance/xdai/api/v1/orders',
+      'https://api.cow.fi/xdai/api/v1/orders',
       expect.objectContaining({
         ...RAW_FETCH_RESPONSE_PARAMETERS,
         body: JSON.stringify(body),
@@ -422,7 +422,7 @@ describe('CoW Api', () => {
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.cow.finance/xdai/api/v1/orders',
+      'https://api.cow.fi/xdai/api/v1/orders',
       expect.objectContaining({
         ...RAW_FETCH_RESPONSE_PARAMETERS,
         body: JSON.stringify({
@@ -464,7 +464,7 @@ describe('CoW Api', () => {
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.cow.finance/xdai/api/v1/orders',
+      'https://api.cow.fi/xdai/api/v1/orders',
       expect.objectContaining({
         ...RAW_FETCH_RESPONSE_PARAMETERS,
         body: JSON.stringify({
@@ -488,7 +488,7 @@ describe('CoW Api', () => {
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.cow.finance/xdai/api/v1/account/0x00000000005ef87f8ca7014309ece7260bbcdaeb/orders?offset=0&limit=5',
+      'https://api.cow.fi/xdai/api/v1/account/0x00000000005ef87f8ca7014309ece7260bbcdaeb/orders?offset=0&limit=5',
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(orders.length).toEqual(5)
@@ -502,7 +502,7 @@ describe('CoW Api', () => {
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v2/trades?owner=${TRADE_RESPONSE.owner}&offset=0&limit=10`,
+      `https://api.cow.fi/xdai/api/v2/trades?owner=${TRADE_RESPONSE.owner}&offset=0&limit=10`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(trades.length).toEqual(5)
@@ -581,7 +581,7 @@ describe('CoW Api', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v1/orders/${ORDER_RESPONSE.uid}`,
+      `https://api.cow.fi/xdai/api/v1/orders/${ORDER_RESPONSE.uid}`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(order?.class).toEqual('limit')
@@ -604,11 +604,11 @@ describe('CoW Api', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v1/orders/${ORDER_RESPONSE.uid}`,
+      `https://api.cow.fi/xdai/api/v1/orders/${ORDER_RESPONSE.uid}`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://barn.api.cow.finance/xdai/api/v1/orders/${ORDER_RESPONSE.uid}`,
+      `https://barn.api.cow.fi/xdai/api/v1/orders/${ORDER_RESPONSE.uid}`,
       FETCH_RESPONSE_PARAMETERS,
     )
   })
@@ -630,7 +630,7 @@ describe('CoW Api', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v1/users/${address}/total_surplus`,
+      `https://api.cow.fi/xdai/api/v1/users/${address}/total_surplus`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(surplus).toEqual(totalSurplus)
@@ -653,7 +653,7 @@ describe('CoW Api', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v1/app_data/${appDataHash}`,
+      `https://api.cow.fi/xdai/api/v1/app_data/${appDataHash}`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(appData).toEqual(appDataBody)
@@ -676,7 +676,7 @@ describe('CoW Api', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v1/app_data/${appDataHash}`,
+      `https://api.cow.fi/xdai/api/v1/app_data/${appDataHash}`,
       expect.objectContaining({
         body: JSON.stringify(appDataBody),
         method: 'PUT',
@@ -699,7 +699,7 @@ describe('CoW Api', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v1/solver_competition/${auctionId}`,
+      `https://api.cow.fi/xdai/api/v1/solver_competition/${auctionId}`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(competition).toEqual(AUCTION)
@@ -719,7 +719,7 @@ describe('CoW Api', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.finance/xdai/api/v1/solver_competition/by_tx_hash/${txHash}`,
+      `https://api.cow.fi/xdai/api/v1/solver_competition/by_tx_hash/${txHash}`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(competition).toEqual(AUCTION)

--- a/packages/order-book/src/api.ts
+++ b/packages/order-book/src/api.ts
@@ -30,14 +30,14 @@ import { DEFAULT_BACKOFF_OPTIONS, DEFAULT_LIMITER_OPTIONS, FetchParams, OrderBoo
 import { transformOrder } from './transformOrder'
 import { EnrichedOrder } from './types'
 
-const PROD_BASE_URL = 'https://api.cow.finance'
-const STAGING_BASE_URL = 'https://barn.api.cow.finance'
-const PARTNER_PROD_BASE_URL = 'https://partners.cow.finance'
-const PARTNER_STAGING_BASE_URL = 'https://partners.barn.cow.finance'
+const PROD_BASE_URL = 'https://api.cow.fi'
+const STAGING_BASE_URL = 'https://barn.api.cow.fi'
+const PARTNER_PROD_BASE_URL = 'https://partners.cow.fi'
+const PARTNER_STAGING_BASE_URL = 'https://partners.barn.cow.fi'
 
 /**
  * An object containing *production* environment base URLs for each supported `chainId`.
- * @see {@link https://api.cow.finance/docs/#/}
+ * @see {@link https://api.cow.fi/docs/#/}
  */
 export const ORDER_BOOK_PROD_CONFIG: ApiBaseUrls = {
   [SupportedChainId.MAINNET]: `${PROD_BASE_URL}/mainnet`,
@@ -73,7 +73,7 @@ export const ORDER_BOOK_STAGING_CONFIG: ApiBaseUrls = {
 /**
  * An object containing *partner production* environment base URLs for each supported `chainId`.
  * Used when apiKey is set; requests include X-API-Key header.
- * @see {@link https://partners.cow.finance}
+ * @see {@link https://partners.cow.fi}
  */
 export const ORDER_BOOK_PARTNER_PROD_CONFIG: ApiBaseUrls = {
   [SupportedChainId.MAINNET]: `${PARTNER_PROD_BASE_URL}/mainnet`,
@@ -92,7 +92,7 @@ export const ORDER_BOOK_PARTNER_PROD_CONFIG: ApiBaseUrls = {
 /**
  * An object containing *partner staging* environment base URLs for each supported `chainId`.
  * Used when apiKey is set and env is staging; requests include X-API-Key header.
- * @see {@link https://partners.barn.cow.finance}
+ * @see {@link https://partners.barn.cow.fi}
  */
 export const ORDER_BOOK_PARTNER_STAGING_CONFIG: ApiBaseUrls = {
   [SupportedChainId.MAINNET]: `${PARTNER_STAGING_BASE_URL}/mainnet`,
@@ -193,7 +193,7 @@ export type GetTradesRequest = {
  * }
  * ```
  *
- * @see {@link Swagger documentation https://api.cow.finance/docs/#/}
+ * @see {@link Swagger documentation https://api.cow.fi/docs/#/}
  * @see {@link OrderBook API https://github.com/cowprotocol/services}
  */
 export class OrderBookApi {
@@ -214,7 +214,7 @@ export class OrderBookApi {
    * Get the version of the API.
    * @param contextOverride Optional context override for this request.
    * @returns The version of the API.
-   * @see {@link https://api.cow.finance/docs/#/default/get_api_v1_version}
+   * @see {@link https://api.cow.fi/docs/#/default/get_api_v1_version}
    */
   getVersion(contextOverride: PartialApiContext = {}): Promise<string> {
     return this.fetch({ path: '/api/v1/version', method: 'GET' }, contextOverride)

--- a/packages/order-book/src/quoteAmountsAndCosts/README.md
+++ b/packages/order-book/src/quoteAmountsAndCosts/README.md
@@ -1,7 +1,7 @@
 # CoW Protocol Order Amounts and Costs
 
 This document explains how CoW Protocol calculates order amounts and costs,
-from the initial `https://api.cow.finance/mainnet/api/v1/quote` API response to the final signed order.
+from the initial `https://api.cow.fi/mainnet/api/v1/quote` API response to the final signed order.
 
 ## 1. What `/quote` API returns
 
@@ -41,7 +41,7 @@ Quote API response example:
 
 An order example:
 ```
-https://api.cow.finance/mainnet/api/v1/orders/0xeaed649f015a7d39c47cc9edf9e0d503cac55c9420cbf1951e3017c50a8d5c36d8da6bf26964af9d7eed9e03e53415d37aa9604568401277
+https://api.cow.fi/mainnet/api/v1/orders/0xeaed649f015a7d39c47cc9edf9e0d503cac55c9420cbf1951e3017c50a8d5c36d8da6bf26964af9d7eed9e03e53415d37aa9604568401277
 ```
 
 The response `quote` field contains three amount fields:

--- a/packages/order-book/src/request.test.ts
+++ b/packages/order-book/src/request.test.ts
@@ -4,7 +4,7 @@ import { RateLimiter } from 'limiter'
 
 fetchMock.enableMocks()
 
-const URL = 'https://cow.finance'
+const URL = 'https://cow.fi'
 const ERROR_MESSAGE = '💣💥 Booom!'
 
 const OK_RESPONSE = {

--- a/packages/order-signing/src/orderSigningUtils.ts
+++ b/packages/order-signing/src/orderSigningUtils.ts
@@ -32,7 +32,7 @@ export const COW_EIP712_TYPES = {
  * Utility class for signing order intents and cancellations.
  *
  * @remarks This class only supports `eth_sign` and wallet-native EIP-712 signing. For use of
- *          `presign` and `eip1271` {@link https://docs.cow.finance/ | see the docs}.
+ *          `presign` and `eip1271` {@link https://docs.cow.fi/ | see the docs}.
  * @example
  *
  * ```typescript

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -4,7 +4,7 @@
 
 # CoW SDK
 
-## 📚 [Docs website](https://docs.cow.finance/)
+## 📚 [Docs website](https://docs.cow.fi/)
 
 ## Test coverage
 
@@ -31,13 +31,13 @@ The SDK supports all CoW Protocol enabled networks:
 
 ## 🔗 **Related Resources**
 
-- **[CoW Protocol Documentation](https://docs.cow.finance/)**
-- **[API Reference](https://api.cow.finance/docs/)**
-- **[CoW Protocol Website](https://cow.finance/)**
+- **[CoW Protocol Documentation](https://docs.cow.fi/)**
+- **[API Reference](https://api.cow.fi/docs/)**
+- **[CoW Protocol Website](https://cow.fi/)**
 - **[Examples Repository](https://github.com/cowprotocol/cow-sdk/tree/main/examples)**
 - **Issues**: [GitHub Issues](https://github.com/cowprotocol/cow-sdk/issues)
 - **Discord**: [CoW Protocol Discord](https://discord.com/invite/cowprotocol)
-- **Documentation**: [docs.cow.finance](https://docs.cow.finance/)
+- **Documentation**: [docs.cow.fi](https://docs.cow.fi/)
 
 ## Getting Started
 
@@ -81,7 +81,7 @@ The `@cowprotocol/cow-sdk` provides tools at different abstraction levels, allow
 
 ### Advanced
 - **[`BridgingSdk`](https://github.com/cowprotocol/cow-sdk/tree/main/packages/bridging/README.md)** - Cross-chain token transfers and bridging functionality
-- **[`ConditionalOrder`](https://github.com/cowprotocol/cow-sdk/tree/main/packages/composable/README.md)** - SDK for Programmatic Orders such as TWAP ([Read more](https://docs.cow.finance/cow-protocol/concepts/order-types/programmatic-orders))
+- **[`ConditionalOrder`](https://github.com/cowprotocol/cow-sdk/tree/main/packages/composable/README.md)** - SDK for Programmatic Orders such as TWAP ([Read more](https://docs.cow.fi/cow-protocol/concepts/order-types/programmatic-orders))
 - **[`CowShedSdk`](https://github.com/cowprotocol/cow-sdk/tree/main/packages/cow-shed/README.md)** - Account abstraction that leverages EOA with smart contract capabilities
 
 ## v6 → v7 Migration Guide
@@ -290,7 +290,7 @@ const orderBookApi = new OrderBookApi({
 })
 ```
 
-By default, the SDK routes requests through `partners.cow.finance` (prod) or `partners.barn.cow.finance` (staging) and includes the `X-API-Key` header. If you provide custom `baseUrls`, those take precedence over the default partner hosts, but the `X-API-Key` header is still sent with every request.
+By default, the SDK routes requests through `partners.cow.fi` (prod) or `partners.barn.cow.fi` (staging) and includes the `X-API-Key` header. If you provide custom `baseUrls`, those take precedence over the default partner hosts, but the `X-API-Key` header is still sent with every request.
 
 See the [OrderBookApi documentation](https://github.com/cowprotocol/cow-sdk/tree/main/packages/order-book/README.md#partner-api-authenticated-access) for more details, including usage with the Trading SDK.
 

--- a/packages/trading/README.md
+++ b/packages/trading/README.md
@@ -65,7 +65,7 @@ Special cases:
 
 You need:
 
-- `chainId` - Supported chain ID ([see list](https://docs.cow.finance/cow-protocol/reference/sdks/core-utilities/sdk-config)).
+- `chainId` - Supported chain ID ([see list](https://docs.cow.fi/cow-protocol/reference/sdks/core-utilities/sdk-config)).
 - `appCode` - Unique app identifier for tracking orders.
 - `signer` - Private key, ethers signer, or `Eip1193` provider (optional - will use global adapter's signer if not provided).
 
@@ -159,9 +159,9 @@ The function returns `quoteResults` object with the following properties:
 
 - `tradeParameters` - trade type, assets, amounts and other optional parameters
 - `amountsAndCosts` - the order sell/buy amounts including network costs, fees and slippage
-- `orderToSign` - order parameters to sign (see [order signing](https://docs.cow.finance/cow-protocol/reference/sdks/cow-sdk/classes/OrderSigningUtils))
-- `quoteResponse` - DTO from [quote API](https://api.cow.finance/docs/#/default/post_api_v1_quote)
-- `appDataInfo` - [order's metadata](https://docs.cow.finance/cow-protocol/reference/sdks/app-data)
+- `orderToSign` - order parameters to sign (see [order signing](https://docs.cow.fi/cow-protocol/reference/sdks/cow-sdk/classes/OrderSigningUtils))
+- `quoteResponse` - DTO from [quote API](https://api.cow.fi/docs/#/default/post_api_v1_quote)
+- `appDataInfo` - [order's metadata](https://docs.cow.fi/cow-protocol/reference/sdks/app-data)
 - `orderTypedData` - EIP-712 typed data for signing
 
 Another parameter is returned by this function is `postSwapOrderFromQuote`.
@@ -536,7 +536,7 @@ See `TradeOptionalParameters` type for more details.
 | `slippageBps`       | `number`     | 50                | Slippage tolerance applied to the order to get the limit price. Expressed in Basis Points (BPS). One basis point is equivalent to 0.01% (1/100th of a percent).                                   |
 | `receiver`          | `string`     | order creator     | The address that will receive the order's tokens.                                                                                                                                                 |
 | `validFor`          | `number`     | 30 mins           | The order expiration time in seconds.                                                                                                                                                             |
-| `partnerFee`        | `PartnerFee` | -                 | Partners of the protocol can specify their fee for the order, including the fee in basis points (BPS) and the fee recipient address. [Read more](https://docs.cow.finance/governance/fees/partner-fee) |
+| `partnerFee`        | `PartnerFee` | -                 | Partners of the protocol can specify their fee for the order, including the fee in basis points (BPS) and the fee recipient address. [Read more](https://docs.cow.fi/governance/fees/partner-fee) |
 
 ##### Example
 
@@ -585,8 +585,8 @@ However, you can provide additional parameters to customize the order creation.
 
 #### Swap
 
-1. `quoteRequest` - the quote request object. It is used to get a quote from the quote API ([read more](https://docs.cow.finance/cow-protocol/reference/sdks/cow-sdk/modules#orderquoterequest))
-2. `appData` - the order's metadata ([read more](https://docs.cow.finance/cow-protocol/reference/sdks/app-data/modules#appdataparams))
+1. `quoteRequest` - the quote request object. It is used to get a quote from the quote API ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/cow-sdk/modules#orderquoterequest))
+2. `appData` - the order's metadata ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/app-data/modules#appdataparams))
 
 ##### Example
 
@@ -690,7 +690,7 @@ console.log('Buy amount:', order.buyAmount)
 
 Cancels an order off-chain by sending a signed cancellation request to the order book API. This is a "soft cancel" that is faster and doesn't require gas, but requires order book support.
 
-You always can cancel orders using [CoW Swap](https://swap.cow.finance), [see the tutorial for more details](https://docs.cow.finance/cow-protocol/tutorials/cow-swap/swap#cancel-your-order).
+You always can cancel orders using [CoW Swap](https://swap.cow.fi), [see the tutorial for more details](https://docs.cow.fi/cow-protocol/tutorials/cow-swap/swap#cancel-your-order).
 
 **Parameters:**
 - `orderUid` - The unique identifier of the order to cancel

--- a/packages/trading/src/README.md
+++ b/packages/trading/src/README.md
@@ -16,8 +16,8 @@ It will put all necessary parameters to your order, calculates proper amounts, a
 
 ### Why Use This SDK?
 
-- [App-data](https://docs.cow.finance/cow-protocol/reference/sdks/app-data) (order metadata)
-- [Order signing](https://docs.cow.finance/cow-protocol/reference/sdks/cow-sdk/classes/OrderSigningUtils)
+- [App-data](https://docs.cow.fi/cow-protocol/reference/sdks/app-data) (order metadata)
+- [Order signing](https://docs.cow.fi/cow-protocol/reference/sdks/cow-sdk/classes/OrderSigningUtils)
 - Network costs, fees, and slippage
 - Order parameters (validity, partial fills, etc.)
 - Quote API settings (price quality, signing scheme, etc.)
@@ -43,7 +43,7 @@ Special cases:
 
 You need:
 
-- `chainId` - Supported chain ID ([see list](https://docs.cow.finance/cow-protocol/reference/sdks/core-utilities/sdk-config)).
+- `chainId` - Supported chain ID ([see list](https://docs.cow.fi/cow-protocol/reference/sdks/core-utilities/sdk-config)).
 - `signer` - Private key, ethers signer, or `Eip1193` provider.
 - `appCode` - Unique app identifier for tracking orders.
 
@@ -89,9 +89,9 @@ The function returns `quoteResults` object with the following properties:
 
 - `tradeParameters` - trade type, assets, amounts and other optional parameters
 - `amountsAndCosts` - the order sell/buy amounts including network costs, fees and slippage
-- `orderToSign` - order parameters to sign (see [order signing](https://docs.cow.finance/cow-protocol/reference/sdks/cow-sdk/classes/OrderSigningUtils))
-- `quoteResponse` - DTO from [quote API](https://api.cow.finance/docs/#/default/post_api_v1_quote)
-- `appDataInfo` - [order's metadata](https://docs.cow.finance/cow-protocol/reference/sdks/app-data)
+- `orderToSign` - order parameters to sign (see [order signing](https://docs.cow.fi/cow-protocol/reference/sdks/cow-sdk/classes/OrderSigningUtils))
+- `quoteResponse` - DTO from [quote API](https://api.cow.fi/docs/#/default/post_api_v1_quote)
+- `appDataInfo` - [order's metadata](https://docs.cow.fi/cow-protocol/reference/sdks/app-data)
 - `orderTypedData` - EIP-712 typed data for signing
 
 Another parameter is returned by this function is `postSwapOrderFromQuote`.
@@ -386,7 +386,7 @@ See `TradeOptionalParameters` type for more details.
 | `slippageBps`        | `number`       | 50                | Slippage tolerance applied to the order to get the limit price. Expressed in Basis Points (BPS). One basis point is equivalent to 0.01% (1/100th of a percent). |
 | `receiver`           | `string`       | order creator     | The address that will receive the order's tokens.                                                                                                               |
 | `validFor` / `validTo` | `number`       | 30 mins (validFor) | Order expiration: Use `validFor` for seconds from now (e.g., 600 = 10 mins), OR use `validTo` for exact timestamp (e.g., 2524608000). Cannot use both.      |
-| `partnerFee`         | `PartnerFee`   | -                 | Partners of the protocol can specify their fee for the order, including the fee in basis points (BPS) and the fee recipient address. [Read more](https://docs.cow.finance/governance/fees/partner-fee)                  |
+| `partnerFee`         | `PartnerFee`   | -                 | Partners of the protocol can specify their fee for the order, including the fee in basis points (BPS) and the fee recipient address. [Read more](https://docs.cow.fi/governance/fees/partner-fee)                  |
 
 ##### Example
 
@@ -430,8 +430,8 @@ However, you can provide additional parameters to customize the order creation.
 
 #### Swap
 
-1. `quoteRequest` - the quote request object. It is used to get a quote from the quote API ([read more](https://docs.cow.finance/cow-protocol/reference/sdks/cow-sdk/modules#orderquoterequest))
-2. `appData` - the order's metadata ([read more](https://docs.cow.finance/cow-protocol/reference/sdks/app-data/modules#appdataparams))
+1. `quoteRequest` - the quote request object. It is used to get a quote from the quote API ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/cow-sdk/modules#orderquoterequest))
+2. `appData` - the order's metadata ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/app-data/modules#appdataparams))
 
 ##### Example
 


### PR DESCRIPTION
Important! This is going to be a major version bump.

Revert of https://github.com/cowprotocol/cow-sdk/pull/860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain from `cow.finance` to `cow.fi` across CDN URLs, API endpoints, documentation links, and partner domains.
  * Updated S3 deployment target for SDK artifacts.
  * Simplified release configuration by removing prerelease mode.

* **Tests**
  * Updated test assertions to reflect new API domain endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->