### PR TITLE
docs: remove info about umbrella sdk

### DIFF
--- a/packages/bridging/README.md
+++ b/packages/bridging/README.md
@@ -18,8 +18,6 @@ yarn add @cowprotocol/sdk-bridging
 
 ## Usage
 
-### Individual package usage
-
 ```typescript
 import {
   SupportedChainId,
@@ -74,70 +72,6 @@ const { swap, bridge, postSwapOrderFromQuote } = quoteResult
 console.log('Swap info', swap)
 
 // Display all data related to the bridge (costs, amounts, provider info, hook, and the bridging quote) ✉️
-console.log('Bridge info', bridge)
-
-// Get the buy amount after slippage in the target chain
-const { buyAmount } = bridge.amountsAndCosts.afterSlippage
-
-if (confirm(`You will get at least: ${buyAmount}, ok?`)) {
-  const orderId = await postSwapOrderFromQuote()
-  console.log('Order created, id: ', orderId)
-}
-```
-
-### Usage with CoW SDK
-
-```typescript
-import {
-  CowSdk,
-  SupportedChainId,
-  QuoteBridgeRequest,
-  OrderKind,
-  assertIsBridgeQuoteAndPost,
-} from '@cowprotocol/cow-sdk'
-import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
-import { JsonRpcProvider, Wallet } from 'ethers'
-
-// Configure the adapter
-const provider = new JsonRpcProvider('YOUR_RPC_URL')
-const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
-const adapter = new EthersV6Adapter({ provider, signer: wallet })
-
-// Initialize the unified SDK
-const sdk = new CowSdk({
-  chainId: SupportedChainId.ARBITRUM_ONE, // Source chain
-  adapter,
-})
-
-const parameters: QuoteBridgeRequest = {
-  // Cross-chain orders are always SELL orders (BUY not supported yet)
-  kind: OrderKind.SELL,
-
-  // Sell token (and source chain)
-  sellTokenChainId: SupportedChainId.ARBITRUM_ONE,
-  sellTokenAddress: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
-  sellTokenDecimals: 18,
-
-  // Buy token (and target chain)
-  buyTokenChainId: SupportedChainId.BASE,
-  buyTokenAddress: '0x4200000000000000000000000000000000000006',
-  buyTokenDecimals: 18,
-
-  // Amount to sell
-  amount: '120000000000000000',
-
-  signer: adapter.signer,
-
-  // Optional parameters
-  appCode: 'YOUR_APP_CODE',
-}
-
-const quoteResult = await bridgingSdk.getQuote(parameters)
-assertIsBridgeQuoteAndPost(quoteResult)
-const { swap, bridge, postSwapOrderFromQuote } = quoteResult
-
-// Display all data related to the swap and bridge
-console.log('Swap info', swap)
 console.log('Bridge info', bridge)
 
 // Get the buy amount after slippage in the target chain

--- a/packages/composable/README.md
+++ b/packages/composable/README.md
@@ -54,8 +54,6 @@ class CustomOrder extends ConditionalOrder<DataType, StaticType> {
 
 ## Usage
 
-### Individual package usage
-
 ```typescript
 import { ConditionalOrderFactory, Multiplexer, ConditionalOrder, ProofLocation } from '@cowprotocol/sdk-composable'
 import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
@@ -92,38 +90,6 @@ const multiplexer = new Multiplexer(SupportedChainId.MAINNET, orders, merkleRoot
 
 // Generate proofs for off-chain storage
 const proofs = multiplexer.dumpProofsAndParams()
-```
-
-### Usage with CoW SDK
-
-```typescript
-import { CowSdk, ConditionalOrderFactory, Multiplexer, ProofLocation } from '@cowprotocol/cow-sdk'
-import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
-import { JsonRpcProvider, Wallet } from 'ethers'
-
-// Configure the adapter
-const provider = new JsonRpcProvider('YOUR_RPC_URL')
-const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
-const adapter = new EthersV6Adapter({ provider, signer: wallet })
-
-// Initialize the unified SDK
-const sdk = new CowSdk({
-  chainId: SupportedChainId.MAINNET,
-  adapter,
-  composableOptions: {
-    registry: orderTypeRegistry,
-    orders: initialOrders,
-    root: merkleRoot,
-    location: ProofLocation.PRIVATE,
-  },
-})
-
-// Access composable functionality
-const factory = sdk.composable.factory
-const multiplexer = sdk.composable.multiplexer
-
-// Create conditional orders
-const conditionalOrder = factory.fromParams(orderParams)
 ```
 
 ## Conditional Order Types

--- a/packages/providers/ethers-v5-adapter/README.md
+++ b/packages/providers/ethers-v5-adapter/README.md
@@ -34,38 +34,7 @@ const wallet = new ethers.Wallet('YOUR_PRIVATE_KEY', provider)
 const adapter = new EthersV5Adapter({ provider, signer: wallet })
 ```
 
-### Using with CoW SDK
-
-```typescript
-import { CowSdk, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { EthersV5Adapter } from '@cowprotocol/sdk-ethers-v5-adapter'
-import { ethers } from 'ethers'
-
-// Configure the adapter
-const provider = new ethers.providers.JsonRpcProvider('YOUR_RPC_URL')
-const wallet = new ethers.Wallet('YOUR_PRIVATE_KEY', provider)
-const adapter = new EthersV5Adapter({ provider, signer: wallet })
-
-// Initialize the unified SDK
-const sdk = new CowSdk({
-  chainId: SupportedChainId.SEPOLIA,
-  adapter,
-  tradingOptions: {
-    traderParams: {
-      appCode: 'YOUR_APP_CODE',
-    },
-    options: {
-      chainId: SupportedChainId.SEPOLIA,
-    },
-  },
-})
-
-// Use the SDK
-const orderId = await sdk.trading.postSwapOrder(parameters)
-const orders = await sdk.orderBook.getOrders({ owner: address })
-```
-
-### Using with Individual Packages
+### Example
 
 ```typescript
 import { TradingSdk } from '@cowprotocol/sdk-trading'

--- a/packages/providers/ethers-v6-adapter/README.md
+++ b/packages/providers/ethers-v6-adapter/README.md
@@ -34,38 +34,7 @@ const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
 const adapter = new EthersV6Adapter({ provider, signer: wallet })
 ```
 
-### Using with CoW SDK
-
-```typescript
-import { CowSdk, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
-import { JsonRpcProvider, Wallet } from 'ethers'
-
-// Configure the adapter
-const provider = new JsonRpcProvider('YOUR_RPC_URL')
-const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
-const adapter = new EthersV6Adapter({ provider, signer: wallet })
-
-// Initialize the unified SDK
-const sdk = new CowSdk({
-  chainId: SupportedChainId.SEPOLIA,
-  adapter,
-  tradingOptions: {
-    traderParams: {
-      appCode: 'YOUR_APP_CODE',
-    },
-    options: {
-      chainId: SupportedChainId.SEPOLIA,
-    },
-  },
-})
-
-// Use the SDK
-const orderId = await sdk.trading.postSwapOrder(parameters)
-const orders = await sdk.orderBook.getOrders({ owner: address })
-```
-
-### Using with Individual Packages
+### Example
 
 ```typescript
 import { TradingSdk } from '@cowprotocol/sdk-trading'

--- a/packages/providers/viem-adapter/README.md
+++ b/packages/providers/viem-adapter/README.md
@@ -37,41 +37,7 @@ const provider = createPublicClient({ chain: sepolia, transport })
 const adapter = new ViemAdapter({ provider, signer: account })
 ```
 
-### Using with CoW SDK
-
-```typescript
-import { CowSdk, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
-import { http, createPublicClient, privateKeyToAccount } from 'viem'
-import { sepolia } from 'viem/chains'
-
-// Configure the adapter
-const account = privateKeyToAccount('YOUR_PRIVATE_KEY' as `0x${string}`)
-const transport = http('YOUR_RPC_URL')
-const provider = createPublicClient({ chain: sepolia, transport })
-// You also can set `walletClient` instead of `signer` using `useWalletClient` from wagmi
-const adapter = new ViemAdapter({ provider, signer: account })
-
-// Initialize the unified SDK
-const sdk = new CowSdk({
-  chainId: SupportedChainId.SEPOLIA,
-  adapter,
-  tradingOptions: {
-    traderParams: {
-      appCode: 'YOUR_APP_CODE',
-    },
-    options: {
-      chainId: SupportedChainId.SEPOLIA,
-    },
-  },
-})
-
-// Use the SDK
-const orderId = await sdk.trading.postSwapOrder(parameters)
-const orders = await sdk.orderBook.getOrders({ owner: address })
-```
-
-### Using with Individual Packages
+### Example
 
 ```typescript
 import { TradingSdk } from '@cowprotocol/sdk-trading'

--- a/packages/trading/README.md
+++ b/packages/trading/README.md
@@ -71,8 +71,6 @@ You need:
 
 ## Usage
 
-### Individual package usage
-
 ```typescript
 import { SupportedChainId, OrderKind, TradeParameters, TradingSdk } from '@cowprotocol/sdk-trading'
 import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'

--- a/packages/weiroll/README.md
+++ b/packages/weiroll/README.md
@@ -27,8 +27,6 @@ yarn add @cowprotocol/sdk-weiroll
 
 ## Usage
 
-### Individual package usage
-
 ```typescript
 import {
   WeirollPlanner,


### PR DESCRIPTION
Removed "Usage with CoW SDK" since this is an artifact of the deleted "umbrella sdk".
We have individual SDKs available separately and `@cowprotocol/cow-sdk` which only re-exports them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated usage documentation** across multiple packages with clearer examples and improved structure for consistency
* **Reorganized README sections** for better readability and streamlined guidance on getting started with individual packages
* **Clarified example sections** with standardized naming conventions throughout the SDK documentation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cow-sdk/pull/874)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->