### PR TITLE
fix(trading): take protocol fee into account

### DIFF
--- a/packages/trading/src/getEthFlowTransaction.ts
+++ b/packages/trading/src/getEthFlowTransaction.ts
@@ -5,12 +5,7 @@ import {
 } from './types'
 import { calculateUniqueOrderId } from './calculateUniqueOrderId'
 import { getOrderToSign } from './getOrderToSign'
-import {
-  SupportedChainId,
-  BARN_ETH_FLOW_ADDRESSES,
-  ETH_FLOW_ADDRESSES,
-  ProtocolOptions,
-} from '@cowprotocol/sdk-config'
+import { SupportedChainId, BARN_ETH_FLOW_ADDRESSES, ETH_FLOW_ADDRESSES, ProtocolOptions } from '@cowprotocol/sdk-config'
 import { GAS_LIMIT_DEFAULT } from './consts'
 import { adjustEthFlowOrderParams, calculateGasMargin } from './utils/misc'
 import {
@@ -33,7 +28,7 @@ export async function getEthFlowTransaction(
 ): Promise<{ orderId: string; transaction: TransactionParams; orderToSign: UnsignedOrder }> {
   const signer = paramSigner ? getGlobalAdapter().createSigner(paramSigner) : getGlobalAdapter().signer
 
-  const { networkCostsAmount = '0', checkEthFlowOrderExists } = additionalParams
+  const { networkCostsAmount = '0', checkEthFlowOrderExists, protocolFeeBps } = additionalParams
   const from = await signer.getAddress()
   const slippageBps = _params.slippageBps ?? getDefaultSlippageBps(chainId, true)
 
@@ -57,6 +52,7 @@ export async function getEthFlowTransaction(
       isEthFlow: true,
       from,
       networkCostsAmount,
+      protocolFeeBps,
     },
     params,
     appDataKeccak256,

--- a/packages/trading/src/postCoWProtocolTrade.test.ts
+++ b/packages/trading/src/postCoWProtocolTrade.test.ts
@@ -216,6 +216,35 @@ describe('postCoWProtocolTrade', () => {
     }
   })
 
+  it('When protocolFeeBps is in additionalParams with partnerFee, then buyAmount should account for protocol fee in partner fee base', async () => {
+    const expectedBuyAmountWithProtocolFee = '1970090045022511257'
+    const expectedBuyAmountWithoutProtocolFee = '1970100000000000000'
+
+    const orderWithPartnerFee: LimitOrderParameters = {
+      ...defaultOrderParams,
+      partnerFee: { volumeBps: 100, recipient: '0xfeerecipient' },
+    }
+
+    const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
+    for (const adapterName of adapterNames) {
+      setGlobalAdapter(adapters[adapterName])
+
+      await postCoWProtocolTrade(orderBookApiMock, appDataMock, orderWithPartnerFee, {}, adapters[adapterName].signer)
+      expect(sendOrderMock.mock.calls[0][0].buyAmount).toBe(expectedBuyAmountWithoutProtocolFee)
+      sendOrderMock.mockReset()
+
+      await postCoWProtocolTrade(
+        orderBookApiMock,
+        appDataMock,
+        orderWithPartnerFee,
+        { protocolFeeBps: 5 },
+        adapters[adapterName].signer,
+      )
+      expect(sendOrderMock.mock.calls[0][0].buyAmount).toBe(expectedBuyAmountWithProtocolFee)
+      sendOrderMock.mockReset()
+    }
+  })
+
   describe('settlementContractOverride', () => {
     it('should pass settlementContractOverride to signOrder', async () => {
       const customAddress = '0x1111111111111111111111111111111111111111'

--- a/packages/trading/src/postCoWProtocolTrade.ts
+++ b/packages/trading/src/postCoWProtocolTrade.ts
@@ -21,6 +21,7 @@ export async function postCoWProtocolTrade(
     signingScheme: _signingScheme = SigningScheme.EIP712,
     customEIP1271Signature,
     applyCostsSlippageAndFees,
+    protocolFeeBps,
   } = additionalParams
 
   const isEthFlow = getIsEthFlowOrder(params)
@@ -44,7 +45,7 @@ export async function postCoWProtocolTrade(
   const from = owner || (await signer.getAddress())
 
   const orderToSign = getOrderToSign(
-    { chainId, from, networkCostsAmount, isEthFlow, applyCostsSlippageAndFees },
+    { chainId, from, networkCostsAmount, isEthFlow, applyCostsSlippageAndFees, protocolFeeBps },
     params,
     appData.appDataKeccak256,
   )
@@ -66,12 +67,10 @@ export async function postCoWProtocolTrade(
         }
       }
 
-      const signingResult = await OrderSigningUtils.signOrder(
-        orderToSign,
-        chainId,
-        signer,
-        { env, settlementContractOverride },
-      )
+      const signingResult = await OrderSigningUtils.signOrder(orderToSign, chainId, signer, {
+        env,
+        settlementContractOverride,
+      })
 
       if (isEip1271) {
         return {

--- a/packages/trading/src/postSwapOrder.test.ts
+++ b/packages/trading/src/postSwapOrder.test.ts
@@ -1,6 +1,6 @@
 import { getQuoteWithSigner } from './getQuote'
 import { SupportedChainId } from '@cowprotocol/sdk-config'
-import { OrderKind } from '@cowprotocol/sdk-order-book'
+import { getQuoteAmountsAndCosts, OrderKind } from '@cowprotocol/sdk-order-book'
 import { postSwapOrderFromQuote } from './postSwapOrder'
 import { SwapParameters } from './types'
 import { AdaptersTestSetup, createAdapters } from '../tests/setup'
@@ -234,6 +234,67 @@ describe('postSwapOrder', () => {
       // 30000000000000000000 - (30000000000000000000 * 8 / 100) = 27600000000000000000
       expect(call.buyAmount).toBe('27600000000000000000')
     }
+  })
+
+  it('When protocolFeeBps is in quote response with partnerFee, then buyAmount should be lower than without protocolFeeBps', async () => {
+    const partnerFee = { volumeBps: 50, recipient: '0x444cc' }
+    const protocolFeeBps = 5
+
+    const orderBookApiNoPf = {
+      context: { chainId: SELL_ORDER_PARAMS.chainId },
+      getQuote: jest.fn().mockResolvedValue(SELL_ORDER_QUOTE_MOCK),
+      sendOrder: jest.fn().mockResolvedValue('0x01'),
+      uploadAppData: jest.fn().mockResolvedValue(null),
+    }
+    const orderBookApiWithPf = {
+      context: { chainId: SELL_ORDER_PARAMS.chainId },
+      getQuote: jest.fn().mockResolvedValue({ ...SELL_ORDER_QUOTE_MOCK, protocolFeeBps }),
+      sendOrder: jest.fn().mockResolvedValue('0x01'),
+      uploadAppData: jest.fn().mockResolvedValue(null),
+    }
+
+    const orderParams = { ...SELL_ORDER_PARAMS, partnerFee }
+
+    // Compute expected buyAmount with protocolFeeBps using the same function used internally
+    const { afterSlippage: expectedWithPf } = getQuoteAmountsAndCosts({
+      orderParams: SELL_ORDER_QUOTE_MOCK.quote as any,
+      slippagePercentBps: SELL_ORDER_PARAMS.slippageBps ?? 50,
+      partnerFeeBps: partnerFee.volumeBps,
+      protocolFeeBps,
+    })
+    const { afterSlippage: expectedNoPf } = getQuoteAmountsAndCosts({
+      orderParams: SELL_ORDER_QUOTE_MOCK.quote as any,
+      slippagePercentBps: SELL_ORDER_PARAMS.slippageBps ?? 50,
+      partnerFeeBps: partnerFee.volumeBps,
+      protocolFeeBps: 0,
+    })
+
+    const adapterName = Object.keys(adapters)[0] as keyof AdaptersTestSetup
+    setGlobalAdapter(adapters[adapterName])
+
+    await postSwapOrderFromQuote(
+      await getQuoteWithSigner(
+        { ...orderParams, amount: adapters[adapterName].utils.parseUnits('0.1', 18).toString() },
+        undefined,
+        orderBookApiNoPf as any,
+      ),
+    )
+    const buyAmountNoPf = orderBookApiNoPf.sendOrder.mock.calls[0][0].buyAmount
+
+    await postSwapOrderFromQuote(
+      await getQuoteWithSigner(
+        { ...orderParams, amount: adapters[adapterName].utils.parseUnits('0.1', 18).toString() },
+        undefined,
+        orderBookApiWithPf as any,
+      ),
+    )
+    const buyAmountWithPf = orderBookApiWithPf.sendOrder.mock.calls[0][0].buyAmount
+
+    // With protocolFeeBps, partner fee base (beforeAllFees.buyAmount) is larger,
+    // so partner fee amount is larger and buyAmount is lower
+    expect(BigInt(buyAmountWithPf)).toBeLessThan(BigInt(buyAmountNoPf))
+    expect(buyAmountWithPf).toBe(expectedWithPf.buyAmount.toString())
+    expect(buyAmountNoPf).toBe(expectedNoPf.buyAmount.toString())
   })
 
   it('When receiver/validTo is present in advancedSettings quoteRequest, then it should end up in the order', async () => {

--- a/packages/trading/src/postSwapOrder.ts
+++ b/packages/trading/src/postSwapOrder.ts
@@ -38,9 +38,8 @@ export async function postSwapOrderFromQuote(
       signingScheme: advancedSettings?.quoteRequest?.signingScheme,
       networkCostsAmount: quoteResponse.quote.feeAmount,
       protocolFeeBps:
-        (advancedSettings?.additionalParams?.protocolFeeBps ?? quoteResponse.protocolFeeBps)
-          ? Number(quoteResponse.protocolFeeBps)
-          : undefined,
+        advancedSettings?.additionalParams?.protocolFeeBps ??
+        (quoteResponse.protocolFeeBps ? Number(quoteResponse.protocolFeeBps) : undefined),
       ...advancedSettings?.additionalParams,
     },
     signer,

--- a/packages/trading/src/postSwapOrder.ts
+++ b/packages/trading/src/postSwapOrder.ts
@@ -37,6 +37,10 @@ export async function postSwapOrderFromQuote(
     {
       signingScheme: advancedSettings?.quoteRequest?.signingScheme,
       networkCostsAmount: quoteResponse.quote.feeAmount,
+      protocolFeeBps:
+        (advancedSettings?.additionalParams?.protocolFeeBps ?? quoteResponse.protocolFeeBps)
+          ? Number(quoteResponse.protocolFeeBps)
+          : undefined,
       ...advancedSettings?.additionalParams,
     },
     signer,

--- a/packages/trading/src/types.ts
+++ b/packages/trading/src/types.ts
@@ -306,4 +306,6 @@ export interface PostTradeAdditionalParams {
    * by the caller (for example, for limit orders that should not include these costs).
    */
   applyCostsSlippageAndFees?: boolean
+
+  protocolFeeBps?: number
 }


### PR DESCRIPTION
It turned out that the `protocolFee` was not included in the final order.
The flow is:

```
createPostSwapOrderFromQuote
->
postSwapOrderFromQuoteTrading
->
postCoWProtocolTrade
->
getOrderToSign
```

Why it affects only flows with partnerFee:
`getQuoteAmountsAndCosts()` calculates `afterPartnerFees` based on `beforeAllFees`, which in turn directly depends on the `protocolFeeBps`. If we don't set `protocolFeeBps`, then the `afterPartnerFees` will be incorrect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional protocol fee basis points configuration in trading operations to customize fees during order posting.

* **Tests**
  * Added test coverage for protocol fee handling and its effect on order buy amounts across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->