### PR TITLE
feat(app-data): rename MetadataApi to AppDataSdk

### DIFF
--- a/packages/app-data/README.md
+++ b/packages/app-data/README.md
@@ -19,7 +19,7 @@ pnpm add @cowprotocol/sdk-app-data
 ## Usage
 
 ```typescript
-import { MetadataApi } from '@cowprotocol/sdk-app-data'
+import { AppDataSdk } from '@cowprotocol/sdk-app-data'
 import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
 import { JsonRpcProvider, Wallet } from 'ethers'
 
@@ -28,7 +28,7 @@ const provider = new JsonRpcProvider('YOUR_RPC_URL')
 const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
 const adapter = new EthersV6Adapter({ provider, signer: wallet })
 
-export const metadataApi = new MetadataApi(adapter)
+export const appDataSdk = new AppDataSdk(adapter)
 
 const appCode = 'YOUR_APP_CODE'
 const environment = 'prod'
@@ -37,7 +37,7 @@ const referrer = { address: `REFERRER_ADDRESS` }
 const quote = { slippageBips: 1 } // Slippage percent, it's 0 to 100
 const orderClass = { orderClass: 'market' } // "market" | "limit" | "liquidity"
 
-const appDataDoc = await metadataApi.generateAppDataDoc({
+const appDataDoc = await appDataSdk.generateAppDataDoc({
   appCode,
   environment,
   metadata: {
@@ -48,7 +48,7 @@ const appDataDoc = await metadataApi.generateAppDataDoc({
 })
 
 // Get appData info
-const { appDataContent, appDataHex, cid } = await metadataApi.getAppDataInfo(appDataDoc)
+const { appDataContent, appDataHex, cid } = await appDataSdk.getAppDataInfo(appDataDoc)
 
 // The app-data hex string (app-data part of the order struct)
 console.log(appDataHex)
@@ -66,10 +66,10 @@ console.log(cid)
 
 ### Using via Cow SDK
 
-You can also import `MetadataApi` directly from the main SDK:
+You can also import `AppDataSdk` directly from the main SDK:
 
 ```typescript
-import { MetadataApi } from '@cowprotocol/cow-sdk'
+import { AppDataSdk } from '@cowprotocol/cow-sdk'
 import { EthersV6Adapter } from '@cowprotocol/sdk-ethers-v6-adapter'
 import { JsonRpcProvider, Wallet } from 'ethers'
 
@@ -78,7 +78,7 @@ const provider = new JsonRpcProvider('YOUR_RPC_URL')
 const wallet = new Wallet('YOUR_PRIVATE_KEY', provider)
 const adapter = new EthersV6Adapter({ provider, signer: wallet })
 
-export const metadataApi = new MetadataApi(adapter)
+export const appDataSdk = new AppDataSdk(adapter)
 // ... rest of the usage remains the same
 ```
 

--- a/packages/app-data/src/api/index.ts
+++ b/packages/app-data/src/api/index.ts
@@ -11,10 +11,10 @@ import { uploadMetadataDocToIpfsLegacy } from './uploadMetadataDocToIpfsLegacy'
 import { validateAppDataDoc } from './validateAppDataDoc'
 
 /**
- * MetadataApi provides a convenient interface for interacting with CoW Protocol's
+ * AppDataSdk provides a convenient interface for interacting with CoW Protocol's
  * app-data functionality. It supports both direct method calls and object-oriented usage.
  */
-export class MetadataApi {
+export class AppDataSdk {
   /**
    * Creates a new MetadataApi instance
    *
@@ -51,3 +51,9 @@ export class MetadataApi {
     fetchDocFromAppDataHex: fetchDocFromAppDataHexLegacy, // appDataHex --> appData
   }
 }
+
+/**
+ * @deprecated use AppDataSdk instead
+ * The class exists for backward compatibility only and should be deleted in the future
+ */
+export class MetadataApi extends AppDataSdk {}


### PR DESCRIPTION
The package name is `@cowprotocol/sdk-app-data`, it would be more coherent to call the main class `AppDataSdk`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `AppDataSdk` as the primary interface for app-data operations with consolidated functionality.
  * `MetadataApi` is now deprecated; `AppDataSdk` is the recommended approach.

* **Documentation**
  * Updated usage examples and import statements to reflect the new interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->