### PR TITLE
chore: update pnpm config and renovate config

### DIFF
--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -1,16 +1,16 @@
-// This file follows JSON5 syntax, to make it
+// This file follows JSONC syntax, to make it
 // easier to maintain.
 {
-  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   // Enable the npm manager solely so Renovate can bump the
   // `packageManager` field in package.json — the single source of
   // truth for the pnpm version used by every workflow. All other
   // npm dependency updates are suppressed in packageRules below.
-  enabledManagers: ["github-actions", "npm"],
+  "enabledManagers": ["github-actions", "npm"],
   // PR titles use Conventional Commits: `deps(<action>): ...`
-  semanticCommits: "enabled",
-  semanticCommitType: "deps",
-  packageRules: [
+  "semanticCommits": "enabled",
+  "semanticCommitType": "deps",
+  "packageRules": [
     // ---
     // npm: suppress every dependency update except `pnpm` (the
     // `packageManager` field in package.json). Workflows read the
@@ -19,19 +19,19 @@
     // any workflow file, and no version-mismatch errors.
     // ---
     {
-      matchManagers: ["npm"],
-      enabled: false,
+      "matchManagers": ["npm"],
+      "enabled": false,
     },
     {
-      matchManagers: ["npm"],
-      matchDepTypes: ["packageManager"],
-      matchPackageNames: ["pnpm"],
-      enabled: true,
-      semanticCommitScope: "pnpm",
-      commitMessageTopic: "pnpm",
-      schedule: ["on monday"],
-      minimumReleaseAge: "14 days",
-      separateMajorMinor: false,
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["packageManager"],
+      "matchPackageNames": ["pnpm"],
+      "enabled": true,
+      "semanticCommitScope": "pnpm",
+      "commitMessageTopic": "pnpm",
+      "schedule": ["on monday"],
+      "minimumReleaseAge": "14 days", // Keep in sync with pnpm-workspace.yaml.
+      "separateMajorMinor": false,
     },
     // GitHub Actions updates: run weekly, skip releases newer than 2 weeks
     // to avoid picking up freshly published versions that may be unstable or
@@ -40,18 +40,18 @@
     // When both major and minor releases exist, propose only the latest bump
     // (typically major) instead of a separate minor PR.
     {
-      matchManagers: ["github-actions"],
-      schedule: ["on monday"],
-      minimumReleaseAge: "14 days",
+      "matchManagers": ["github-actions"],
+      "schedule": ["on monday"],
+      "minimumReleaseAge": "14 days", // Keep in sync with pnpm-workspace.yaml.
       // Track upgrades by semver tag, but pin the resolved version to its full
       // commit SHA (semver tag kept as a trailing comment). Use the coerced
       // variant so short tags like `v3` / `v1.7` (which several actions only
       // publish) still parse instead of silently stopping updates.
-      versioning: "semver-coerced",
-      pinDigests: true,
-      separateMajorMinor: false,
-      semanticCommitScope: "{{depName}}",
-      commitMessageTopic: "{{depName}}",
+      "versioning": "semver-coerced",
+      "pinDigests": true,
+      "separateMajorMinor": false,
+      "semanticCommitScope": "{{depName}}",
+      "commitMessageTopic": "{{depName}}",
     },
   ],
 }

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-shamefully-hoist=false
-strict-peer-dependencies=false
-node-linker=isolated

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,23 @@
+# Use the public npm registry for unscoped dependencies.
+registries:
+  default: https://registry.npmjs.org/
+
+# Prefer cached data, but fetch anything missing.
+preferOffline: true
+
+# Quarantine new third-party releases; keep this aligned with Renovate.
+minimumReleaseAge: 20160 # 14 days
+minimumReleaseAgeExclude:
+  - '@cowprotocol/*'
+
+# Reject transitive dependencies from git or direct tarball URLs.
+blockExoticSubdeps: true
+
+# Protect age-exempt packages from weaker publisher evidence during the same window.
+trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 20160 # 14 days
+
+# Explicitly skip dependency lifecycle scripts currently present in the lockfile.
 allowBuilds:
   '@swc/core': false
   bufferutil: false


### PR DESCRIPTION
Changes:
- Migrate renovate config from json5 to jsonc (json5 lacks native VS Code support, the extension for it is old and lacks json schema support)
- Migrate the `.npmrc` config because in PNPM 11, it's being read only for auth and registry
- Migrate some more `.npmrc` settings from `cowswap` repo, such as `minimumReleaseAge`

I similar change needs to be done in cowswap: pnpm 11 upgrade and npmrc migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation configuration for clearer, standardized formatting while preserving existing update policies.
  * Added workspace-level package resolution and security policies, including offline preference, release-age safeguards, and protection against exotic dependency sources.
  * Removed legacy package manager configuration settings related to hoisting, peer dependencies, and node linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->