### PR TITLE
fix: app data cid lazy import

### DIFF
--- a/packages/app-data/src/api/appDataHexToCid.ts
+++ b/packages/app-data/src/api/appDataHexToCid.ts
@@ -1,6 +1,5 @@
 import { getGlobalAdapter } from '@cowprotocol/sdk-common'
 import { MetaDataError } from '../consts'
-import { CID } from 'multiformats/cid'
 
 /**
  *  Convert an app-data hex string to a CID
@@ -64,6 +63,8 @@ async function _appDataHexToCidLegacy(appDataHex: string): Promise<string> {
     multihashHex: appDataHex, // 32 bytes of the sha2-256 hash
   })
 
+  // multiformats@13+ is ESM-only — load lazily so CJS consumers don't trip on require()
+  const { CID } = await import('multiformats/cid')
   return CID.decode(cidBytes).toV0().toString()
 }
 


### PR DESCRIPTION
One of the imports CID has broken tests in cowswap repo, I replaced it by lazy loading (like in other places).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with CommonJS consumers by implementing lazy loading of critical dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cow-sdk/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->