### PR TITLE
feat: internal ids for evm chains

### DIFF
--- a/packages/config/src/chains/details/arbitrum.ts
+++ b/packages/config/src/chains/details/arbitrum.ts
@@ -11,7 +11,7 @@ const arbitrumLogo = `${RAW_CHAINS_FILES_PATH}/images/arbitrum-logo.svg`
  */
 export const arbitrumOne: EvmChainInfo = {
   id: SupportedChainId.ARBITRUM_ONE,
-  cowNetworkName: 'arbitrum-one',
+  internalId: 'arbitrum-one',
   label: 'Arbitrum',
   eip155Label: 'Arbitrum One',
   nativeCurrency: {

--- a/packages/config/src/chains/details/arbitrum.ts
+++ b/packages/config/src/chains/details/arbitrum.ts
@@ -11,6 +11,7 @@ const arbitrumLogo = `${RAW_CHAINS_FILES_PATH}/images/arbitrum-logo.svg`
  */
 export const arbitrumOne: EvmChainInfo = {
   id: SupportedChainId.ARBITRUM_ONE,
+  cowNetworkName: 'arbitrum-one',
   label: 'Arbitrum',
   eip155Label: 'Arbitrum One',
   nativeCurrency: {

--- a/packages/config/src/chains/details/avalanche.ts
+++ b/packages/config/src/chains/details/avalanche.ts
@@ -8,6 +8,7 @@ const avaxLogo = `${RAW_CHAINS_FILES_PATH}/images/avax-logo.svg`
 // See https://github.com/wevm/viem/blob/main/src/chains/definitions/avalanche.ts
 export const avalanche: EvmChainInfo = {
   id: SupportedChainId.AVALANCHE,
+  cowNetworkName: 'avalanche',
   label: 'Avalanche',
   eip155Label: 'Avalanche C-Chain',
   logo: { light: avaxLogo, dark: avaxLogo },

--- a/packages/config/src/chains/details/avalanche.ts
+++ b/packages/config/src/chains/details/avalanche.ts
@@ -8,7 +8,7 @@ const avaxLogo = `${RAW_CHAINS_FILES_PATH}/images/avax-logo.svg`
 // See https://github.com/wevm/viem/blob/main/src/chains/definitions/avalanche.ts
 export const avalanche: EvmChainInfo = {
   id: SupportedChainId.AVALANCHE,
-  cowNetworkName: 'avalanche',
+  internalId: 'avalanche',
   label: 'Avalanche',
   eip155Label: 'Avalanche C-Chain',
   logo: { light: avaxLogo, dark: avaxLogo },

--- a/packages/config/src/chains/details/base.ts
+++ b/packages/config/src/chains/details/base.ts
@@ -11,6 +11,7 @@ const baseLogo = `${RAW_CHAINS_FILES_PATH}/images/base-logo.svg`
  */
 export const base: EvmChainInfo = {
   id: SupportedChainId.BASE,
+  cowNetworkName: 'base',
   label: 'Base',
   eip155Label: 'Base',
   nativeCurrency: {

--- a/packages/config/src/chains/details/base.ts
+++ b/packages/config/src/chains/details/base.ts
@@ -11,7 +11,7 @@ const baseLogo = `${RAW_CHAINS_FILES_PATH}/images/base-logo.svg`
  */
 export const base: EvmChainInfo = {
   id: SupportedChainId.BASE,
-  cowNetworkName: 'base',
+  internalId: 'base',
   label: 'Base',
   eip155Label: 'Base',
   nativeCurrency: {

--- a/packages/config/src/chains/details/bnb.ts
+++ b/packages/config/src/chains/details/bnb.ts
@@ -8,7 +8,7 @@ const bnbLogo = `${RAW_CHAINS_FILES_PATH}/images/bnb-logo.svg`
 // and https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-56.json
 export const bnb: EvmChainInfo = {
   id: SupportedChainId.BNB,
-  cowNetworkName: 'bnb',
+  internalId: 'bnb',
   label: 'BNB',
   eip155Label: 'BNB Chain Mainnet',
   logo: { light: bnbLogo, dark: bnbLogo },

--- a/packages/config/src/chains/details/bnb.ts
+++ b/packages/config/src/chains/details/bnb.ts
@@ -8,6 +8,7 @@ const bnbLogo = `${RAW_CHAINS_FILES_PATH}/images/bnb-logo.svg`
 // and https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-56.json
 export const bnb: EvmChainInfo = {
   id: SupportedChainId.BNB,
+  cowNetworkName: 'bnb',
   label: 'BNB',
   eip155Label: 'BNB Chain Mainnet',
   logo: { light: bnbLogo, dark: bnbLogo },

--- a/packages/config/src/chains/details/gnosis.ts
+++ b/packages/config/src/chains/details/gnosis.ts
@@ -12,6 +12,7 @@ const gnosisChainLogo = `${RAW_CHAINS_FILES_PATH}/images/gnosis-logo.svg`
  */
 export const gnosisChain: EvmChainInfo = {
   id: SupportedChainId.GNOSIS_CHAIN,
+  cowNetworkName: 'xdai',
   label: 'Gnosis',
   eip155Label: 'Gnosis',
   nativeCurrency: {

--- a/packages/config/src/chains/details/gnosis.ts
+++ b/packages/config/src/chains/details/gnosis.ts
@@ -12,7 +12,7 @@ const gnosisChainLogo = `${RAW_CHAINS_FILES_PATH}/images/gnosis-logo.svg`
  */
 export const gnosisChain: EvmChainInfo = {
   id: SupportedChainId.GNOSIS_CHAIN,
-  cowNetworkName: 'xdai',
+  internalId: 'xdai',
   label: 'Gnosis',
   eip155Label: 'Gnosis',
   nativeCurrency: {

--- a/packages/config/src/chains/details/ink.ts
+++ b/packages/config/src/chains/details/ink.ts
@@ -8,6 +8,7 @@ const inkLogo = `${RAW_CHAINS_FILES_PATH}/images/ink-logo.svg`
 // and https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-57073.json
 export const ink: EvmChainInfo = {
   id: SupportedChainId.INK,
+  cowNetworkName: 'ink',
   label: 'Ink',
   eip155Label: 'Ink Chain Mainnet',
   logo: { light: inkLogo, dark: inkLogo },

--- a/packages/config/src/chains/details/ink.ts
+++ b/packages/config/src/chains/details/ink.ts
@@ -8,7 +8,7 @@ const inkLogo = `${RAW_CHAINS_FILES_PATH}/images/ink-logo.svg`
 // and https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-57073.json
 export const ink: EvmChainInfo = {
   id: SupportedChainId.INK,
-  cowNetworkName: 'ink',
+  internalId: 'ink',
   label: 'Ink',
   eip155Label: 'Ink Chain Mainnet',
   logo: { light: inkLogo, dark: inkLogo },

--- a/packages/config/src/chains/details/linea.ts
+++ b/packages/config/src/chains/details/linea.ts
@@ -7,7 +7,7 @@ const lineaLogo = `${RAW_CHAINS_FILES_PATH}/images/linea-logo.svg`
 // and https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-59144.json
 export const linea: EvmChainInfo = {
   id: SupportedChainId.LINEA,
-  cowNetworkName: 'linea',
+  internalId: 'linea',
   label: 'Linea',
   eip155Label: 'Linea Mainnet',
   logo: { light: lineaLogo, dark: lineaLogo },

--- a/packages/config/src/chains/details/linea.ts
+++ b/packages/config/src/chains/details/linea.ts
@@ -7,6 +7,7 @@ const lineaLogo = `${RAW_CHAINS_FILES_PATH}/images/linea-logo.svg`
 // and https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-59144.json
 export const linea: EvmChainInfo = {
   id: SupportedChainId.LINEA,
+  cowNetworkName: 'linea',
   label: 'Linea',
   eip155Label: 'Linea Mainnet',
   logo: { light: lineaLogo, dark: lineaLogo },

--- a/packages/config/src/chains/details/mainnet.ts
+++ b/packages/config/src/chains/details/mainnet.ts
@@ -11,6 +11,7 @@ const ethereumLogo = `${RAW_CHAINS_FILES_PATH}/images/mainnet-logo.svg`
  */
 export const mainnet: EvmChainInfo = {
   id: SupportedChainId.MAINNET,
+  cowNetworkName: 'mainnet',
   label: 'Ethereum',
   eip155Label: 'Ethereum Mainnet',
   nativeCurrency: {

--- a/packages/config/src/chains/details/mainnet.ts
+++ b/packages/config/src/chains/details/mainnet.ts
@@ -11,7 +11,7 @@ const ethereumLogo = `${RAW_CHAINS_FILES_PATH}/images/mainnet-logo.svg`
  */
 export const mainnet: EvmChainInfo = {
   id: SupportedChainId.MAINNET,
-  cowNetworkName: 'mainnet',
+  internalId: 'mainnet',
   label: 'Ethereum',
   eip155Label: 'Ethereum Mainnet',
   nativeCurrency: {

--- a/packages/config/src/chains/details/optimism.ts
+++ b/packages/config/src/chains/details/optimism.ts
@@ -7,7 +7,7 @@ const optimismLogo = `${RAW_CHAINS_FILES_PATH}/images/optimism-logo.svg`
 // See https://github.com/wevm/viem/blob/main/src/chains/definitions/optimism.ts
 export const optimism: EvmChainInfo = {
   id: 10,
-  cowNetworkName: 'optimism',
+  internalId: 'optimism',
   label: 'Optimism',
   eip155Label: 'OP Mainnet',
   logo: { light: optimismLogo, dark: optimismLogo },

--- a/packages/config/src/chains/details/optimism.ts
+++ b/packages/config/src/chains/details/optimism.ts
@@ -7,6 +7,7 @@ const optimismLogo = `${RAW_CHAINS_FILES_PATH}/images/optimism-logo.svg`
 // See https://github.com/wevm/viem/blob/main/src/chains/definitions/optimism.ts
 export const optimism: EvmChainInfo = {
   id: 10,
+  cowNetworkName: 'optimism',
   label: 'Optimism',
   eip155Label: 'OP Mainnet',
   logo: { light: optimismLogo, dark: optimismLogo },

--- a/packages/config/src/chains/details/plasma.ts
+++ b/packages/config/src/chains/details/plasma.ts
@@ -8,7 +8,7 @@ const dark = light
 // and https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-9745.json
 export const plasma: EvmChainInfo = {
   id: SupportedChainId.PLASMA,
-  cowNetworkName: 'plasma',
+  internalId: 'plasma',
   label: 'Plasma',
   eip155Label: 'Plasma Mainnet',
   logo: { light, dark },

--- a/packages/config/src/chains/details/plasma.ts
+++ b/packages/config/src/chains/details/plasma.ts
@@ -8,6 +8,7 @@ const dark = light
 // and https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-9745.json
 export const plasma: EvmChainInfo = {
   id: SupportedChainId.PLASMA,
+  cowNetworkName: 'plasma',
   label: 'Plasma',
   eip155Label: 'Plasma Mainnet',
   logo: { light, dark },

--- a/packages/config/src/chains/details/polygon.ts
+++ b/packages/config/src/chains/details/polygon.ts
@@ -7,6 +7,7 @@ const polygonLogo = `${RAW_CHAINS_FILES_PATH}/images/polygon-logo.svg`
 // See https://github.com/wevm/viem/blob/main/src/chains/definitions/polygon.ts
 export const polygon: EvmChainInfo = {
   id: SupportedChainId.POLYGON,
+  cowNetworkName: 'polygon',
   label: 'Polygon',
   eip155Label: 'Polygon Mainnet',
   logo: { light: polygonLogo, dark: polygonLogo },

--- a/packages/config/src/chains/details/polygon.ts
+++ b/packages/config/src/chains/details/polygon.ts
@@ -7,7 +7,7 @@ const polygonLogo = `${RAW_CHAINS_FILES_PATH}/images/polygon-logo.svg`
 // See https://github.com/wevm/viem/blob/main/src/chains/definitions/polygon.ts
 export const polygon: EvmChainInfo = {
   id: SupportedChainId.POLYGON,
-  cowNetworkName: 'polygon',
+  internalId: 'polygon',
   label: 'Polygon',
   eip155Label: 'Polygon Mainnet',
   logo: { light: polygonLogo, dark: polygonLogo },

--- a/packages/config/src/chains/details/sepolia.ts
+++ b/packages/config/src/chains/details/sepolia.ts
@@ -11,7 +11,7 @@ const sepoliaLogo = `${RAW_CHAINS_FILES_PATH}/images/sepolia-logo.svg`
  */
 export const sepolia: EvmChainInfo = {
   id: SupportedChainId.SEPOLIA,
-  cowNetworkName: 'sepolia',
+  internalId: 'sepolia',
   label: 'Sepolia',
   eip155Label: 'Ethereum Sepolia',
   nativeCurrency: {

--- a/packages/config/src/chains/details/sepolia.ts
+++ b/packages/config/src/chains/details/sepolia.ts
@@ -11,6 +11,7 @@ const sepoliaLogo = `${RAW_CHAINS_FILES_PATH}/images/sepolia-logo.svg`
  */
 export const sepolia: EvmChainInfo = {
   id: SupportedChainId.SEPOLIA,
+  cowNetworkName: 'sepolia',
   label: 'Sepolia',
   eip155Label: 'Ethereum Sepolia',
   nativeCurrency: {

--- a/packages/config/src/chains/types.ts
+++ b/packages/config/src/chains/types.ts
@@ -215,6 +215,14 @@ export interface EvmChainInfo extends BaseChainInfo {
   readonly id: ChainId
 
   /**
+   * CoW Protocol network name.
+   *
+   * Used by internal services, metrics labels, and database names. This can differ
+   * from display labels, ERC-3770 prefixes, and API URL path segments.
+   */
+  readonly cowNetworkName: string
+
+  /**
    * EIP155 label of the chain. Field used for connecting to MetaMask.
    */
   readonly eip155Label: string
@@ -247,6 +255,14 @@ export interface NonEvmChainInfo extends BaseChainInfo {
    * The chain id for non-EVM chains.
    */
   readonly id: ChainId
+
+  /**
+   * CoW Protocol network name.
+   *
+   * Used by internal services, metrics labels, and database names. This can differ
+   * from display labels, ERC-3770 prefixes, and API URL path segments.
+   */
+  readonly cowNetworkName?: string
 
   /**
    * Native currency of the chain (address is empty string for non-EVM chains).

--- a/packages/config/src/chains/types.ts
+++ b/packages/config/src/chains/types.ts
@@ -215,12 +215,12 @@ export interface EvmChainInfo extends BaseChainInfo {
   readonly id: ChainId
 
   /**
-   * CoW Protocol network name.
+   * Internal CoW Protocol identifier.
    *
    * Used by internal services, metrics labels, and database names. This can differ
    * from display labels, ERC-3770 prefixes, and API URL path segments.
    */
-  readonly cowNetworkName: string
+  readonly internalId?: string
 
   /**
    * EIP155 label of the chain. Field used for connecting to MetaMask.
@@ -257,12 +257,12 @@ export interface NonEvmChainInfo extends BaseChainInfo {
   readonly id: ChainId
 
   /**
-   * CoW Protocol network name.
+   * Internal CoW Protocol identifier.
    *
    * Used by internal services, metrics labels, and database names. This can differ
    * from display labels, ERC-3770 prefixes, and API URL path segments.
    */
-  readonly cowNetworkName?: string
+  readonly internalId?: string
 
   /**
    * Native currency of the chain (address is empty string for non-EVM chains).

--- a/packages/config/src/chains/utils.ts
+++ b/packages/config/src/chains/utils.ts
@@ -89,6 +89,15 @@ export function getChainInfo(chainId: ChainId): ChainInfo | undefined {
 }
 
 /**
+ * Return the CoW Protocol network name for a chain.
+ *
+ * This is used by internal services, metrics labels, and database names.
+ */
+export function getCowNetworkName(chainId: ChainId): string | undefined {
+  return getChainInfo(chainId)?.cowNetworkName
+}
+
+/**
  * Check if the chain is supported by CoW Protocol.
  */
 export function isSupportedChain(chainId: ChainId): chainId is SupportedChainId {

--- a/packages/config/src/chains/utils.ts
+++ b/packages/config/src/chains/utils.ts
@@ -89,12 +89,12 @@ export function getChainInfo(chainId: ChainId): ChainInfo | undefined {
 }
 
 /**
- * Return the CoW Protocol network name for a chain.
+ * Return the internal CoW Protocol identifier for a chain.
  *
  * This is used by internal services, metrics labels, and database names.
  */
-export function getCowNetworkName(chainId: ChainId): string | undefined {
-  return getChainInfo(chainId)?.cowNetworkName
+export function getInternalId(chainId: ChainId): string | undefined {
+  return getChainInfo(chainId)?.internalId
 }
 
 /**


### PR DESCRIPTION
## Why
                                                                        
 - Purpose: expose the network identifier used by CoW infra surfaces like Prometheus labels and database names.                                                                                             
 - Avoids downstream apps maintaining duplicate chain-id → network-name maps.      

## What

 - Add cowNetworkName to SDK chain metadata.                                                                                                                                                                
 - Add getCowNetworkName(chainId) helper.                                                                                                                                                                   
 - Populate CoW network names for configured chains.               
 - Paired with https://github.com/cowprotocol/debug-tool/pull/133                                                                 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-network identifier fields to chain configuration entries for multiple supported networks.

* **Refactor**
  * Extended chain configuration types to include an optional network identifier.
  * Added a utility to read network identifier values from chain configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->