### PR TITLE
fix: make EcdsaSigningScheme assignable to SigningScheme

### DIFF
--- a/packages/order-book/src/api.spec.ts
+++ b/packages/order-book/src/api.spec.ts
@@ -1,7 +1,8 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 import { CowError } from '@cowprotocol/sdk-common'
 import { OrderBookApi } from './api'
-import { BuyTokenDestination, EcdsaSigningScheme, OrderKind, SellTokenSource, SigningScheme } from './generated'
+import { BuyTokenDestination, OrderKind, SellTokenSource, SigningScheme } from './generated'
+import { EcdsaSigningScheme } from './signingSchemes'
 import { SupportedChainId, ETH_ADDRESS } from '@cowprotocol/sdk-config'
 import { AUCTION } from './mock'
 

--- a/packages/order-book/src/api.ts
+++ b/packages/order-book/src/api.ts
@@ -16,7 +16,6 @@ import {
   CompetitionOrderStatus,
   NativePriceResponse,
   Order,
-  OrderCancellations,
   OrderCreation,
   OrderQuoteRequest,
   OrderQuoteResponse,
@@ -29,6 +28,7 @@ import {
 import { DEFAULT_BACKOFF_OPTIONS, DEFAULT_LIMITER_OPTIONS, FetchParams, OrderBookApiError, request } from './request'
 import { transformOrder } from './transformOrder'
 import { EnrichedOrder } from './types'
+import { OrderCancellations } from './signingSchemes'
 
 const PROD_BASE_URL = 'https://api.cow.fi'
 const STAGING_BASE_URL = 'https://barn.api.cow.fi'

--- a/packages/order-book/src/index.ts
+++ b/packages/order-book/src/index.ts
@@ -3,3 +3,9 @@ export * from './types'
 export * from './generated'
 export * from './request'
 export * from './quoteAmountsAndCosts'
+
+// Override the generated `EcdsaSigningScheme` enum with a subset of `SigningScheme`
+// so its values are assignable to `SigningScheme`, plus the cancellation types that
+// depend on it. See ./signingSchemes for details.
+export { EcdsaSigningScheme } from './signingSchemes'
+export type { OrderCancellation, OrderCancellations } from './signingSchemes'

--- a/packages/order-book/src/signingSchemes.test.ts
+++ b/packages/order-book/src/signingSchemes.test.ts
@@ -1,0 +1,74 @@
+import { OrderKind, SigningScheme } from './generated'
+import type { OrderCreation } from './generated'
+import { EcdsaSigningScheme, type OrderCancellation, type OrderCancellations } from './signingSchemes'
+
+/**
+ * Regression tests for https://github.com/cowprotocol/cow-sdk/issues/187
+ *
+ * `EcdsaSigningScheme` must be a subset of `SigningScheme` so that the result of
+ * `OrderSigningUtils.signOrder()` / `signOrderCancellations()` can be passed to
+ * `OrderBookApi.sendOrder()` / `sendSignedOrderCancellations()` without a type error.
+ *
+ * The type-level `expectAssignable` checks below are enforced at compile time by
+ * ts-jest, so a regression to two nominally-unrelated enums would fail the build.
+ */
+describe('EcdsaSigningScheme', () => {
+  it('keeps the same runtime values as the matching SigningScheme members', () => {
+    expect(EcdsaSigningScheme.EIP712).toBe(SigningScheme.EIP712)
+    expect(EcdsaSigningScheme.ETHSIGN).toBe(SigningScheme.ETHSIGN)
+    expect(Object.values(EcdsaSigningScheme)).toEqual([SigningScheme.EIP712, SigningScheme.ETHSIGN])
+  })
+
+  it('only exposes the ECDSA-compatible schemes', () => {
+    expect(Object.values(EcdsaSigningScheme)).not.toContain(SigningScheme.PRESIGN)
+    expect(Object.values(EcdsaSigningScheme)).not.toContain(SigningScheme.EIP1271)
+  })
+
+  it('is assignable to SigningScheme', () => {
+    const expectAssignable = (_scheme: SigningScheme): void => undefined
+
+    expectAssignable(EcdsaSigningScheme.EIP712)
+    expectAssignable(EcdsaSigningScheme.ETHSIGN)
+
+    const scheme: EcdsaSigningScheme = EcdsaSigningScheme.EIP712
+    expectAssignable(scheme)
+  })
+
+  it('lets a signing result be spread into an OrderCreation body', () => {
+    const signingResult: { signature: string; signingScheme: EcdsaSigningScheme } = {
+      signature: '0x',
+      signingScheme: EcdsaSigningScheme.EIP712,
+    }
+
+    const order = {
+      sellToken: '0x0000000000000000000000000000000000000001',
+      buyToken: '0x0000000000000000000000000000000000000002',
+      receiver: '0x0000000000000000000000000000000000000003',
+      sellAmount: '1',
+      buyAmount: '1',
+      validTo: 0,
+      feeAmount: '0',
+      kind: OrderKind.SELL,
+      partiallyFillable: false,
+      appData: '{}',
+    }
+
+    // Would fail to compile if EcdsaSigningScheme were not assignable to SigningScheme.
+    const orderCreation: OrderCreation = { ...order, ...signingResult }
+
+    expect(orderCreation.signingScheme).toBe(SigningScheme.EIP712)
+  })
+
+  it('lets a cancellation signing result be spread into the cancellation bodies', () => {
+    const signingResult: { signature: string; signingScheme: EcdsaSigningScheme } = {
+      signature: '0x',
+      signingScheme: EcdsaSigningScheme.ETHSIGN,
+    }
+
+    const orderCancellation: OrderCancellation = { ...signingResult }
+    const orderCancellations: OrderCancellations = { ...signingResult, orderUids: ['0x'] }
+
+    expect(orderCancellation.signingScheme).toBe(SigningScheme.ETHSIGN)
+    expect(orderCancellations.signingScheme).toBe(SigningScheme.ETHSIGN)
+  })
+})

--- a/packages/order-book/src/signingSchemes.ts
+++ b/packages/order-book/src/signingSchemes.ts
@@ -1,0 +1,76 @@
+import {
+  SigningScheme,
+  type OrderCancellation as GeneratedOrderCancellation,
+  type OrderCancellations as GeneratedOrderCancellations,
+} from './generated'
+
+/**
+ * The subset of {@link SigningScheme} values that can be produced by signing an
+ * order with an ECDSA key (i.e. `eip712` and `ethsign`).
+ *
+ * The orderbook OpenAPI spec models `EcdsaSigningScheme` and `SigningScheme` as
+ * two independent string enums. When generated as TypeScript `enum`s they become
+ * nominally unrelated types, so an `EcdsaSigningScheme` value is not assignable
+ * to a `SigningScheme` field even though every `EcdsaSigningScheme` value is a
+ * valid `SigningScheme` value.
+ *
+ * This caused a type error in the documented low-level flow, where the result of
+ * `OrderSigningUtils.signOrder()` (which carries `EcdsaSigningScheme`) is spread
+ * into the `OrderCreation` body of `OrderBookApi.sendOrder()` (which expects
+ * `SigningScheme`):
+ *
+ * ```ts
+ * const { quote } = await orderBookApi.getQuote(quoteRequest)
+ * const orderSigningResult = await OrderSigningUtils.signOrder(quote, chainId, signer)
+ * // previously failed: EcdsaSigningScheme not assignable to SigningScheme
+ * const orderId = await orderBookApi.sendOrder({ ...quote, ...orderSigningResult })
+ * ```
+ *
+ * To fix this `EcdsaSigningScheme` is defined here as a genuine subset of
+ * `SigningScheme` rather than a standalone enum. It keeps the same runtime values
+ * and member names, so existing usages (`EcdsaSigningScheme.EIP712`,
+ * `Record<EcdsaSigningScheme, T>`, etc.) keep working, while values are now
+ * assignable to `SigningScheme`.
+ *
+ * @see https://github.com/cowprotocol/cow-sdk/issues/187
+ */
+export const EcdsaSigningScheme = {
+  EIP712: SigningScheme.EIP712,
+  ETHSIGN: SigningScheme.ETHSIGN,
+} as const
+
+/**
+ * How was the order signed?
+ *
+ * Subset of {@link SigningScheme} restricted to the schemes produced by ECDSA
+ * signing (`eip712` and `ethsign`). Values are assignable to `SigningScheme`.
+ */
+export type EcdsaSigningScheme = (typeof EcdsaSigningScheme)[keyof typeof EcdsaSigningScheme]
+
+/**
+ * Data a user provides when cancelling a single order.
+ *
+ * Re-typed on top of the generated `OrderCancellation` so its `signingScheme`
+ * uses the {@link EcdsaSigningScheme} subset of `SigningScheme`. This keeps the
+ * result of `OrderSigningUtils.signOrderCancellation()` directly assignable to
+ * this type.
+ *
+ * @see https://github.com/cowprotocol/cow-sdk/issues/187
+ */
+export type OrderCancellation = Omit<GeneratedOrderCancellation, 'signingScheme'> & {
+  signingScheme: EcdsaSigningScheme
+}
+
+/**
+ * Data a user provides when cancelling multiple orders.
+ *
+ * Re-typed on top of the generated `OrderCancellations` so its `signingScheme`
+ * uses the {@link EcdsaSigningScheme} subset of `SigningScheme`. This keeps the
+ * result of `OrderSigningUtils.signOrderCancellations()` directly assignable to
+ * this type.
+ *
+ * @see https://github.com/cowprotocol/cow-sdk/issues/187
+ */
+export type OrderCancellations = Omit<GeneratedOrderCancellations, 'signingScheme'> & {
+  signingScheme: EcdsaSigningScheme
+}


### PR DESCRIPTION
## Problem

The orderbook OpenAPI spec models `EcdsaSigningScheme` and `SigningScheme` as two independent string enums. The code generator (`openapi-typescript-codegen`) emits them as two separate TypeScript `enum` declarations, which TypeScript treats as **nominally unrelated** types. So an `EcdsaSigningScheme` value is not assignable to a `SigningScheme` field, even though every `EcdsaSigningScheme` value (`eip712`, `ethsign`) is also a valid `SigningScheme` value.

This breaks the documented low-level flow. `OrderSigningUtils.signOrder()` returns a `SigningResult` whose `signingScheme` is `EcdsaSigningScheme`, but `OrderBookApi.sendOrder()` expects an `OrderCreation` whose `signingScheme` is `SigningScheme`. The snippet from the docs and from the SDK's own JSDoc (`api.ts`, `orderSigningUtils.ts`) fails to type check:

```ts
const orderSigningResult = await OrderSigningUtils.signOrder(quote, chainId, signer)
// Type 'EcdsaSigningScheme' is not assignable to type 'SigningScheme'
const orderId = await orderBookApi.sendOrder({ ...quote, ...orderSigningResult })
```

The same applies to `signOrderCancellations()` / `sendSignedOrderCancellations()`. Until now consumers had to cast the value manually, and the `sdk-trading` package works around it internally with a `SIGN_SCHEME_MAP` lookup.

Reported in #187 (and seen again recently on SDK `v7.2.9`).

## Fix

Redefine the `order-book` package's public `EcdsaSigningScheme` as a genuine subset of `SigningScheme`, instead of a standalone enum. This mirrors how `sdk-contracts-ts` already models it (`export type EcdsaSigningScheme = SigningScheme.EIP712 | SigningScheme.ETHSIGN`).

- `EcdsaSigningScheme` keeps the same runtime values and member names (`EcdsaSigningScheme.EIP712`, `Record<EcdsaSigningScheme, T>`, `Object.values(...)`, etc. all keep working), but its values are now assignable to `SigningScheme`.
- `OrderCancellation` and `OrderCancellations` are re-typed on top of the generated types so their `signingScheme` uses the same subset, keeping the result of `signOrderCancellation(s)()` assignable to `sendSignedOrderCancellations()`.
- The generated files under `src/generated/` are left untouched, since they are regenerated on every build (`prebuild` runs `swagger:codegen`). The override lives entirely in the package barrel and a new non-generated `signingSchemes.ts`.

## Testing

- Added `signingSchemes.test.ts` with runtime checks plus compile-time assignability assertions (enforced by `ts-jest`), covering the exact `sendOrder` / cancellation spread scenarios from the issue.
- `pnpm build`, `pnpm typecheck`, `pnpm lint` and `pnpm test` pass for `order-book`, `order-signing`, `trading` and the umbrella `cow-sdk` package.

Fixes #187