### PR TITLE
refactor: rename util function

### DIFF
--- a/packages/config/src/chains/utils.ts
+++ b/packages/config/src/chains/utils.ts
@@ -93,6 +93,13 @@ export function getChainInfo(chainId: ChainId): ChainInfo | undefined {
  *
  * This is used by internal services, metrics labels, and database names.
  */
+export function getInternalChainId(chainId: ChainId): string | undefined {
+  return getChainInfo(chainId)?.internalId
+}
+
+/**
+ * @deprecated use `getInternalChainId` instead.
+ */
 export function getInternalId(chainId: ChainId): string | undefined {
   return getChainInfo(chainId)?.internalId
 }


### PR DESCRIPTION
`getInternalId` is too generic, as pointed out here https://github.com/cowprotocol/debug-tool/pull/133#discussion_r3390495579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced improved chain identification utilities for enhanced chain data handling.

* **Deprecations**
  * Existing chain utility function marked as deprecated; implementations should migrate to the updated function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->