### PR TITLE
fix(flash-loans)!: simplify CollateralSwapOrder interface

### DIFF
--- a/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
+++ b/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
@@ -146,7 +146,7 @@ export class AaveCollateralSwapSdk {
       tradeParameters: { amount },
       settings,
     } = params
-    const sellAmount = BigInt(amount)
+    const flashLoanAmount = BigInt(amount)
 
     const quoteAndPost = await tradingSdk.getQuote(quoteParams)
 
@@ -156,8 +156,7 @@ export class AaveCollateralSwapSdk {
       AaveFlashLoanType.CollateralSwap,
       quoteParams,
       {
-        sellAmount,
-        buyAmount: quoteResults.amountsAndCosts.afterSlippage.buyAmount,
+        flashLoanAmount,
         orderToSign: quoteResults.orderToSign,
         collateralPermit: settings?.collateralPermit,
       },
@@ -167,11 +166,11 @@ export class AaveCollateralSwapSdk {
       instanceAddress,
       trader: quoteParams.owner,
       collateralToken: collateralToken,
-      amount: sellAmount,
+      amount: flashLoanAmount,
     }
 
     if (!settings?.preventApproval && !settings?.collateralPermit) {
-      await this.approveCollateralIfNeeded(collateralParams, sellAmount)
+      await this.approveCollateralIfNeeded(collateralParams)
     }
 
     return postSwapOrderFromQuote(swapSettings)
@@ -240,6 +239,9 @@ export class AaveCollateralSwapSdk {
    *          and token amounts required for execution. The hooks enable the order to trigger
    *          flash loan deployment (pre-hook) and collateral swap execution (post-hook).
    *
+   * @param {AaveFlashLoanType} flashLoanType - The flash loan flow to configure (CollateralSwap,
+   *                                              DebtSwap, or RepayCollateral). Selects which Aave
+   *                                              hook adapter and post-hook call data are used.
    * @param {CollateralSwapTradeParams} params - Trade parameters including chain ID, validity period,
    *                                              owner address, and flash loan fee amount.
    * @param {CollateralSwapOrder} settings - Order configuration including sell/buy amounts, the
@@ -256,10 +258,11 @@ export class AaveCollateralSwapSdk {
     params: CollateralSwapTradeParams,
     settings: CollateralSwapOrder,
   ): Promise<CollateralSwapPostParams> {
-    const { sellAmount, buyAmount, orderToSign, collateralPermit } = settings
+    const { flashLoanAmount, orderToSign, collateralPermit } = settings
     const { chainId, flashLoanFeeAmount, validTo, owner: trader } = params
 
-    const amount = sellAmount.toString()
+    const amount = flashLoanAmount.toString()
+    const buyAmount = orderToSign.buyAmount
 
     const encodedOrder: EncodedOrder = {
       ...OrderSigningUtils.encodeUnsignedOrder(orderToSign),
@@ -271,7 +274,7 @@ export class AaveCollateralSwapSdk {
       flashLoanAmount: amount,
       flashLoanFeeAmount: flashLoanFeeAmount.toString(),
       sellAssetAmount: amount,
-      buyAssetAmount: buyAmount.toString(),
+      buyAssetAmount: buyAmount,
     }
 
     const instanceAddress = await this.getExpectedInstanceAddress(
@@ -422,14 +425,14 @@ export class AaveCollateralSwapSdk {
     })) as AccountAddress
   }
 
-  private async approveCollateralIfNeeded(collateralParams: CollateralParameters, sellAmount: bigint): Promise<void> {
+  private async approveCollateralIfNeeded(collateralParams: CollateralParameters): Promise<void> {
     const allowance = await this.getCollateralAllowance(collateralParams).catch((error) => {
       console.error('[AaveCollateralSwapSdk] Could not get allowance for collateral token', error)
 
       return null
     })
 
-    if (!allowance || allowance < sellAmount) {
+    if (!allowance || allowance < collateralParams.amount) {
       await this.approveCollateral(collateralParams)
     }
   }

--- a/packages/flash-loans/src/aave/collateralSwap.integration.test.ts
+++ b/packages/flash-loans/src/aave/collateralSwap.integration.test.ts
@@ -144,8 +144,7 @@ describe('AaveFlashLoanIntegration.collateralSwap', () => {
         flashLoanFeeAmount,
       },
       {
-        sellAmount,
-        buyAmount,
+        flashLoanAmount: sellAmount,
         orderToSign,
         collateralPermit,
       },

--- a/packages/flash-loans/src/aave/debtSwap.integration.test.ts
+++ b/packages/flash-loans/src/aave/debtSwap.integration.test.ts
@@ -88,8 +88,7 @@ describe('AaveFlashLoanIntegration.debtSwap', () => {
         flashLoanFeeAmount,
       },
       {
-        sellAmount,
-        buyAmount,
+        flashLoanAmount: sellAmount,
         orderToSign,
         collateralPermit,
       },

--- a/packages/flash-loans/src/aave/repayCollateral.integration.test.ts
+++ b/packages/flash-loans/src/aave/repayCollateral.integration.test.ts
@@ -88,8 +88,7 @@ describe('AaveFlashLoanIntegration.repayCollateral', () => {
         flashLoanFeeAmount,
       },
       {
-        sellAmount,
-        buyAmount,
+        flashLoanAmount: sellAmount,
         orderToSign,
         collateralPermit,
       },

--- a/packages/flash-loans/src/aave/types.ts
+++ b/packages/flash-loans/src/aave/types.ts
@@ -70,9 +70,25 @@ export interface CollateralSwapTradeParams {
 }
 
 export interface CollateralSwapOrder {
-  sellAmount: bigint
-  buyAmount: bigint
+  /**
+   * Gross amount borrowed via the Aave flash loan, in the underlying token's unit.
+   * Populates {@link FlashLoanHookAmounts.flashLoanAmount} on the resulting hooks.
+   * Includes the portion that gets repaid as the flash loan fee — i.e. `orderToSign.sellAmount + flashLoanFeeAmount`
+   * for a standard collateral swap, since aTokens are 1:1 with the underlying.
+   */
+  flashLoanAmount: bigint
+  /**
+   * The unsigned CoW Protocol order that will be signed via EIP-1271. The order's `sellAmount`,
+   * `buyAmount`, `sellToken`, `buyToken`, `kind`, and `validTo` are the source of truth for the
+   * hooks — flash loan amount and hook buy/sell amounts are derived from this order to guarantee
+   * the generated hooks match the order they get attached to.
+   */
   orderToSign: UnsignedOrder
+  /**
+   * Optional EIP-2612 permit signature authorizing the adapter to spend the collateral aToken.
+   * When provided, the SDK uses permit-based approval instead of a separate `approve` tx. Leave
+   * undefined to fall back to the standard ERC-20 approval flow.
+   */
   collateralPermit?: CollateralPermitData
 }
 


### PR DESCRIPTION
Fixes #875

1. `CollateralSwapOrder.sellAmount` is renamed to `CollateralSwapOrder.flashLoanAmount`. Important! The amount is not the same with `CollateralSwapOrder.orderToSign.sellAmount`! `flashLoanAmount` is an amount before all fees, when `orderToSign.sellAmount` is an amount after network costs.
2. `CollateralSwapOrder.buyAmount` is deleted because it's the same as `CollateralSwapOrder.orderToSign.buyAmount`.

<img width="2300" height="1768" alt="image" src="https://github.com/user-attachments/assets/d00fd4a0-eda5-4806-be79-4dc348d86215" />
