### PR TITLE
fix(viem-adapter): hex-encode value in estimateGas

### DIFF
--- a/packages/providers/viem-adapter/src/ViemSignerAdapter.ts
+++ b/packages/providers/viem-adapter/src/ViemSignerAdapter.ts
@@ -125,11 +125,24 @@ export class ViemSignerAdapter extends AbstractSigner<PublicClient> {
     }
 
     const formattedTx = this._formatTxParams(txParams)
+    // `eth_estimateGas` is called directly via `publicClient.request`, bypassing
+    // viem's parameter formatting. Strict go-ethereum RPCs (BNB Chain, Arbitrum One,
+    // Polygon, Avalanche, Linea) unmarshal `value` into `*hexutil.Big`, which
+    // requires a 0x-prefixed hex string. Callers (e.g. the SDK's eth-flow path,
+    // which forwards `orderToSign.sellAmount` from `BigInt.toString()`) pass `value`
+    // through as a decimal string, so hex-encode it here to satisfy the RPC.
+    const rawValue = formattedTx.value
+    const value =
+      rawValue === undefined || rawValue === null
+        ? '0x0'
+        : typeof rawValue === 'string' && rawValue.startsWith('0x')
+          ? rawValue
+          : '0x' + BigInt(rawValue).toString(16)
     const params = {
       from: typeof this._account === 'string' ? this._account : this._account.address,
       to: formattedTx.to,
       data: formattedTx.data,
-      value: formattedTx.value ?? '0x0',
+      value,
     }
 
     const hexGas = await this._publicClient.request({


### PR DESCRIPTION
# Summary                                                                                                                                                                                               
                                                                                                                                                                                                        
  Fixes [cowprotocol/cowswap#7522](https://github.com/cowprotocol/cowswap/issues/7522)                                                                                                                    
                                                                                                                                                                                                        
  `ViemSignerAdapter.estimateGas` builds the `eth_estimateGas` request by hand                                                                                                                          
  via `this._publicClient.request({ method: 'eth_estimateGas', params: [...] })`,                                                                                                                         
  which bypasses viem's parameter formatting (`numberToHex(...)` on `gas` /
  `value`). When the SDK's eth-flow path calls it through                                                                                                                                                 
  `contract.estimateGas.createOrder(order, { value: orderToSign.sellAmount })`,                                                                                                                         
  `sellAmount` is the decimal-string output of `BigInt.toString()` (e.g.                                                                                                                                  
  `"1000000000000000"`). Strict go-ethereum RPCs (BNB Chain, Arbitrum One,                                                                                                                                
  Polygon, Avalanche, Linea) unmarshal `value` into `*hexutil.Big`, which                                                                                                                                 
  requires a `0x`-prefixed hex string, and reject with:                                                                                                                                                   
                                                                                                                                                                                                          
  > `-32602 invalid argument 0: json: cannot unmarshal non-string into Go struct field TransactionArgs.value of type *hexutil.Big`                                                                        
                                                                                                                                                                                                          
  The eth-flow path swallows the failure (`getEthFlowTransaction` catches and                                                                                                                             
  falls back to `GAS_LIMIT_DEFAULT`), so the order itself still completes — but                                                                                                                           
  every placement on those chains logs a console `InvalidParamsRpcError` in the                                                                                                                           
  dapp consuming this adapter.                                                                                                                                                                            
                                                                                                                                                                                                        
  This PR hex-encodes `value` before it reaches the RPC. `0x`-prefixed strings                                                                                                                            
  and `undefined` / `null` are passed through unchanged, so existing callers                                                                                                                              
  behave identically.                                                                                                                                                                                     
                                                                                                                                                                                                          
  `sendTransaction` and `signTransaction` don't need the same fix because they                                                                                                                            
  go through viem's typed actions (`this._client.sendTransaction`,                                                                                                                                      
  `this._client.signTransaction`), which already normalize `value`.                                                                                                                                       
                                                                                                                                                                                                        
  # To Test                                                                                                                                                                                               
   
  1. **eth-flow `estimateGas` reaches the RPC on strict chains**                                                                                                                                          
                                                                                                                                                                                                        
  - [ ] Install the adapter from this branch in a cowswap fork (e.g.                                                                                                                                      
        `pnpm link` the local build, or publish an RC and bump                                                                                                                                          
        `@cowprotocol/sdk-viem-adapter` in `apps/cowswap-frontend/package.json`).                                                                                                                         
  - [ ] Connect Rabby (or any EOA wallet) and switch to **BNB Chain**.
  - [ ] Pick BNB as the sell token, any token as buy, enter an amount.                                                                                                                                    
  - [ ] Click *Place Order*.                                                                                                                                                                              
  - [ ] Verify the browser console shows **no** `InvalidParamsRpcError`                                                                                                                                   
        logged during order placement.                                                                                                                                                                    
  - [ ] Verify the order is created on-chain (transaction confirms, order                                                                                                                                 
        shows up in the order list).                                                                                                                                                                      
  - [ ] Repeat on **Arbitrum One**, **Polygon**, **Avalanche**, and **Linea**.                                                                                                                            
                                                                                                                                                                                                        
  2. **Mainnet path unchanged**                                                                                                                                                                           
                                                                                                                                                                                                        
  - [ ] Repeat the same flow on **Ethereum mainnet**.                                                                                                                                                     
  - [ ] Verify the order is still created and no new console errors appear.                                                                                                                             
                                                                                                                                                                                                          
  3. **`estimateGas` callers without `value` still work**                                                                                                                                               
                                                                                                                                                                                                        
  - [ ] Trigger a contract call that has no `value` (e.g. an `invalidateOrder`                                                                                                                            
        path through `contract.estimateGas.invalidateOrder`).
  - [ ] Verify it still returns a gas estimate, no thrown errors.                                                                                                                                         
                                                                                                                                                                                                        
  4. **Already-hex `value` is passed through unchanged**                                                                                                                                                  
                                              
  - [ ] Call `signer.estimateGas({ to, data, value: '0x123' })` directly.                                                                                                                                 
  - [ ] Assert the request body sent to the RPC contains `"value":"0x123"` —                                                                                                                            
        not double-encoded.                                                                                                                                                                               
                                                                                                                                                                                                        
  5. **Decimal-string `value` is hex-encoded**                                                                                                                                                            
                                                                                                                                                                                                          
  - [ ] Call `signer.estimateGas({ to, data, value: '1000000000000000' })`.                                                                                                                             
  - [ ] Assert the request body sent to the RPC contains                                                                                                                                                  
        `"value":"0x38d7ea4c68000"`.                                                                                                                                                                      
                                                                                                                                                                                                        
  # Background                                                                                                                                                                                            
                                                                                                                                                                                                        
  Surfaced by cowswap's Viem migration                                                                                                                                                                    
  ([cowprotocol/cowswap#7061](https://github.com/cowprotocol/cowswap/pull/7061),                                                                                                                        
  commit `48daef9bfb`, merged 2026-04-14), which replaced                                                                                                                                                 
  `EthersV5Adapter` with `ViemAdapter` on every contract call site. The old                                                                                                                             
  `ethers@5` `Signer.estimateGas` hex-encoded `BigNumber` values internally, so                                                                                                                         
  the same eth-flow call site was silent under the old adapter — the gap in                                                                                                                               
  `ViemSignerAdapter.estimateGas` only became user-visible after the migration.                                                                                                                           
                                                                                                                                                                                                          
  Functional impact in cowswap is zero today (the SDK falls back to a default                                                                                                                             
  gas limit and the order still completes), and the cowswap issue is labelled                                                                                                                             
  `Low`. The motivation here is twofold: remove the misleading console error,                                                                                                                             
  and make `estimateGas` actually return a real estimate so eth-flow on these                                                                                                                             
  chains stops always paying the fallback gas limit.                                                                                                                                                      
                                                                                                                                                                                                          
  A temporary workaround is shipping in cowswap                                                                                                                                                           
  ([cowprotocol/cowswap#7524](https://github.com/cowprotocol/cowswap/pull/7524))                                                                                                                          
  `value`). When the SDK's eth-flow path calls it through
  `contract.estimateGas.createOrder(order, { value: orderToSign.sellAmount })`,
  `sellAmount` is the decimal-string output of `BigInt.toString()` (e.g.
  `"1000000000000000"`). Strict go-ethereum RPCs (BNB Chain, Arbitrum One,
  Polygon, Avalanche, Linea) unmarshal `value` into `*hexutil.Big`, which
  requires a `0x`-prefixed hex string, and reject with:

  > `-32602 invalid argument 0: json: cannot unmarshal non-string into Go struct field TransactionArgs.value of type *hexutil.Big`

  The eth-flow path swallows the failure (`getEthFlowTransaction` catches and
  falls back to `GAS_LIMIT_DEFAULT`), so the order itself still completes — but
  every placement on those chains logs a console `InvalidParamsRpcError` in the
  dapp consuming this adapter.

  This PR hex-encodes `value` before it reaches the RPC. `0x`-prefixed strings
  and `undefined` / `null` are passed through unchanged, so existing callers
  behave identically.

  `sendTransaction` and `signTransaction` don't need the same fix because they
  go through viem's typed actions (`this._client.sendTransaction`,
  `this._client.signTransaction`), which already normalize `value`.

  # To Test

  1. **eth-flow `estimateGas` reaches the RPC on strict chains**

  - [ ] Install the adapter from this branch in a cowswap fork (e.g.
        `pnpm link` the local build, or publish an RC and bump
        `@cowprotocol/sdk-viem-adapter` in `apps/cowswap-frontend/package.json`).
  - [ ] Connect Rabby (or any EOA wallet) and switch to **BNB Chain**.
  - [ ] Pick BNB as the sell token, any token as buy, enter an amount.
  - [ ] Click *Place Order*.
  - [ ] Verify the browser console shows **no** `InvalidParamsRpcError`
        logged during order placement.
  - [ ] Verify the order is created on-chain (transaction confirms, order
        shows up in the order list).
  - [ ] Repeat on **Arbitrum One**, **Polygon**, **Avalanche**, and **Linea**.

  2. **Mainnet path unchanged**

  - [ ] Repeat the same flow on **Ethereum mainnet**.
  - [ ] Verify the order is still created and no new console errors appear.

  3. **`estimateGas` callers without `value` still work**

  - [ ] Trigger a contract call that has no `value` (e.g. an `invalidateOrder`
        path through `contract.estimateGas.invalidateOrder`).
  - [ ] Verify it still returns a gas estimate, no thrown errors.

  4. **Already-hex `value` is passed through unchanged**

  - [ ] Call `signer.estimateGas({ to, data, value: '0x123' })` directly.
  - [ ] Assert the request body sent to the RPC contains `"value":"0x123"` —
        not double-encoded.

  5. **Decimal-string `value` is hex-encoded**

  - [ ] Call `signer.estimateGas({ to, data, value: '1000000000000000' })`.
  - [ ] Assert the request body sent to the RPC contains
        `"value":"0x38d7ea4c68000"`.

  # Background

  Surfaced by cowswap's Viem migration
  ([cowprotocol/cowswap#7061](https://github.com/cowprotocol/cowswap/pull/7061),
  commit `48daef9bfb`, merged 2026-04-14), which replaced
  `EthersV5Adapter` with `ViemAdapter` on every contract call site. The old
  `ethers@5` `Signer.estimateGas` hex-encoded `BigNumber` values internally, so
  the same eth-flow call site was silent under the old adapter — the gap in
  `ViemSignerAdapter.estimateGas` only became user-visible after the migration.

  Functional impact in cowswap is zero today (the SDK falls back to a default
  gas limit and the order still completes), and the cowswap issue is labelled
  `Low`. The motivation here is twofold: remove the misleading console error,
  and make `estimateGas` actually return a real estimate so eth-flow on these
  chains stops always paying the fallback gas limit.

  A temporary workaround is shipping in cowswap
  ([cowprotocol/cowswap#7524](https://github.com/cowprotocol/cowswap/pull/7524))
  - [ ] Assert the request body sent to the RPC contains
        `"value":"0x38d7ea4c68000"`.

  # Background

  Surfaced by cowswap's Viem migration
  ([cowprotocol/cowswap#7061](https://github.com/cowprotocol/cowswap/pull/7061),
  commit `48daef9bfb`, merged 2026-04-14), which replaced
  `EthersV5Adapter` with `ViemAdapter` on every contract call site. The old
  `ethers@5` `Signer.estimateGas` hex-encoded `BigNumber` values internally, so
  the same eth-flow call site was silent under the old adapter — the gap in
  `ViemSignerAdapter.estimateGas` only became user-visible after the migration.

  Functional impact in cowswap is zero today (the SDK falls back to a default
  gas limit and the order still completes), and the cowswap issue is labelled
  `Low`. The motivation here is twofold: remove the misleading console error,
  and make `estimateGas` actually return a real estimate so eth-flow on these
  chains stops always paying the fallback gas limit.

  A temporary workaround is shipping in cowswap
  ([cowprotocol/cowswap#7524](https://github.com/cowprotocol/cowswap/pull/7524))
  that decorates the signer's `estimateGas` in user code. Once this SDK PR is
  released, that workaround can be reverted with a version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gas estimation RPC parameter formatting to properly encode decimal values as hex strings and ensure correct default value handling for broader JSON-RPC compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cow-sdk/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->