### PR TITLE
chore: add github-actions-only renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,32 @@
+// This file follows JSON5 syntax, to make it
+// easier to maintain.
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  // Disable every built-in manager (npm, dockerfile, ...) except github-actions.
+  enabledManagers: ["github-actions"],
+  // PR titles use Conventional Commits: `deps(<action>): ...`
+  semanticCommits: "enabled",
+  semanticCommitType: "deps",
+  packageRules: [
+    // GitHub Actions updates: run weekly, skip releases newer than 2 weeks
+    // to avoid picking up freshly published versions that may be unstable or
+    // compromised, and pin to full commit SHAs (with the version as a
+    // trailing comment) rather than mutable tags.
+    // When both major and minor releases exist, propose only the latest bump
+    // (typically major) instead of a separate minor PR.
+    {
+      matchManagers: ["github-actions"],
+      schedule: ["on monday"],
+      minimumReleaseAge: "14 days",
+      // Track upgrades by semver tag, but pin the resolved version to its full
+      // commit SHA (semver tag kept as a trailing comment). Use the coerced
+      // variant so short tags like `v3` / `v1.7` (which several actions only
+      // publish) still parse instead of silently stopping updates.
+      versioning: "semver-coerced",
+      pinDigests: true,
+      separateMajorMinor: false,
+      semanticCommitScope: "{{depName}}",
+      commitMessageTopic: "{{depName}}",
+    },
+  ],
+}


### PR DESCRIPTION
Adds a github-actions-only Renovate config: weekly, 2-week-aged, SHA-pinned GitHub Actions bumps with Conventional Commit `deps(<action>):` titles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update automation to focus on workflow action updates only.
  * Dependency update PRs will now follow a consistent schedule, use older releases only after a delay, and pin versions more strictly for stability.
  * Commit messages for these updates now follow a more standardized format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->