### PR TITLE
feat(common, order-signing): classify EIP-7702 accounts + helper for wrapping delegates

### DIFF
--- a/packages/common/src/utils/accountKind.test.ts
+++ b/packages/common/src/utils/accountKind.test.ts
@@ -1,0 +1,105 @@
+import {
+  classifyAccount,
+  DEFAULT_WRAPPING_DELEGATES,
+  extractEip7702Delegate,
+  isEip7702DelegationCode,
+  makeWrappingDelegateRegistry,
+  WrappingDelegateRegistry,
+} from './accountKind'
+
+const ZERO = '0x0000000000000000000000000000000000000000'
+// Real EIP-7702 marker observed on mainnet (Metamask Smart Account delegator):
+// `0xef0100 || 0x63c0c19a282a1b52b07dd5a65b58948a07dae32b`.
+const MM_DELEGATION = '0xef010063c0c19a282a1b52b07dd5a65b58948a07dae32b'
+const MM_DELEGATE_ADDR = '63c0c19a282a1b52b07dd5a65b58948a07dae32b'
+const REGULAR_CONTRACT_CODE = '0x6080604052348015600f57600080fd5b50'
+
+function makeAdapter(code: string) {
+  return { getCode: async (_: string) => code }
+}
+
+describe('isEip7702DelegationCode', () => {
+  it('matches the canonical 23-byte marker', () => {
+    expect(isEip7702DelegationCode(MM_DELEGATION)).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isEip7702DelegationCode(MM_DELEGATION.toUpperCase())).toBe(true)
+  })
+
+  it('rejects empty code', () => {
+    expect(isEip7702DelegationCode('0x')).toBe(false)
+  })
+
+  it('rejects regular contract code', () => {
+    expect(isEip7702DelegationCode(REGULAR_CONTRACT_CODE)).toBe(false)
+  })
+
+  it('rejects 7702 prefix with wrong length', () => {
+    expect(isEip7702DelegationCode('0xef0100abcd')).toBe(false)
+    expect(isEip7702DelegationCode(MM_DELEGATION + 'ab')).toBe(false)
+  })
+})
+
+describe('extractEip7702Delegate', () => {
+  it('returns the 20-byte delegate from a marker', () => {
+    expect(extractEip7702Delegate(MM_DELEGATION)).toBe(MM_DELEGATE_ADDR)
+  })
+
+  it('returns null for non-delegation code', () => {
+    expect(extractEip7702Delegate('0x')).toBeNull()
+    expect(extractEip7702Delegate(REGULAR_CONTRACT_CODE)).toBeNull()
+  })
+})
+
+describe('classifyAccount', () => {
+  it('classifies empty code as eoa', async () => {
+    expect(await classifyAccount(makeAdapter('0x'), ZERO)).toBe('eoa')
+  })
+
+  it('classifies undefined code as eoa', async () => {
+    const adapter = { getCode: async (_: string) => undefined }
+    expect(await classifyAccount(adapter, ZERO)).toBe('eoa')
+  })
+
+  it('classifies 7702 marker not in registry as delegated-eoa-plain', async () => {
+    expect(await classifyAccount(makeAdapter(MM_DELEGATION), ZERO)).toBe('delegated-eoa-plain')
+  })
+
+  it('classifies 7702 marker in registry as delegated-eoa-wrapping', async () => {
+    const registry: WrappingDelegateRegistry = {
+      wrappingDelegates: new Set([MM_DELEGATE_ADDR]),
+    }
+    expect(await classifyAccount(makeAdapter(MM_DELEGATION), ZERO, registry)).toBe('delegated-eoa-wrapping')
+  })
+
+  it('classifies regular contract code as contract', async () => {
+    expect(await classifyAccount(makeAdapter(REGULAR_CONTRACT_CODE), ZERO)).toBe('contract')
+  })
+
+  it('default registry is empty so every 7702 marker is plain', async () => {
+    expect(DEFAULT_WRAPPING_DELEGATES.wrappingDelegates.size).toBe(0)
+    expect(await classifyAccount(makeAdapter(MM_DELEGATION), ZERO)).toBe('delegated-eoa-plain')
+  })
+})
+
+describe('makeWrappingDelegateRegistry', () => {
+  it('accepts checksum addresses with 0x prefix', async () => {
+    const registry = makeWrappingDelegateRegistry(['0x63C0c19A282a1B52B07dD5a65b58948A07DAE32B'])
+    expect(await classifyAccount(makeAdapter(MM_DELEGATION), ZERO, registry)).toBe('delegated-eoa-wrapping')
+  })
+
+  it('accepts lowercase addresses with 0x prefix', async () => {
+    const registry = makeWrappingDelegateRegistry(['0x63c0c19a282a1b52b07dd5a65b58948a07dae32b'])
+    expect(await classifyAccount(makeAdapter(MM_DELEGATION), ZERO, registry)).toBe('delegated-eoa-wrapping')
+  })
+
+  it('accepts lowercase addresses without 0x prefix', async () => {
+    const registry = makeWrappingDelegateRegistry([MM_DELEGATE_ADDR])
+    expect(await classifyAccount(makeAdapter(MM_DELEGATION), ZERO, registry)).toBe('delegated-eoa-wrapping')
+  })
+
+  it('returns empty registry for empty input', () => {
+    expect(makeWrappingDelegateRegistry([]).wrappingDelegates.size).toBe(0)
+  })
+})

--- a/packages/common/src/utils/accountKind.ts
+++ b/packages/common/src/utils/accountKind.ts
@@ -1,0 +1,124 @@
+import { AbstractProviderAdapter } from '../adapters/AbstractProviderAdapter'
+
+/**
+ * Classification of an account's on-chain shape, from CoW's signing-scheme
+ * perspective.
+ *
+ * - `eoa`: no code at the address. Sign EIP-712 off-chain, CoW verifies with
+ *   `ecrecover`.
+ * - `delegated-eoa-plain`: EIP-7702 set-code marker (`0xef0100 || delegate`)
+ *   whose delegate returns raw ECDSA from `signTypedData_v4`. EIP-712 path
+ *   works because the inner ECDSA still recovers to the EOA address.
+ * - `delegated-eoa-wrapping`: EIP-7702 marker whose delegate forces signature
+ *   wrapping at sign time — ERC-7739 nested typed data, ERC-7579 / Modular
+ *   Account v2 validator prefix, or both. The bytes from `signTypedData_v4`
+ *   do NOT `ecrecover` to the owner. Verify via the owner's
+ *   `isValidSignature` (EIP-1271 + EIP-7702 dispatch to the delegate).
+ * - `contract`: deployed smart contract (Safe, custom AA wallet). Today the
+ *   common path is `setPreSignature` on-chain (`presign`).
+ */
+export type AccountKind = 'eoa' | 'delegated-eoa-plain' | 'delegated-eoa-wrapping' | 'contract'
+
+/**
+ * Lookup table for delegate addresses known to force signature wrapping on
+ * `signTypedData_v4`. Addresses may be provided as checksum or lowercase,
+ * with or without `0x`; lookups are case-insensitive.
+ *
+ * Membership causes `classifyAccount` to return `delegated-eoa-wrapping`
+ * instead of `delegated-eoa-plain`. Integrators add addresses as they
+ * confirm a delegate's wallet returns wrapped bytes (e.g. by inspecting
+ * the byte length and shape of a sample signature).
+ */
+export interface WrappingDelegateRegistry {
+  readonly wrappingDelegates: ReadonlySet<string>
+}
+
+/**
+ * Normalize an address-like string for registry comparison: strip `0x` and
+ * lowercase. No format validation — the caller is expected to provide a
+ * hex address.
+ */
+function normalizeDelegateAddress(address: string): string {
+  const lower = address.toLowerCase()
+  return lower.startsWith('0x') ? lower.slice(2) : lower
+}
+
+/**
+ * Build a `WrappingDelegateRegistry` from a list of delegate addresses,
+ * tolerating checksum casing and `0x` prefix.
+ */
+export function makeWrappingDelegateRegistry(addresses: Iterable<string>): WrappingDelegateRegistry {
+  const set = new Set<string>()
+  for (const address of addresses) {
+    set.add(normalizeDelegateAddress(address))
+  }
+  return { wrappingDelegates: set }
+}
+
+/**
+ * Default empty registry. Vendors / integrators are expected to merge their
+ * own allowlist; CoW does not maintain a canonical list.
+ */
+export const DEFAULT_WRAPPING_DELEGATES: WrappingDelegateRegistry = makeWrappingDelegateRegistry([])
+
+const EIP7702_DELEGATION_PREFIX = '0xef0100'
+const EIP7702_DELEGATION_HEX_LENGTH = 2 + 23 * 2 // "0x" + 23 bytes
+
+/**
+ * True if `code` matches the EIP-7702 set-code marker exactly:
+ * `0xef0100 || delegate_address` (23 bytes total).
+ */
+export function isEip7702DelegationCode(code: string): boolean {
+  if (!code) return false
+  const lower = code.toLowerCase()
+  return lower.length === EIP7702_DELEGATION_HEX_LENGTH && lower.startsWith(EIP7702_DELEGATION_PREFIX)
+}
+
+/**
+ * Extracts the 20-byte delegate address (lowercase hex, no `0x`) from a
+ * canonical EIP-7702 set-code marker. Returns `null` if `code` is not a
+ * delegation marker.
+ */
+export function extractEip7702Delegate(code: string): string | null {
+  if (!isEip7702DelegationCode(code)) return null
+  // Skip "0x" + "ef0100"
+  return code.slice(2 + 6).toLowerCase()
+}
+
+/**
+ * Classifies an account by inspecting on-chain code at `owner`.
+ *
+ * Reads `getCode(owner)` once. Pure function over the result — no caching;
+ * callers should cache for performance if they need to. The classification
+ * is the input to CoW signing-scheme selection:
+ *
+ * - `eoa`, `delegated-eoa-plain` -> `SigningScheme.EIP712`
+ * - `delegated-eoa-wrapping`     -> `SigningScheme.EIP1271` with the wallet's
+ *                                   raw bytes forwarded as the signature
+ *                                   (see `signOrderForWrappingDelegate`).
+ * - `contract`                   -> `SigningScheme.PRESIGN` (today's default
+ *                                   for Safes; off-chain EIP-1271 is also
+ *                                   possible if the wallet supports it).
+ *
+ * @param adapter Provider adapter exposing `getCode`.
+ * @param owner Address to classify (the order owner).
+ * @param registry Allowlist of wrapping delegates. Defaults to empty.
+ */
+export async function classifyAccount(
+  adapter: Pick<AbstractProviderAdapter, 'getCode'>,
+  owner: string,
+  registry: WrappingDelegateRegistry = DEFAULT_WRAPPING_DELEGATES,
+): Promise<AccountKind> {
+  const code = (await adapter.getCode(owner)) || '0x'
+
+  if (code === '0x') return 'eoa'
+
+  const delegate = extractEip7702Delegate(code)
+  if (delegate !== null) {
+    // `extractEip7702Delegate` returns lowercased hex without `0x`, which is
+    // the same shape `makeWrappingDelegateRegistry` produces.
+    return registry.wrappingDelegates.has(delegate) ? 'delegated-eoa-wrapping' : 'delegated-eoa-plain'
+  }
+
+  return 'contract'
+}

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './accountKind'
 export * from './cowError'
 export * from './log'
 export * from './serialize'

--- a/packages/order-signing/src/index.ts
+++ b/packages/order-signing/src/index.ts
@@ -1,2 +1,3 @@
 export * from './orderSigningUtils'
 export * from './types'
+export * from './wrappingDelegate'

--- a/packages/order-signing/src/wrappingDelegate.ts
+++ b/packages/order-signing/src/wrappingDelegate.ts
@@ -1,0 +1,51 @@
+import { ProtocolOptions, SupportedChainId } from '@cowprotocol/sdk-config'
+import { ContractsOrder, normalizeOrder, ORDER_TYPE_FIELDS } from '@cowprotocol/sdk-contracts-ts'
+import { AbstractSigner } from '@cowprotocol/sdk-common'
+
+import { UnsignedOrder } from './types'
+import { getDomain } from './utils'
+
+/**
+ * Produce a CoW order signature for an EIP-7702 delegated EOA whose delegate
+ * wraps signatures at sign time (ERC-7739 nested typed-data, ERC-7579 /
+ * Modular Account v2 validator prefix, or both).
+ *
+ * The wallet's `signTypedData` returns bytes that do NOT `ecrecover` to the
+ * owner — they only verify via the owner's `isValidSignature`, which EIP-7702
+ * routes to the delegate. The bytes are forwarded verbatim with no further
+ * wrapping (unlike the `(order, sig)` ABI tuple used for adapter-style
+ * EIP-1271 verifiers).
+ *
+ * Intended use as the `customEIP1271Signature` callback in
+ * `postCoWProtocolTrade`:
+ *
+ * ```ts
+ * await postCoWProtocolTrade(orderBookApi, appData, params, {
+ *   signingScheme: SigningScheme.EIP1271,
+ *   customEIP1271Signature: (order, signer) =>
+ *     signOrderForWrappingDelegate(order, chainId, signer),
+ * })
+ * ```
+ *
+ * Use `classifyAccount` from `@cowprotocol/sdk-common` to decide when to
+ * route through this path.
+ *
+ * @param order The unsigned order to sign.
+ * @param chainId The chain id (drives the CoW settlement EIP-712 domain).
+ * @param signer The owner's signer.
+ * @param options Optional protocol overrides (env, settlement contract).
+ * @returns Raw wallet bytes — suitable as an EIP-1271 signature against the
+ *          owner address.
+ */
+export async function signOrderForWrappingDelegate<Provider>(
+  order: UnsignedOrder,
+  chainId: SupportedChainId,
+  signer: AbstractSigner<Provider>,
+  options?: ProtocolOptions,
+): Promise<string> {
+  const domain = getDomain(chainId, options)
+  // Normalize to match the canonical EIP-712 payload used everywhere else
+  // (fills `sellTokenBalance`/`buyTokenBalance` defaults, hashes `appData`).
+  const normalized = normalizeOrder(order as unknown as ContractsOrder)
+  return signer.signTypedData(domain, { Order: ORDER_TYPE_FIELDS }, normalized as unknown as Record<string, unknown>)
+}


### PR DESCRIPTION
## Summary

Two additive utilities for integrators that need to support EIP-7702 delegated EOAs whose delegate wraps signatures at sign time (ERC-7739 nested typed data, ERC-7579 / Modular Account v2 validator prefix, or both).

### \`@cowprotocol/sdk-common\` — \`classifyAccount\`

\`getCode\`-based classification with four buckets:

- \`eoa\` — empty code
- \`delegated-eoa-plain\` — canonical 7702 marker (\`0xef0100 || delegate\`, 23 bytes) whose delegate is NOT in the wrapping registry
- \`delegated-eoa-wrapping\` — same marker whose delegate IS in the registry
- \`contract\` — anything else with bytecode

The wrapping registry is caller-supplied (\`WrappingDelegateRegistry\`). \`makeWrappingDelegateRegistry(addresses)\` builds one from a list of delegate addresses, tolerating checksum casing and the \`0x\` prefix. The default registry is empty, so today every 7702 EOA classifies as \`delegated-eoa-plain\` and existing flows are unchanged.

### \`@cowprotocol/sdk-order-signing\` — \`signOrderForWrappingDelegate\`

Signs the canonical normalized CoW order typed data via the wallet's \`signTypedData\` and returns the bytes verbatim. Intended to be passed as \`customEIP1271Signature\` in \`postCoWProtocolTrade\`:

\`\`\`ts
import { classifyAccount, makeWrappingDelegateRegistry } from '@cowprotocol/sdk-common'
import { signOrderForWrappingDelegate, SigningScheme } from '@cowprotocol/sdk-order-signing'

const registry = makeWrappingDelegateRegistry([
  /* delegate addresses that force 7739 / MA v2 wrapping at sign time */
])

const kind = await classifyAccount(adapter, owner, registry)
if (kind === 'delegated-eoa-wrapping') {
  await postCoWProtocolTrade(orderBookApi, appData, params, {
    signingScheme: SigningScheme.EIP1271,
    customEIP1271Signature: (order, signer) =>
      signOrderForWrappingDelegate(order, chainId, signer),
  })
}
\`\`\`

The bytes are forwarded as the EIP-1271 signature with no further wrapping (specifically NOT the \`(order, sig)\` ABI tuple that \`getEip1271Signature\` produces for adapter-style verifiers like Safe's fallback handler). CoW then resolves verification via \`isValidSignature(orderHash, signature)\` on the owner address; EIP-7702 routes that call through the delegate, which decodes its own wrapping (validator-prefix unpacking, nested-envelope reconstruction, etc.).

## Why

Production EOAs are increasingly running 7702 delegates. For delegates that return raw ECDSA from \`signTypedData_v4\` (e.g. Metamask Smart Account today), the existing EIP-712 path already works. For delegates that wrap, the bytes don't \`ecrecover\` to the owner and the order is rejected with no clean way today to route to EIP-1271 without bringing in an adapter contract.

## Compat

- All changes are additive: two new files plus barrel re-exports. No existing export's signature or behavior is touched.
- Empty default registry means there's zero behavioral change for integrators who don't opt in.
- Existing \`customEIP1271Signature\` callers (passing pre-wrapped \`(order, sig)\` tuples) are unaffected — the new helper is an alternative, not a replacement.

## Tests

17 new unit tests in \`packages/common/src/utils/accountKind.test.ts\` covering:

- \`isEip7702DelegationCode\` (canonical marker, case-insensitivity, length boundaries, regular bytecode rejection)
- \`extractEip7702Delegate\` (round-trip extraction)
- \`classifyAccount\` (all four buckets, undefined-code fallback, registry-driven wrapping detection)
- \`makeWrappingDelegateRegistry\` (checksum / lowercase / no-\`0x\` tolerance)

Sample real-world marker tested: \`0xef010063c0c19a282a1b52b07dd5a65b58948a07dae32b\` — the Metamask Smart Account delegator observed on Ethereum mainnet.

Existing tests in \`@cowprotocol/sdk-order-signing\` still pass (13/13).

## Independent review

Diff reviewed with OpenAI Codex (read-only sandbox). Two findings raised and addressed before this PR:

1. \`signOrderForWrappingDelegate\` now calls \`normalizeOrder\` so the EIP-712 payload matches the canonical signing path (same default for \`sellTokenBalance\` / \`buyTokenBalance\`, same \`appData\` hashing). Without this, callers passing a partially-specified \`UnsignedOrder\` could sign a different payload than the one CoW receives.
2. \`makeWrappingDelegateRegistry\` introduced so callers don't silently lose entries when they pass checksum / \`0x\`-prefixed addresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for EIP-7702 delegated EOA accounts with automatic account type classification.
  * Introduced account classification system to distinguish between standard EOAs, delegated EOAs, and contracts.
  * Added new order signing capability for delegated EOA accounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cow-sdk/pull/878)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->