### PR TITLE
feat!: migrate to API v2 for /solver_competition

### DIFF
--- a/packages/order-book/src/api.spec.ts
+++ b/packages/order-book/src/api.spec.ts
@@ -699,7 +699,7 @@ describe('CoW Api', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.fi/xdai/api/v1/solver_competition/${auctionId}`,
+      `https://api.cow.fi/xdai/api/v2/solver_competition/${auctionId}`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(competition).toEqual(AUCTION)
@@ -719,7 +719,7 @@ describe('CoW Api', () => {
     // then
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.cow.fi/xdai/api/v1/solver_competition/by_tx_hash/${txHash}`,
+      `https://api.cow.fi/xdai/api/v2/solver_competition/by_tx_hash/${txHash}`,
       FETCH_RESPONSE_PARAMETERS,
     )
     expect(competition).toEqual(AUCTION)

--- a/packages/order-book/src/api.ts
+++ b/packages/order-book/src/api.ts
@@ -446,7 +446,7 @@ export class OrderBookApi {
   ): Promise<SolverCompetitionResponse> {
     return this.fetch(
       {
-        path: `/api/v1/solver_competition${typeof auctionIdorTx === 'string' ? '/by_tx_hash' : ''}/${auctionIdorTx}`,
+        path: `/api/v2/solver_competition${typeof auctionIdorTx === 'string' ? '/by_tx_hash' : ''}/${auctionIdorTx}`,
         method: 'GET',
       },
       contextOverride,


### PR DESCRIPTION
/v1 was deleted.
Request example: https://api.cow.fi/mainnet/api/v2/solver_competition/by_tx_hash/0xfc444f71fd54cb440f45b84db763d1960162e82fbb851b1f092f859ba97f224a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated solver competition data retrieval to use the newer API version.
  * Preserved existing behavior for selecting results by transaction hash versus other identifiers.
  * Adjusted related tests to match the updated API endpoint paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->