### PR TITLE
test(composable): reach full unit test coverage

### DIFF
--- a/packages/composable/src/orderTypes/test/TestConditionalOrder.ts
+++ b/packages/composable/src/orderTypes/test/TestConditionalOrder.ts
@@ -1,3 +1,4 @@
+import { AbstractProviderAdapter } from '@cowprotocol/sdk-common'
 import { ConditionalOrder } from '../../ConditionalOrder'
 import { GPv2Order, IsValidResult, PollParams, PollResultErrors } from '../../types'
 import { encodeParams } from '../../utils'
@@ -18,13 +19,16 @@ export type TestConditionalOrderParams = {
 export class TestConditionalOrder extends ConditionalOrder<string, string> {
   isSingleOrder: boolean
 
-  constructor(params: TestConditionalOrderParams) {
+  constructor(params: TestConditionalOrderParams, adapter?: AbstractProviderAdapter) {
     const { handler, salt, data = '0x', isSingleOrder = true } = params
-    super({
-      handler,
-      salt,
-      data,
-    })
+    super(
+      {
+        handler,
+        salt,
+        data,
+      },
+      adapter,
+    )
     this.isSingleOrder = isSingleOrder
   }
 

--- a/packages/composable/src/utils.ts
+++ b/packages/composable/src/utils.ts
@@ -42,13 +42,15 @@ export async function getDomainVerifier(
   chainId: SupportedChainId,
   provider: Provider,
 ): Promise<string> {
-  return (await getGlobalAdapter().readContract({
-    address: EXTENSIBLE_FALLBACK_HANDLER_CONTRACT_ADDRESS[chainId],
-    abi: ExtensibleFallbackHandlerFactoryAbi,
-    functionName: 'domainVerifiers',
-    args: [safe, domain],
-  }),
-  provider) as string
+  return (await getGlobalAdapter().readContract(
+    {
+      address: EXTENSIBLE_FALLBACK_HANDLER_CONTRACT_ADDRESS[chainId],
+      abi: ExtensibleFallbackHandlerFactoryAbi,
+      functionName: 'domainVerifiers',
+      args: [safe, domain],
+    },
+    provider,
+  )) as string
 }
 
 export function createSetDomainVerifierTx(domain: string, verifier: string): string {

--- a/packages/composable/tests/ConditionalOrder.spec.ts
+++ b/packages/composable/tests/ConditionalOrder.spec.ts
@@ -2,10 +2,12 @@ import {
   DEFAULT_ORDER_PARAMS,
   TestConditionalOrder,
   createTestConditionalOrder,
+  type TestConditionalOrderParams,
 } from '../src/orderTypes/test/TestConditionalOrder'
 import { ConditionalOrder } from '../src/ConditionalOrder'
-import { Twap } from '../src/orderTypes/Twap'
+import { Twap, CURRENT_BLOCK_TIMESTAMP_FACTORY_ADDRESS } from '../src/orderTypes/Twap'
 import { TWAP_PARAMS_TEST } from './Twap.spec'
+import { ComposableCowFactoryAbi } from '../src/abis/ComposableCowFactoryAbi'
 
 import { GPv2Order, OwnerContext, PollParams, PollResultCode, PollResultErrors } from '../src/types'
 import { BuyTokenDestination, OrderBookApi, OrderKind, SellTokenSource } from '@cowprotocol/sdk-order-book'
@@ -102,8 +104,7 @@ describe('ConditionalOrder - Multi-Adapter Tests', () => {
     test('should default optional constructor fields', () => {
       const order = new TestConditionalOrder({
         handler: DEFAULT_ORDER_PARAMS.handler,
-        data: DEFAULT_ORDER_PARAMS.data,
-      })
+      } as TestConditionalOrderParams)
 
       expect(order.encodeStaticInput()).toBe('0x')
       expect(order.isSingleOrder).toBe(true)
@@ -773,21 +774,78 @@ describe('ConditionalOrder - Multi-Adapter Tests', () => {
   })
 
   describe('calldata helpers', () => {
+    function decodeCalldata(functionName: 'create' | 'createWithContext' | 'remove', calldata: string) {
+      return adapters.viemAdapter.utils.decodeFunctionData(ComposableCowFactoryAbi, functionName, calldata)
+    }
+
+    function expectFunctionSelector(functionName: 'create' | 'createWithContext' | 'remove', calldata: string) {
+      const selector = adapters.viemAdapter.utils
+        .id(`${functionName}((address,bytes32,bytes),bool)`)
+        .slice(0, 10)
+
+      if (functionName === 'createWithContext') {
+        expect(calldata.slice(0, 10)).toBe(
+          adapters.viemAdapter.utils.id(`${functionName}((address,bytes32,bytes),address,bytes,bool)`).slice(0, 10),
+        )
+        return
+      }
+
+      if (functionName === 'remove') {
+        expect(calldata.slice(0, 10)).toBe(adapters.viemAdapter.utils.id('remove(bytes32)').slice(0, 10))
+        return
+      }
+
+      expect(calldata.slice(0, 10)).toBe(selector)
+    }
+
     test('should encode create and remove calldata for valid orders', () => {
       setGlobalAdapter(adapters.viemAdapter)
 
       const order = createTestConditionalOrder()
+      const createCalldata = order.createCalldata
+      const removeCalldata = order.removeCalldata
 
-      expect(order.createCalldata).toMatch(/^0x/)
-      expect(order.removeCalldata).toMatch(/^0x/)
+      expectFunctionSelector('create', createCalldata)
+      expectFunctionSelector('remove', removeCalldata)
+
+      const [params, dispatch] = decodeCalldata('create', createCalldata) as [
+        { handler: string; salt: string; staticInput: string },
+        boolean,
+      ]
+      const [orderId] = decodeCalldata('remove', removeCalldata) as [string]
+
+      expect(params).toEqual({
+        handler: order.handler,
+        salt: order.salt,
+        staticInput: order.encodeStaticInput(),
+      })
+      expect(dispatch).toBe(true)
+      expect(orderId).toBe(order.id)
     })
 
     test('should encode createWithContext calldata when context has no factory args', () => {
       setGlobalAdapter(adapters.viemAdapter)
 
       const twap = Twap.fromData(TWAP_PARAMS_TEST)
+      const createCalldata = twap.createCalldata
 
-      expect(twap.createCalldata).toMatch(/^0x/)
+      expectFunctionSelector('createWithContext', createCalldata)
+
+      const [params, factory, factoryData, dispatch] = decodeCalldata('createWithContext', createCalldata) as [
+        { handler: string; salt: string; staticInput: string },
+        string,
+        string,
+        boolean,
+      ]
+
+      expect(params).toEqual({
+        handler: twap.handler,
+        salt: twap.salt,
+        staticInput: twap.encodeStaticInput(),
+      })
+      expect(factory).toBe(CURRENT_BLOCK_TIMESTAMP_FACTORY_ADDRESS)
+      expect(factoryData).toBe('0x')
+      expect(dispatch).toBe(true)
     })
 
     test('should encode createWithContext calldata when an order has context', () => {
@@ -806,8 +864,25 @@ describe('ConditionalOrder - Multi-Adapter Tests', () => {
       }
 
       const order = new ContextOrder(DEFAULT_ORDER_PARAMS)
+      const createCalldata = order.createCalldata
 
-      expect(order.createCalldata).toMatch(/^0x/)
+      expectFunctionSelector('createWithContext', createCalldata)
+
+      const [params, factory, factoryData, dispatch] = decodeCalldata('createWithContext', createCalldata) as [
+        { handler: string; salt: string; staticInput: string },
+        string,
+        string,
+        boolean,
+      ]
+
+      expect(params).toEqual({
+        handler: order.handler,
+        salt: order.salt,
+        staticInput: order.encodeStaticInput(),
+      })
+      expect(factory).toBe('0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc')
+      expect(adapters.viemAdapter.utils.decodeAbi(['uint256'], factoryData)[0]).toBe(42n)
+      expect(dispatch).toBe(true)
     })
 
     test('should throw when generating calldata for invalid orders', () => {
@@ -834,9 +909,6 @@ describe('ConditionalOrder - Multi-Adapter Tests', () => {
 
       expect(order.orderType).toBe('TEST')
       expect(order.encodeStaticInput()).toBe(DEFAULT_ORDER_PARAMS.data)
-      expect(new TestConditionalOrder({ ...DEFAULT_ORDER_PARAMS, data: undefined as unknown as string }).encodeStaticInput()).toBe(
-        '0x',
-      )
       expect(order.transformStructToData('0x01')).toBe('0x01')
       expect(order.transformDataToStruct('0x02')).toBe('0x02')
     })

--- a/packages/composable/tests/ConditionalOrder.spec.ts
+++ b/packages/composable/tests/ConditionalOrder.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '../src/orderTypes/test/TestConditionalOrder'
 import { ConditionalOrder } from '../src/ConditionalOrder'
 import { Twap } from '../src/orderTypes/Twap'
+import { TWAP_PARAMS_TEST } from './Twap.spec'
 
 import { GPv2Order, OwnerContext, PollParams, PollResultCode, PollResultErrors } from '../src/types'
 import { BuyTokenDestination, OrderBookApi, OrderKind, SellTokenSource } from '@cowprotocol/sdk-order-book'
@@ -90,6 +91,32 @@ describe('ConditionalOrder - Multi-Adapter Tests', () => {
       orders.forEach((order) => {
         expect(order).toBeDefined()
       })
+    })
+
+    test('should accept an adapter in the constructor', () => {
+      const order = new TestConditionalOrder(DEFAULT_ORDER_PARAMS, adapters.ethersV5Adapter)
+
+      expect(order.isValid().isValid).toBe(true)
+    })
+
+    test('should default optional constructor fields', () => {
+      const order = new TestConditionalOrder({
+        handler: DEFAULT_ORDER_PARAMS.handler,
+        data: DEFAULT_ORDER_PARAMS.data,
+      })
+
+      expect(order.encodeStaticInput()).toBe('0x')
+      expect(order.isSingleOrder).toBe(true)
+    })
+
+    test('should allow overriding isSingleOrder', () => {
+      const order = new TestConditionalOrder({
+        handler: DEFAULT_ORDER_PARAMS.handler,
+        data: DEFAULT_ORDER_PARAMS.data,
+        isSingleOrder: false,
+      })
+
+      expect(order.isSingleOrder).toBe(false)
     })
 
     test('should fail with bad address across all adapters', () => {
@@ -698,6 +725,126 @@ describe('ConditionalOrder - Multi-Adapter Tests', () => {
 
         jest.restoreAllMocks()
       }
+    })
+
+    test('should return handlePollFailedAlreadyPresent result when order is already in orderbook', async () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      class OrderInBookOrder extends TestConditionalOrder {
+        protected handlePollFailedAlreadyPresent(): Promise<PollResultErrors> {
+          return Promise.resolve({
+            result: PollResultCode.TRY_AT_EPOCH,
+            epoch: 1_800_000_000,
+            reason: 'Handled by order type',
+          })
+        }
+      }
+
+      const param = {
+        owner: OWNER,
+        chainId: 1,
+        provider: {},
+        orderBookApi: mockOrderBookApi as unknown as OrderBookApi,
+      } as PollParams
+
+      jest.spyOn(adapters.viemAdapter, 'readContract').mockImplementation(async (params) => {
+        if (params.functionName === 'getTradeableOrderWithSignature') {
+          return [DISCRETE_ORDER, signature]
+        }
+        if (params.functionName === 'singleOrders') {
+          return true
+        }
+        throw new Error(`Unexpected call: ${params.functionName}`)
+      })
+
+      const order = new OrderInBookOrder(DEFAULT_ORDER_PARAMS)
+      mockOrderBookApi.getOrder.mockResolvedValue({})
+
+      const pollResult = await order.poll(param)
+
+      expect(pollResult).toEqual({
+        result: PollResultCode.TRY_AT_EPOCH,
+        epoch: 1_800_000_000,
+        reason: 'Handled by order type',
+      })
+
+      jest.restoreAllMocks()
+    })
+  })
+
+  describe('calldata helpers', () => {
+    test('should encode create and remove calldata for valid orders', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const order = createTestConditionalOrder()
+
+      expect(order.createCalldata).toMatch(/^0x/)
+      expect(order.removeCalldata).toMatch(/^0x/)
+    })
+
+    test('should encode createWithContext calldata when context has no factory args', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const twap = Twap.fromData(TWAP_PARAMS_TEST)
+
+      expect(twap.createCalldata).toMatch(/^0x/)
+    })
+
+    test('should encode createWithContext calldata when an order has context', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      class ContextOrder extends TestConditionalOrder {
+        get context() {
+          return {
+            address: '0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc',
+            factoryArgs: {
+              argsType: ['uint256'],
+              args: [42n],
+            },
+          }
+        }
+      }
+
+      const order = new ContextOrder(DEFAULT_ORDER_PARAMS)
+
+      expect(order.createCalldata).toMatch(/^0x/)
+    })
+
+    test('should throw when generating calldata for invalid orders', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      class InvalidOrder extends TestConditionalOrder {
+        isValid() {
+          return { isValid: false, reason: 'Nope' }
+        }
+      }
+
+      const order = new InvalidOrder(DEFAULT_ORDER_PARAMS)
+
+      expect(() => order.createCalldata).toThrow('Invalid order: Nope')
+      expect(() => order.removeCalldata).toThrow('Invalid order: Nope')
+    })
+  })
+
+  describe('TestConditionalOrder helpers', () => {
+    test('should expose order type and helper methods', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const order = createTestConditionalOrder()
+
+      expect(order.orderType).toBe('TEST')
+      expect(order.encodeStaticInput()).toBe(DEFAULT_ORDER_PARAMS.data)
+      expect(new TestConditionalOrder({ ...DEFAULT_ORDER_PARAMS, data: undefined as unknown as string }).encodeStaticInput()).toBe(
+        '0x',
+      )
+      expect(order.transformStructToData('0x01')).toBe('0x01')
+      expect(order.transformDataToStruct('0x02')).toBe('0x02')
+    })
+
+    test('should throw from toString until implemented', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      expect(() => createTestConditionalOrder().toString()).toThrow('Method not implemented.')
     })
   })
 })

--- a/packages/composable/tests/ConditionalOrderFactory.spec.ts
+++ b/packages/composable/tests/ConditionalOrderFactory.spec.ts
@@ -1,0 +1,53 @@
+import { ConditionalOrderFactory } from '../src/ConditionalOrderFactory'
+import { TWAP_ADDRESS, Twap } from '../src/orderTypes/Twap'
+import { DEFAULT_CONDITIONAL_ORDER_REGISTRY } from '../src/orderTypes'
+import { TWAP_PARAMS_TEST } from './Twap.spec'
+import { createAdapters } from './setup'
+import { setGlobalAdapter } from '@cowprotocol/sdk-common'
+
+describe('ConditionalOrderFactory', () => {
+  const adapters = createAdapters()
+
+  beforeAll(() => {
+    setGlobalAdapter(adapters.viemAdapter)
+  })
+
+  it('normalizes registry keys to lowercase', () => {
+    const factory = new ConditionalOrderFactory({
+      [TWAP_ADDRESS.toUpperCase()]: (params) => Twap.fromParams(params),
+    })
+
+    expect(factory.knownOrderTypes[TWAP_ADDRESS.toLowerCase()]).toBeDefined()
+  })
+
+  it('instantiates a TWAP from params via the default registry', () => {
+    const twap = Twap.fromData(TWAP_PARAMS_TEST)
+    const factory = new ConditionalOrderFactory(DEFAULT_CONDITIONAL_ORDER_REGISTRY)
+    const order = factory.fromParams(twap.leaf)
+
+    expect(order).toBeInstanceOf(Twap)
+    expect(order?.id).toBe(twap.id)
+  })
+
+  it('uses the provided adapter in the constructor', () => {
+    const factory = new ConditionalOrderFactory(DEFAULT_CONDITIONAL_ORDER_REGISTRY, adapters.ethersV5Adapter)
+
+    expect(factory.knownOrderTypes[TWAP_ADDRESS.toLowerCase()]).toBeDefined()
+  })
+
+  it('returns undefined for unknown handlers', () => {
+    const factory = new ConditionalOrderFactory(DEFAULT_CONDITIONAL_ORDER_REGISTRY)
+
+    expect(
+      factory.fromParams({
+        handler: '0x0000000000000000000000000000000000000001',
+        salt: twapSalt(),
+        staticInput: '0x',
+      }),
+    ).toBeUndefined()
+  })
+})
+
+function twapSalt(): string {
+  return Twap.fromData(TWAP_PARAMS_TEST).salt
+}

--- a/packages/composable/tests/Multiplexer.spec.ts
+++ b/packages/composable/tests/Multiplexer.spec.ts
@@ -430,4 +430,97 @@ describe('Multiplexer (ComposableCoW) - Multi-Adapter Tests', () => {
       }
     })
   })
+
+  describe('Error handling', () => {
+    test('should throw when accessing missing orders', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const m = new Multiplexer(SupportedChainId.GNOSIS_CHAIN)
+      const twap = Twap.fromData(TWAP_PARAMS_TEST)
+      m.add(twap)
+
+      expect(() => m.getById('0x' + 'ab'.repeat(32))).toThrow('Order with id')
+      expect(() => m.getByIndex(99)).toThrow('Order with index 99 not found')
+      expect(() => m.update('0x' + 'cd'.repeat(32), (order) => order)).toThrow('Order with id')
+
+      jest.spyOn(m, 'orderIds', 'get').mockReturnValue([twap.id])
+      Reflect.deleteProperty(m as { orders: Orders }, 'orders')
+      ;(m as { orders: Orders }).orders = {}
+
+      expect(() => m.getByIndex(0)).toThrow(`Order with id ${twap.id} not found`)
+    })
+  })
+
+  describe('Static poll', () => {
+    const OWNER = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
+    const signature = '0x' + '11'.repeat(65)
+
+    test('should read tradeable orders with and without off-chain input', async () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const twap = Twap.fromData(TWAP_PARAMS_TEST)
+      const proofWithParams = {
+        proof: ['0x' + '22'.repeat(32)],
+        params: twap.leaf,
+      }
+      const order = {
+        sellToken: TWAP_PARAMS_TEST.sellToken,
+        buyToken: TWAP_PARAMS_TEST.buyToken,
+        receiver: TWAP_PARAMS_TEST.receiver,
+        sellAmount: 1n,
+        buyAmount: 1n,
+        validTo: 1,
+        appData: TWAP_PARAMS_TEST.appData,
+        feeAmount: 0n,
+        kind: '0xf3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee346775',
+        partiallyFillable: false,
+        sellTokenBalance: '0x5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9',
+        buyTokenBalance: '0x5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9',
+      }
+
+      const readContract = jest.spyOn(adapters.viemAdapter, 'readContract').mockResolvedValue([order, signature])
+
+      await expect(
+        Multiplexer.poll(OWNER, proofWithParams, SupportedChainId.MAINNET, {}),
+      ).resolves.toEqual([order, signature])
+
+      await expect(
+        Multiplexer.poll(OWNER, proofWithParams, SupportedChainId.MAINNET, {}, async () => '0xbeef'),
+      ).resolves.toEqual([order, signature])
+
+      expect(readContract).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          functionName: 'getTradeableOrderWithSignature',
+          args: [OWNER, proofWithParams.params, '0x', proofWithParams.proof],
+        }),
+        {},
+      )
+      expect(readContract).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          args: [OWNER, proofWithParams.params, '0xbeef', proofWithParams.proof],
+        }),
+        {},
+      )
+
+      jest.restoreAllMocks()
+    })
+  })
+
+  describe('Serialization edge cases', () => {
+    test('should reject legacy BigNumber-shaped JSON values during deserialization', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const payload = JSON.stringify({
+        chain: SupportedChainId.GNOSIS_CHAIN,
+        orders: {},
+        root: '0x' + '00'.repeat(32),
+        location: ProofLocation.EMITTED,
+        legacy: { type: 'BigNumber', hex: '0x01' },
+      })
+
+      expect(() => Multiplexer.fromJSON(payload)).toThrow()
+    })
+  })
 })

--- a/packages/composable/tests/Twap.spec.ts
+++ b/packages/composable/tests/Twap.spec.ts
@@ -1,6 +1,6 @@
 import { Block, getGlobalAdapter, Provider, setGlobalAdapter, ZERO_ADDRESS } from '@cowprotocol/sdk-common'
 import { GPv2Order, OwnerContext, PollParams, PollResultCode, PollResultErrors } from '../src/types'
-import { DurationType, StartTimeValue, Twap, TWAP_ADDRESS, TwapData } from '../src/orderTypes/Twap'
+import { DurationType, StartTimeValue, Twap, TWAP_ADDRESS, transformDataToStruct, transformStructToData, TwapData } from '../src/orderTypes/Twap'
 
 import { createAdapters } from './setup'
 
@@ -845,6 +845,35 @@ describe('TWAP Order - Multi-Adapter Tests', () => {
       })
     })
 
+    test('should return DONT_TRY_AGAIN when cabinet is not set for mining-time TWAPs', async () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const twap = new MockTwap({ handler: TWAP_ADDRESS, data: TWAP_PARAMS_TEST })
+      mockCabinet.mockReturnValue(uint256Helper(0))
+
+      const result = await twap.pollValidate({ ...pollParams, blockInfo: { blockNumber, blockTimestamp } })
+
+      expect(result).toEqual({
+        result: PollResultCode.DONT_TRY_AGAIN,
+        reason:
+          'Cabinet is not set. Required for TWAP orders that start at mining time.. User likely removed the order.',
+      })
+    })
+
+    test('should return UNEXPECTED_ERROR when poll validation fails unexpectedly', async () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const twap = new MockTwap({ handler: TWAP_ADDRESS, data: TWAP_PARAMS_TEST })
+      mockCabinet.mockRejectedValue(new Error('rpc unavailable'))
+
+      const result = await twap.pollValidate({ ...pollParams, blockInfo: { blockNumber, blockTimestamp } })
+
+      expect(result).toMatchObject({
+        result: PollResultCode.UNEXPECTED_ERROR,
+        reason: 'Unexpected error: rpc unavailable',
+      })
+    })
+
     test('should fetch latest block when blockInfo is not provided across all adapters', async () => {
       const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
 
@@ -1032,6 +1061,188 @@ describe('TWAP Order - Multi-Adapter Tests', () => {
         reason: "TWAP part hash't started. First TWAP part start at 1700000000 (2023-11-14T22:13:20.000Z)",
         error: undefined,
       })
+    })
+
+    test('should return UNEXPECTED_ERROR when TWAP is already expired', async () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const pollParams = getPollParams({
+        blockTimestamp: startTimestamp + 10 * timeBetweenParts,
+      })
+
+      const twap = new MockTwap({
+        handler: TWAP_ADDRESS,
+        data: {
+          ...TWAP_PARAMS_TEST,
+          timeBetweenParts: BigInt(timeBetweenParts),
+          numberOfParts: BigInt(10),
+          startTime: {
+            startType: StartTimeValue.AT_EPOCH,
+            epoch: BigInt(startTimestamp),
+          },
+        },
+      })
+
+      const result = await twap.handlePollFailedAlreadyPresent(orderId, order, pollParams)
+
+      expect(result).toEqual({
+        result: PollResultCode.UNEXPECTED_ERROR,
+        reason: 'TWAP is expired. Expired at 1700001000 (2023-11-14T22:30:00.000Z)',
+        error: undefined,
+      })
+    })
+    test('should handle polling when blockInfo is not provided', async () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      jest.spyOn(adapters.viemAdapter, 'getBlock').mockResolvedValue({
+        number: 123456n,
+        timestamp: 1_700_000_000n,
+      } as never)
+
+      const twap = new MockTwap({
+        handler: TWAP_ADDRESS,
+        data: {
+          ...TWAP_PARAMS_TEST,
+          timeBetweenParts: BigInt(100),
+          numberOfParts: BigInt(10),
+          startTime: {
+            startType: StartTimeValue.AT_EPOCH,
+            epoch: BigInt(1_700_000_000),
+          },
+        },
+      })
+
+      const result = await twap.handlePollFailedAlreadyPresent(orderId, order, {
+        owner: OWNER,
+        chainId: 1,
+        provider: {},
+      })
+
+      expect(result?.result).toBe(PollResultCode.TRY_AT_EPOCH)
+
+      jest.restoreAllMocks()
+    })
+  })
+
+  describe('factory and transforms', () => {
+    test('should instantiate from params and round-trip struct transforms', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const twap = Twap.fromData(TWAP_PARAMS_TEST)
+      const fromParams = Twap.fromParams(twap.leaf)
+
+      expect(fromParams.id).toBe(twap.id)
+      expect(twap.transformStructToData(twap.staticInput)).toEqual(twap.data)
+    })
+
+    test('should compute end timestamp for auto-duration TWAPs', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      class EndTimestampTwap extends Twap {
+        public computeEndTimestamp(startTimestamp: number): number {
+          return this.endTimestamp(startTimestamp)
+        }
+      }
+
+      const twap = new EndTimestampTwap({
+        handler: TWAP_ADDRESS,
+        data: TWAP_PARAMS_TEST,
+      })
+
+      expect(twap.computeEndTimestamp(1_000)).toBe(1_000 + 10 * 3_600)
+    })
+
+    test('should compute end timestamp for limit-duration TWAPs', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      class EndTimestampTwap extends Twap {
+        public computeEndTimestamp(startTimestamp: number): number {
+          return this.endTimestamp(startTimestamp)
+        }
+      }
+
+      const twap = new EndTimestampTwap({
+        handler: TWAP_ADDRESS,
+        data: {
+          ...TWAP_PARAMS_TEST,
+          durationOfPart: {
+            durationType: DurationType.LIMIT_DURATION,
+            duration: 500n,
+          },
+        },
+      })
+
+      expect(twap.computeEndTimestamp(1_000)).toBe(1_000 + 9 * 3_600 + 500)
+    })
+
+    test('should use default start time and duration when transforming partial data', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const partialData = { ...TWAP_PARAMS_TEST } as Partial<TwapData>
+      delete partialData.startTime
+      delete partialData.durationOfPart
+
+      const struct = transformDataToStruct(partialData as TwapData)
+
+      expect(struct.t0).toBe(0n)
+      expect(struct.span).toBe(0n)
+      expect(transformStructToData(struct).startTime.startType).toBe(StartTimeValue.AT_MINING_TIME)
+    })
+
+    test('should round-trip limit-duration structs', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const struct = transformDataToStruct({
+        ...TWAP_PARAMS_TEST,
+        durationOfPart: { durationType: DurationType.LIMIT_DURATION, duration: 500n },
+      })
+
+      expect(transformStructToData(struct).durationOfPart).toEqual({
+        durationType: DurationType.LIMIT_DURATION,
+        duration: 500n,
+      })
+    })
+
+    test('should validate TWAPs that rely on default start time and duration fields', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const partialData = { ...TWAP_PARAMS_TEST } as Partial<TwapData>
+      delete partialData.startTime
+      delete partialData.durationOfPart
+
+      expect(new Twap({ handler: TWAP_ADDRESS, data: partialData as TwapData }).isValid()).toEqual({
+        isValid: true,
+      })
+    })
+
+    test('should invalidate epoch start times outside uint32 range', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const result = Twap.fromData({
+        ...TWAP_PARAMS_TEST,
+        startTime: { startType: StartTimeValue.AT_EPOCH, epoch: BigInt(2 ** 32) },
+      }).isValid()
+
+      expect(result).toEqual({ isValid: false, reason: 'InvalidStartTime' })
+    })
+
+    test('should accept an adapter in the Twap constructor', () => {
+      const twap = new Twap({ handler: TWAP_ADDRESS, data: TWAP_PARAMS_TEST }, adapters.ethersV5Adapter)
+
+      expect(twap.isValid().isValid).toBe(true)
+    })
+
+    test('should format toString with default start time and duration', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const partialData = { ...TWAP_PARAMS_TEST } as Partial<TwapData>
+      delete partialData.startTime
+      delete partialData.durationOfPart
+
+      const twap = new Twap({ handler: TWAP_ADDRESS, data: partialData as TwapData })
+
+      expect(twap.toString()).toContain('AT_MINING_TIME')
+      expect(twap.toString()).toContain('"durationOfPart":"AUTO"')
     })
   })
 })

--- a/packages/composable/tests/index.spec.ts
+++ b/packages/composable/tests/index.spec.ts
@@ -1,0 +1,15 @@
+import * as composable from '../src/index'
+import { DEFAULT_CONDITIONAL_ORDER_REGISTRY, TWAP_ADDRESS } from '../src/orderTypes'
+
+describe('package exports', () => {
+  it('re-exports core composable APIs from the package entrypoint', () => {
+    expect(composable.ConditionalOrder).toBeDefined()
+    expect(composable.ConditionalOrderFactory).toBeDefined()
+    expect(composable.Multiplexer).toBeDefined()
+    expect(composable.Twap).toBeDefined()
+  })
+
+  it('exposes the default conditional order registry', () => {
+    expect(DEFAULT_CONDITIONAL_ORDER_REGISTRY[TWAP_ADDRESS]).toBeDefined()
+  })
+})

--- a/packages/composable/tests/index.spec.ts
+++ b/packages/composable/tests/index.spec.ts
@@ -1,8 +1,9 @@
-import * as composable from '../src/index'
-import { DEFAULT_CONDITIONAL_ORDER_REGISTRY, TWAP_ADDRESS } from '../src/orderTypes'
+import { DEFAULT_CONDITIONAL_ORDER_REGISTRY, TWAP_ADDRESS } from '../src/index'
 
 describe('package exports', () => {
-  it('re-exports core composable APIs from the package entrypoint', () => {
+  it('re-exports core composable APIs from the package entrypoint', async () => {
+    const composable = await import('../src/index')
+
     expect(composable.ConditionalOrder).toBeDefined()
     expect(composable.ConditionalOrderFactory).toBeDefined()
     expect(composable.Multiplexer).toBeDefined()

--- a/packages/composable/tests/utils.spec.ts
+++ b/packages/composable/tests/utils.spec.ts
@@ -1,8 +1,22 @@
 import { decodeParams, encodeParams, fromStructToOrder, isValidAbi } from '../src/utils'
+import {
+  createSetDomainVerifierTx,
+  DEFAULT_TOKEN_FORMATTER,
+  formatEpoch,
+  getBlockInfo,
+  getDomainVerifier,
+  isComposableCow,
+  isExtensibleFallbackHandler,
+} from '../src/utils'
 import { DurationType, StartTimeValue, TwapData, TwapStruct, transformDataToStruct } from '../src/orderTypes/Twap'
 import { GPv2Order } from '../src/types'
 import { createAdapters } from './setup'
 import { setGlobalAdapter } from '@cowprotocol/sdk-common'
+import {
+  COMPOSABLE_COW_CONTRACT_ADDRESS,
+  EXTENSIBLE_FALLBACK_HANDLER_CONTRACT_ADDRESS,
+  SupportedChainId,
+} from '@cowprotocol/sdk-config'
 
 describe('Utils Functions - Multi-Adapter Tests', () => {
   let adapters: ReturnType<typeof createAdapters>
@@ -208,6 +222,101 @@ describe('Utils Functions - Multi-Adapter Tests', () => {
       }
 
       expect(firstOrder).toEqual(expectedOrder)
+    })
+
+    test('should map buy kind and non-erc20 balances', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const order = fromStructToOrder({
+        ...ORDER_DATA,
+        kind: '0x6ed88e868af0a1983e3886d5f3e95a2fafbd6c3450bc229e27342283dc429ccc',
+        sellTokenBalance: '0xabee3b73373acd583a130924aad6dc38cfdc44ba0555ba94ce2ff63980ea0632',
+        buyTokenBalance: '0x4ac99ace14ee0a5ef932dc609df0943ab7ac16b7583634612f8dc35a4289a6ce',
+      })
+
+      expect(order.kind).toBe('buy')
+      expect(order.sellTokenBalance).toBe('external')
+      expect(order.buyTokenBalance).toBe('internal')
+    })
+
+    test('should throw for unknown balance and kind hashes', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      expect(() =>
+        fromStructToOrder({
+          ...ORDER_DATA,
+          sellTokenBalance: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        }),
+      ).toThrow('Unknown balance type')
+
+      expect(() =>
+        fromStructToOrder({
+          ...ORDER_DATA,
+          kind: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        }),
+      ).toThrow('Unknown kind')
+    })
+  })
+
+  describe('handler helpers', () => {
+    test('should identify composable cow and extensible fallback handler addresses', () => {
+      const chainId = SupportedChainId.MAINNET
+
+      expect(isComposableCow(COMPOSABLE_COW_CONTRACT_ADDRESS[chainId], chainId)).toBe(true)
+      expect(isComposableCow('0x0000000000000000000000000000000000000001', chainId)).toBe(false)
+      expect(isExtensibleFallbackHandler(EXTENSIBLE_FALLBACK_HANDLER_CONTRACT_ADDRESS[chainId], chainId)).toBe(true)
+      expect(isExtensibleFallbackHandler('0x0000000000000000000000000000000000000001', chainId)).toBe(false)
+    })
+  })
+
+  describe('extensible fallback handler utilities', () => {
+    test('should encode setDomainVerifier calldata', () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const domain = '0x' + '11'.repeat(32)
+      const verifier = '0x' + '22'.repeat(20)
+
+      expect(createSetDomainVerifierTx(domain, verifier)).toMatch(/^0x/)
+    })
+
+    test('should read domain verifier from the fallback handler', async () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      const domain = '0x' + '11'.repeat(32)
+      const verifier = '0x' + '22'.repeat(20)
+      const safe = '0x' + '33'.repeat(20)
+      const chainId = SupportedChainId.MAINNET
+      const provider = {
+        readContract: jest.fn().mockResolvedValue(verifier),
+      }
+
+      await expect(getDomainVerifier(safe, domain, chainId, provider)).resolves.toBe(verifier)
+      expect(provider.readContract).toHaveBeenCalled()
+    })
+  })
+
+  describe('misc helpers', () => {
+    test('should format token amounts with the default formatter', () => {
+      expect(DEFAULT_TOKEN_FORMATTER('0xabc', 42n)).toBe('42@0xabc')
+    })
+  })
+
+  describe('block helpers', () => {
+    test('should format epoch timestamps and read latest block info', async () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      jest.spyOn(adapters.viemAdapter, 'getBlock').mockResolvedValue({
+        number: 42n,
+        timestamp: 1_700_000_000n,
+      } as never)
+
+      await expect(getBlockInfo({})).resolves.toEqual({
+        blockNumber: 42,
+        blockTimestamp: 1_700_000_000,
+      })
+      expect(formatEpoch(1_700_000_000)).toBe('2023-11-14T22:13:20.000Z')
+
+      jest.restoreAllMocks()
     })
   })
 })


### PR DESCRIPTION
## Summary

- Fix `getDomainVerifier()` — it incorrectly returned the `provider` argument due to a comma-operator typo; now returns the `readContract` result.
- Add unit tests across `packages/composable` to bring statement/branch/line coverage to 100%.
- Cover previously untested paths: Multiplexer error handling and static `poll`, Twap edge cases, `ConditionalOrder` calldata helpers, `ConditionalOrderFactory`, package barrel exports, and utils helpers.
<img width="778" height="495" alt="image" src="https://github.com/user-attachments/assets/585e914b-cd6b-4842-9246-ed05951d4c48" />


## Motivation

Improve regression safety for `@cowprotocol/sdk-composable` without adding integration/fork tests or new public API surface.

## Test plan

- [x] `cd packages/composable && pnpm test`
- [x] `cd packages/composable && pnpm test:coverage` (262 tests, 100% coverage)
- [x] `cd packages/composable && pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain verifier contract reads for provider-specific operations.
  * Enhanced conditional order polling and TWAP validation error handling.
  * Improved order deserialization safeguards for legacy payload formats.

* **Tests**
  * Added broad coverage for conditional orders, TWAP creation and transformations, factory behavior, multiplexer operations, utility helpers, and package exports.
  * Added validation for adapter handling, calldata generation, registry lookups, defaults, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->