### PR TITLE
fix(bridge): correct swapped sell/buy currency bridge fee amounts in Near Intents quote

### DIFF
--- a/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.test.ts
+++ b/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.test.ts
@@ -431,6 +431,117 @@ adapterNames.forEach((adapterName) => {
         expect(quote.signature).toBe('ed25519:testSignature')
       })
 
+      it('reports bridging fee amounts in the correct sell and buy currency scales', async () => {
+        const api = new NearIntentsApi()
+        const sellTokenAddress = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
+        const buyTokenAddress = '0x4200000000000000000000000000000000000006'
+        const testQuoteHash = '0xtestFeeCurrencyQuoteHash'
+
+        // Sell token (USDC, 6 decimals) and buy token (ETH, 18 decimals) differ hugely in scale,
+        // and amountInUsd !== amountOutUsd so the slippage-derived fees are non-zero. This makes a
+        // sell/buy-currency swap observable (with equal USD values, slippage is 0 and the swap hides).
+        const amountIn = '52000000' // 52 USDC (6 decimals)
+        const amountOut = '11760237526222378' // ~0.01176 ETH (18 decimals)
+        const amountInUsd = '51.9897'
+        const amountOutUsd = '51.9508'
+
+        const mockQuoteResponse: QuoteResponse = {
+          quote: {
+            amountIn,
+            amountInFormatted: '52.0',
+            amountInUsd,
+            minAmountIn: amountIn,
+            amountOut,
+            amountOutFormatted: '0.011760237526222378',
+            amountOutUsd,
+            minAmountOut: '11701433538591266',
+            timeEstimate: 60,
+            deadline: '2025-09-05T12:10:38.605Z',
+            timeWhenInactive: '2025-09-05T12:10:38.605Z',
+            depositAddress: '0xAd8b7139196c5ae9fb66B71C91d87A1F9071687e',
+          },
+          quoteRequest: {
+            dry: false,
+            swapType: QuoteRequest.swapType.EXACT_INPUT,
+            depositMode: QuoteRequest.depositMode.SIMPLE,
+            slippageTolerance: 100,
+            originAsset: 'nep141:usdc.omft.near',
+            depositType: QuoteRequest.depositType.ORIGIN_CHAIN,
+            destinationAsset: 'nep141:base.omft.near',
+            amount: amountIn,
+            refundTo: '0x0000000000000000000000000000000000000000',
+            refundType: QuoteRequest.refundType.ORIGIN_CHAIN,
+            recipient: '0x0000000000000000000000000000000000000000',
+            recipientType: QuoteRequest.recipientType.DESTINATION_CHAIN,
+            deadline: '2025-09-05T12:10:38.605Z',
+          },
+          signature: 'ed25519:testFeeSignature',
+          timestamp: '2025-09-05T12:00:38.695Z',
+        }
+
+        jest.spyOn(api, 'getQuote').mockResolvedValue(mockQuoteResponse)
+        jest.spyOn(api, 'getTokens').mockResolvedValue([
+          {
+            assetId: 'nep141:usdc.omft.near',
+            decimals: 6,
+            blockchain: TokenResponse.blockchain.BASE,
+            symbol: 'USDC',
+            price: 1,
+            priceUpdatedAt: '2025-09-05T12:00:38.695Z',
+            contractAddress: sellTokenAddress,
+          },
+          {
+            assetId: 'nep141:base.omft.near',
+            decimals: 18,
+            blockchain: TokenResponse.blockchain.BASE,
+            symbol: 'ETH',
+            price: 1,
+            priceUpdatedAt: '2025-09-05T12:00:38.695Z',
+            contractAddress: buyTokenAddress,
+          },
+        ])
+        jest.spyOn(api, 'getAttestation').mockResolvedValue({
+          version: 1,
+          signature:
+            '0x66edc32e2ab001213321ab7d959a2207fcef5190cc9abb6da5b0d2a8a9af2d4d2b0700e2c317c4106f337fd934fbbb0bf62efc8811a78603b33a8265d3b8f8cb1c',
+        })
+        provider.setApi(api)
+
+        jest.spyOn(provider, 'recoverDepositAddress').mockResolvedValue({
+          address: ATTESTATOR_ADDRESS,
+          quoteHash: testQuoteHash,
+          stringifiedQuote: '',
+          attestationSignature: '',
+        })
+
+        const quote = await provider.getQuote({
+          kind: OrderKind.SELL,
+          sellTokenChainId: 8453,
+          sellTokenAddress,
+          sellTokenDecimals: 6,
+          buyTokenChainId: 8453,
+          buyTokenAddress,
+          buyTokenDecimals: 18,
+          amount: 52000000n,
+          account: '0x0000000000000000000000000000000000000000',
+          appCode: 'test',
+          signer: '0x0000000000000000000000000000000000000000',
+        })
+
+        const slippage = 1 - Number(amountOutUsd) / Number(amountInUsd)
+        const bridgingFee = quote.amountsAndCosts.costs.bridgingFee
+
+        // The sell-currency fee must be denominated in the sell token (USDC, 6 decimals) and thus
+        // scaled by amountIn; the buy-currency fee in the buy token (ETH, 18 decimals), scaled by
+        // amountOut. Before the fix these two were swapped (each reported in the wrong token).
+        expect(bridgingFee.amountInSellCurrency).toBe(BigInt(Math.trunc(Number(amountIn) * slippage)))
+        expect(bridgingFee.amountInBuyCurrency).toBe(BigInt(Math.trunc(Number(amountOut) * slippage)))
+
+        // Sanity on magnitude: the sell fee is USDC-sized (small), the buy fee is ETH-sized (large).
+        expect(bridgingFee.amountInSellCurrency < 1_000_000n).toBe(true)
+        expect(bridgingFee.amountInBuyCurrency > 1_000_000_000_000n).toBe(true)
+      })
+
       it('should return stringifiedQuote and attestationSignature', async () => {
         const api = new NearIntentsApi()
 

--- a/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.ts
+++ b/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.ts
@@ -177,8 +177,8 @@ export class NearIntentsBridgeProvider implements ReceiverAccountBridgeProvider<
     const payoutRatio = Number(quote.amountOutUsd) / Number(quote.amountInUsd)
     const slippage = 1 - payoutRatio
     const slippageBps = Math.trunc(slippage * 10_000)
-    const feeAmountInBuyCurrency = Math.trunc(Number(quote.amountIn) * slippage)
-    const feeAmountInSellCurrency = Math.trunc(Number(quote.amountOut) * slippage)
+    const feeAmountInBuyCurrency = Math.trunc(Number(quote.amountOut) * slippage)
+    const feeAmountInSellCurrency = Math.trunc(Number(quote.amountIn) * slippage)
     const bridgeFee = Math.trunc(Number(quote.amountIn) * slippage)
 
     return {


### PR DESCRIPTION
## Problem

In `NearIntentsBridgeProvider.getQuote()`, the two per-currency bridge-fee amounts exposed on `amountsAndCosts.costs.bridgingFee` are derived from the wrong quote fields, so they end up **swapped**.

`quote.amountIn` is the sell/origin amount and `quote.amountOut` is the buy/destination amount — this is established a few lines below where `beforeFee.sellAmount = BigInt(quote.amountIn)` and `beforeFee.buyAmount = BigInt(quote.amountOut)` (and in `getBridgingParams`, where the origin asset maps to the input amount `quote.amountIn`).

But the fee amounts were computed the other way around:

```ts
const feeAmountInBuyCurrency = Math.trunc(Number(quote.amountIn) * slippage)   // uses the SELL amount
const feeAmountInSellCurrency = Math.trunc(Number(quote.amountOut) * slippage) // uses the BUY amount
```

These are then assigned straight to `amountInSellCurrency` / `amountInBuyCurrency`, so the sell-currency fee holds a buy-token-scaled value and vice versa. This mirrors the shared `bridgingFee` contract used by the other providers (e.g. Across: `amountInSellCurrency` = fee in the sell token, `amountInBuyCurrency` = fee in the buy token).

## Failing scenario

Cross-chain SELL of USDC (6 decimals, `amountIn = 52_000_000`) to ETH (18 decimals, `amountOut = 11_760_237_526_222_378`) with ~0.075% slippage:

- Expected `amountInSellCurrency` ≈ `38_907` (USDC scale) and `amountInBuyCurrency` ≈ `8.8e12` (ETH scale).
- Actual (before fix): the two are swapped, so `amountInSellCurrency` ≈ `8.8e12` and `amountInBuyCurrency` ≈ `38_907` — each fee reported in the wrong token and off by ~12 orders of magnitude.

Any consumer displaying the per-currency bridge-fee breakdown gets grossly wrong numbers. `fees.bridgeFee` (computed separately from `amountIn`) is unaffected.

## Fix

Swap the multiplicands so the sell-currency fee scales with `amountIn` and the buy-currency fee with `amountOut`. Minimal, one-line-each change.

## Tests

Adds a regression test in `NearIntentsBridgeProvider.test.ts` using a quote whose sell/buy tokens differ in scale and whose USD values differ (so slippage — and therefore the fees — is non-zero; the existing tests use equal USD values, making the swap invisible). It asserts `amountInSellCurrency` is the sell-token-scaled fee and `amountInBuyCurrency` the buy-token-scaled fee. The test fails on `main` (values swapped) and passes with this change. Full provider suite (54 tests) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected bridging fee calculations so fees are reported in the appropriate buy and sell token currencies.
  * Improved accuracy for tokens with different decimal scales.

* **Tests**
  * Added coverage to verify fee amounts, currency denomination, and expected relative values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->