### PR TITLE
chore(renovate): run github-actions updates monthly in renovate config 🗓️

### DIFF
--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -29,11 +29,11 @@
       "enabled": true,
       "semanticCommitScope": "pnpm",
       "commitMessageTopic": "pnpm",
-      "schedule": ["on monday"],
+      "schedule": ["* 0-3 1 * *"],
       "minimumReleaseAge": "14 days", // Keep in sync with pnpm-workspace.yaml.
       "separateMajorMinor": false,
     },
-    // GitHub Actions updates: run weekly, skip releases newer than 2 weeks
+    // GitHub Actions updates: run monthly, skip releases newer than 2 weeks
     // to avoid picking up freshly published versions that may be unstable or
     // compromised, and pin to full commit SHAs (with the version as a
     // trailing comment) rather than mutable tags.
@@ -41,7 +41,7 @@
     // (typically major) instead of a separate minor PR.
     {
       "matchManagers": ["github-actions"],
-      "schedule": ["on monday"],
+      "schedule": ["* 0-3 1 * *"],
       "minimumReleaseAge": "14 days", // Keep in sync with pnpm-workspace.yaml.
       // Track upgrades by semver tag, but pin the resolved version to its full
       // commit SHA (semver tag kept as a trailing comment). Use the coerced


### PR DESCRIPTION
- switch schedule from weekly (on monday) to monthly (1st of month, `* 0-3 1 * *`)
- keep 14-day minimumReleaseAge