### PR TITLE
chore: Update openapi.yml version

### DIFF
--- a/packages/bridging/src/BridgingSdk/mock/bridgeRequestMocks.ts
+++ b/packages/bridging/src/BridgingSdk/mock/bridgeRequestMocks.ts
@@ -80,6 +80,9 @@ export const orderQuoteResponse: OrderQuoteResponse = {
       '{"appCode":"test","metadata":{"orderClass":{"orderClass":"market"},"quote":{"slippageBips":50}},"version":"1.3.0"}',
 
     feeAmount: BigInt('1000000').toString(), // 1 USDC (6 decimals)
+    gasAmount: '0',
+    gasPrice: '0',
+    sellTokenPrice: '0',
     kind: OrderKind.SELL,
     partiallyFillable: false,
     sellTokenBalance: SellTokenSource.ERC20,

--- a/packages/order-book/package.json
+++ b/packages/order-book/package.json
@@ -25,7 +25,7 @@
     "test": "jest",
     "test:coverage": "jest --coverage --json --outputFile=jest.results.json && npx coveralls < ./coverage/lcov.info",
     "test:coverage:html": "jest --silent=false --coverage --coverageReporters html",
-    "swagger:codegen": "openapi --input https://raw.githubusercontent.com/cowprotocol/services/dfb50cb4a103e8f949f5a7145beb6be63ef41c85/crates/orderbook/openapi.yml --output src/generated --exportServices false --exportCore false",
+    "swagger:codegen": "openapi --input https://raw.githubusercontent.com/cowprotocol/services/5341875c9498b2026d1b6f67c840b086e4696dcd/crates/orderbook/openapi.yml --output src/generated --exportServices false --exportCore false",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build"

--- a/packages/order-book/src/quoteAmountsAndCosts/getProtocolFeeAmount.test.ts
+++ b/packages/order-book/src/quoteAmountsAndCosts/getProtocolFeeAmount.test.ts
@@ -12,6 +12,9 @@ const otherFields = {
   validTo: 1716904696,
   appData: '{}',
   appDataHash: '0x0',
+  gasAmount: '0',
+  gasPrice: '0',
+  sellTokenPrice: '0',
 }
 
 describe('getProtocolFeeAmount', () => {

--- a/packages/order-book/src/quoteAmountsAndCosts/getQuoteAmountsAndCosts.test.ts
+++ b/packages/order-book/src/quoteAmountsAndCosts/getQuoteAmountsAndCosts.test.ts
@@ -12,6 +12,9 @@ const otherFields = {
   validTo: 1716904696,
   appData: '{}',
   appDataHash: '0x0',
+  gasAmount: '0',
+  gasPrice: '0',
+  sellTokenPrice: '0',
 }
 
 /**

--- a/packages/order-book/src/transformOrder.test.ts
+++ b/packages/order-book/src/transformOrder.test.ts
@@ -24,6 +24,7 @@ const ORDER: Order = {
   executedFeeAmount: '1234567890',
   invalidated: true,
   status: OrderStatus.FULFILLED,
+  settlementContract: '0x9008D19f58AAbD9eD0D60971565AA8510560ab41',
 }
 
 describe('transformOrder', () => {

--- a/packages/order-signing/src/types.ts
+++ b/packages/order-signing/src/types.ts
@@ -4,8 +4,14 @@ import type { OrderParameters, EcdsaSigningScheme } from '@cowprotocol/sdk-order
 
 /**
  * Unsigned order intent to be placed.
+ *
+ * The `gasAmount`, `gasPrice` and `sellTokenPrice` fields are quote-response-only
+ * metadata (see `OrderParameters`); they are not part of the signed order struct,
+ * so they are omitted here.
  */
-export type UnsignedOrder = Omit<OrderParameters, 'receiver'> & { receiver: string }
+export type UnsignedOrder = Omit<OrderParameters, 'receiver' | 'gasAmount' | 'gasPrice' | 'sellTokenPrice'> & {
+  receiver: string
+}
 
 /**
  * Encoded signature including signing scheme for the order.

--- a/packages/trading/src/getOrderToSign.ts
+++ b/packages/trading/src/getOrderToSign.ts
@@ -59,6 +59,11 @@ export function getOrderToSign(
     feeAmount: networkCostsAmount,
     appData: appDataKeccak256,
     partiallyFillable,
+    // Quote-only gas/price metadata: not known when building an order to sign and
+    // unused by getQuoteAmountsAndCosts. Set to zero placeholders to satisfy OrderParameters.
+    gasAmount: '0',
+    gasPrice: '0',
+    sellTokenPrice: '0',
   }
 
   let sellAmountToUse = sellAmount

--- a/packages/trading/src/onChainCancellation.test.ts
+++ b/packages/trading/src/onChainCancellation.test.ts
@@ -37,6 +37,7 @@ const mockEnrichedOrder: EnrichedOrder = {
   executedBuyAmount: '0',
   executedFeeAmount: '0',
   invalidated: false,
+  settlementContract: '0x9008D19f58AAbD9eD0D60971565AA8510560ab41',
 }
 
 const ESTIMATED_GAS = BigInt(125000)

--- a/packages/trading/src/tradingSdk.test.ts
+++ b/packages/trading/src/tradingSdk.test.ts
@@ -82,6 +82,7 @@ const mockOrder: EnrichedOrder = {
   executedBuyAmount: '0',
   executedFeeAmount: '0',
   invalidated: false,
+  settlementContract: '0x9008D19f58AAbD9eD0D60971565AA8510560ab41',
 }
 
 describe('TradingSdk', () => {


### PR DESCRIPTION
The new version fixes the schema for FeePolicy, which was using an "untagged" enum instead of a "tagged" one.

It also includes an "unreleased" change related to OrderParameters, the services commit that triggered this was: https://github.com/cowprotocol/services/commit/c9dc2c07932d756fa275ee8220dfb33adf4ff485

Which is where all the test code comes from

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated API code-generation configuration to point to the latest OpenAPI source.

* **Refactor**
  * Public order type adjusted to treat gas and price fields as quote-only metadata (not part of the signed order).
  * Order construction now includes placeholder quote metadata fields to keep shapes consistent.

* **Tests**
  * Test fixtures updated to include gasAmount, gasPrice, sellTokenPrice and settlement contract fields where relevant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->