### PR TITLE
fix(ci): use jq to parse 'allow-publish' label

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -48,9 +48,14 @@ jobs:
             if [ "$REPO_NAME" = "$REPOSITORY" ]; then
               echo "✅ Internal PR - proceeding with publish"
             else
-              # Check for allow-publish label
+              # Check for allow-publish label.
+              # Parse the labels as JSON and match the "name" field exactly. We use jq
+              # (pre-installed on GitHub-hosted runners) instead of grep because
+              # toJson() pretty-prints with a space after the colon ("name": "allow-publish"),
+              # which the previous no-space grep pattern never matched. Exact equality also
+              # avoids accidentally matching the label's url or any partial/substring name.
               echo "🔍 Checking for 'allow-publish' label..."
-              if echo "$LABELS_JSON" | grep -q '"name":"allow-publish"'; then
+              if [ "$(printf '%s' "$LABELS_JSON" | jq -r 'any(.[]?; .name == "allow-publish")')" = "true" ]; then
                 echo "✅ External PR with 'allow-publish' label - proceeding with publish"
               else
                 echo "❌ External PR without 'allow-publish' label - skipping publish for security"


### PR DESCRIPTION
## What and why

Fixes this issue: https://github.com/cowprotocol/cow-sdk/actions/runs/29615761591

The `Publish to GitHub Packages` workflow never built or published packages for **external PRs**, even after a maintainer added the `allow-publish` label. The job started correctly (the job-level `if` gate matched the `labeled` event), but it died immediately at the first step — `Security Check` — with `exit 1`, so every later step (`Install`, `Generate code`, `Build packages`, `Publish`) was skipped.

**Root cause:** the step re-checked the label with a substring grep:

```bash
grep -q '"name":"allow-publish"'
```

but `LABELS_JSON` comes from `toJson(github.event.pull_request.labels)`, which **pretty-prints** the JSON with a space after every colon (`"name": "allow-publish"`). The no-space pattern never matched, so the check always fell through to the `❌ ... skipping publish` branch. This path had been dead for every external PR since it was written.

## The fix

Parse the labels as real JSON and match the `name` field with **exact equality** using `jq` (pre-installed on GitHub-hosted runners) instead of a fragile substring grep:

```bash
if [ "$(printf '%s' "$LABELS_JSON" | jq -r 'any(.[]?; .name == "allow-publish")')" = "true" ]; then
```

This is both correct (whitespace-insensitive) and **stricter** than the old grep — exact `name` equality can't be satisfied by other fields (e.g. the label `url`) or by a partial/substring label name.

## Security

- The job-level `if` gate (external PRs only run on a `labeled` event with `label.name == 'allow-publish'`, and checkout pins `github.event.pull_request.head.sha` from the event payload) is **unchanged** — that remains the primary control. This step stays as a correct second layer of defense-in-depth.
- No new dependency: `jq` ships on `ubuntu-latest`. `.[]?` defends against a null/non-array value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request label validation for package publishing workflows.
  * Prevented similarly named labels from being incorrectly treated as approval to publish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->