### PR TITLE
feat(flash-loans): add barn (staging) Aave V3 adapters on Base

### DIFF
--- a/packages/flash-loans/src/aave/AaveCollateralSwapSdk.test.ts
+++ b/packages/flash-loans/src/aave/AaveCollateralSwapSdk.test.ts
@@ -1273,6 +1273,54 @@ adapterNames.forEach((adapterName) => {
         swapSettingsCall = (mockPostSwapOrderFromQuote as jest.Mock).mock.calls[0][0]
         expect(swapSettingsCall.appData.metadata.flashloan.liquidityProvider).toBe(customMainnetPool)
       })
+
+      test('should use staging (barn) adapter addresses on Base when env is "staging"', async () => {
+        const stagingSdk = new AaveCollateralSwapSdk({ env: 'staging' })
+        const readContractSpy = setupReadContractMock()
+
+        await stagingSdk.collateralSwap(
+          {
+            chainId: SupportedChainId.BASE,
+            tradeParameters: mockTradeParameters,
+            collateralToken,
+          },
+          mockTradingSdk,
+        )
+
+        const getInstanceCall = readContractSpy.mock.calls.find(
+          (call) => call[0]?.functionName === 'getInstanceDeterministicAddress',
+        )
+
+        expect(getInstanceCall?.[0]?.address).toBe('0xF06B99bFD3ABa9b494eE531c23b19dfCc14e2627')
+        expect(getInstanceCall?.[0]?.args?.[0]).toBe('0x48D064a4B7fe0bDDB754BEE5cf5a562B68AB34A5')
+
+        const swapSettingsCall = (mockPostSwapOrderFromQuote as jest.Mock).mock.calls[0][0]
+        expect(swapSettingsCall.appData.metadata.flashloan.receiver).toBe('0xF06B99bFD3ABa9b494eE531c23b19dfCc14e2627')
+      })
+
+      test('should let an explicit adapter override win over env', async () => {
+        const customFactory = '0x1111111111111111111111111111111111111111'
+        const overrideSdk = new AaveCollateralSwapSdk({
+          env: 'staging',
+          aaveAdapterFactory: { ...AAVE_ADAPTER_FACTORY, [SupportedChainId.BASE]: customFactory },
+        })
+        const readContractSpy = setupReadContractMock()
+
+        await overrideSdk.collateralSwap(
+          {
+            chainId: SupportedChainId.BASE,
+            tradeParameters: mockTradeParameters,
+            collateralToken,
+          },
+          mockTradingSdk,
+        )
+
+        const getInstanceCall = readContractSpy.mock.calls.find(
+          (call) => call[0]?.functionName === 'getInstanceDeterministicAddress',
+        )
+
+        expect(getInstanceCall?.[0]?.address).toBe(customFactory)
+      })
     })
   })
 })

--- a/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
+++ b/packages/flash-loans/src/aave/AaveCollateralSwapSdk.ts
@@ -29,8 +29,10 @@ import {
 } from './types'
 import {
   AAVE_ADAPTER_FACTORY,
+  AAVE_ADAPTER_FACTORY_STAGING,
   AAVE_DAPP_ID_PER_TYPE,
   AAVE_HOOK_ADAPTER_PER_TYPE,
+  AAVE_HOOK_ADAPTER_PER_TYPE_STAGING,
   AAVE_POOL_ADDRESS,
   AaveFlashLoanType,
   ADAPTER_DOMAIN_NAME,
@@ -42,7 +44,7 @@ import {
   HASH_ZERO,
   PERCENT_SCALE,
 } from './const'
-import { SupportedChainId } from '@cowprotocol/sdk-config'
+import { CowEnv, SupportedChainId } from '@cowprotocol/sdk-config'
 import { aaveAdapterFactoryAbi } from './abi/AaveAdapterFactory'
 import { collateralSwapAdapterHookAbi } from './abi/CollateralSwapAdapterHook'
 import { debtSwapAdapterAbi } from './abi/DebtSwapAdapter'
@@ -81,6 +83,7 @@ export type AaveCollateralSwapSdkConfig = {
   aaveAdapterFactory?: Record<SupportedChainId, string>
   aavePoolAddress?: Record<SupportedChainId, string>
   hooksGasLimit?: { pre: bigint; post: bigint }
+  env?: CowEnv
 }
 
 /**
@@ -112,10 +115,16 @@ export class AaveCollateralSwapSdk {
    * @param {Record<SupportedChainId, string>} config.aavePoolAddress -
    *        Mapping of chain IDs to Aave pool addresses.
    *        Defaults to the predefined addresses from the constants.
+   * @param {CowEnv} config.env -
+   *        CoW settlement environment. Selects the prod or staging adapter addresses
+   *        when no explicit override is given. Defaults to 'prod'.
    */
   constructor(config?: AaveCollateralSwapSdkConfig) {
-    this.hookAdapterPerType = config?.hookAdapterPerType ?? AAVE_HOOK_ADAPTER_PER_TYPE
-    this.aaveAdapterFactory = config?.aaveAdapterFactory ?? AAVE_ADAPTER_FACTORY
+    const isStaging = config?.env === 'staging'
+    this.hookAdapterPerType =
+      config?.hookAdapterPerType ?? (isStaging ? AAVE_HOOK_ADAPTER_PER_TYPE_STAGING : AAVE_HOOK_ADAPTER_PER_TYPE)
+    this.aaveAdapterFactory =
+      config?.aaveAdapterFactory ?? (isStaging ? AAVE_ADAPTER_FACTORY_STAGING : AAVE_ADAPTER_FACTORY)
     this.aavePoolAddress = config?.aavePoolAddress ?? AAVE_POOL_ADDRESS
     this.hooksGasLimit = config?.hooksGasLimit ?? DEFAULT_HOOK_GAS_LIMIT
   }

--- a/packages/flash-loans/src/aave/const.ts
+++ b/packages/flash-loans/src/aave/const.ts
@@ -45,6 +45,71 @@ export const AAVE_HOOK_ADAPTER_PER_TYPE: Record<AaveFlashLoanType, Record<Suppor
   [AaveFlashLoanType.RepayCollateral]: AAVE_REPAY_COLLATERAL_ADAPTER_HOOK,
 }
 
+// Staging (barn) is only deployed on Base, bound to the CoW staging settlement.
+export const AAVE_ADAPTER_FACTORY_STAGING: Record<SupportedChainId, string> = {
+  [SupportedChainId.SEPOLIA]: '',
+  [SupportedChainId.GNOSIS_CHAIN]: '',
+  [SupportedChainId.MAINNET]: '',
+  [SupportedChainId.BASE]: '0xF06B99bFD3ABa9b494eE531c23b19dfCc14e2627',
+  [SupportedChainId.ARBITRUM_ONE]: '',
+  [SupportedChainId.AVALANCHE]: '',
+  [SupportedChainId.BNB]: '',
+  [SupportedChainId.POLYGON]: '',
+  [SupportedChainId.LINEA]: '',
+  [SupportedChainId.PLASMA]: '',
+  [SupportedChainId.INK]: '',
+  [SupportedChainId.SOLANA]: '',
+}
+
+const AAVE_COLLATERAL_SWAP_ADAPTER_HOOK_STAGING: Record<SupportedChainId, string> = {
+  [SupportedChainId.SEPOLIA]: '',
+  [SupportedChainId.GNOSIS_CHAIN]: '',
+  [SupportedChainId.MAINNET]: '',
+  [SupportedChainId.BASE]: '0x48D064a4B7fe0bDDB754BEE5cf5a562B68AB34A5',
+  [SupportedChainId.ARBITRUM_ONE]: '',
+  [SupportedChainId.AVALANCHE]: '',
+  [SupportedChainId.BNB]: '',
+  [SupportedChainId.POLYGON]: '',
+  [SupportedChainId.LINEA]: '',
+  [SupportedChainId.PLASMA]: '',
+  [SupportedChainId.INK]: '',
+  [SupportedChainId.SOLANA]: '',
+}
+const AAVE_DEBT_SWAP_ADAPTER_HOOK_STAGING: Record<SupportedChainId, string> = {
+  [SupportedChainId.SEPOLIA]: '',
+  [SupportedChainId.GNOSIS_CHAIN]: '',
+  [SupportedChainId.MAINNET]: '',
+  [SupportedChainId.BASE]: '0x0426DCaFB8aEc417f0e93bCc3fA75bd3E5D8B67B',
+  [SupportedChainId.ARBITRUM_ONE]: '',
+  [SupportedChainId.AVALANCHE]: '',
+  [SupportedChainId.BNB]: '',
+  [SupportedChainId.POLYGON]: '',
+  [SupportedChainId.LINEA]: '',
+  [SupportedChainId.PLASMA]: '',
+  [SupportedChainId.INK]: '',
+  [SupportedChainId.SOLANA]: '',
+}
+const AAVE_REPAY_COLLATERAL_ADAPTER_HOOK_STAGING: Record<SupportedChainId, string> = {
+  [SupportedChainId.SEPOLIA]: '',
+  [SupportedChainId.GNOSIS_CHAIN]: '',
+  [SupportedChainId.MAINNET]: '',
+  [SupportedChainId.BASE]: '0x40bf6655e0B0A7ccF896319536DE3005422bAC9b',
+  [SupportedChainId.ARBITRUM_ONE]: '',
+  [SupportedChainId.AVALANCHE]: '',
+  [SupportedChainId.BNB]: '',
+  [SupportedChainId.POLYGON]: '',
+  [SupportedChainId.LINEA]: '',
+  [SupportedChainId.PLASMA]: '',
+  [SupportedChainId.INK]: '',
+  [SupportedChainId.SOLANA]: '',
+}
+
+export const AAVE_HOOK_ADAPTER_PER_TYPE_STAGING: Record<AaveFlashLoanType, Record<SupportedChainId, string>> = {
+  [AaveFlashLoanType.CollateralSwap]: AAVE_COLLATERAL_SWAP_ADAPTER_HOOK_STAGING,
+  [AaveFlashLoanType.DebtSwap]: AAVE_DEBT_SWAP_ADAPTER_HOOK_STAGING,
+  [AaveFlashLoanType.RepayCollateral]: AAVE_REPAY_COLLATERAL_ADAPTER_HOOK_STAGING,
+}
+
 export const DEFAULT_HOOK_GAS_LIMIT = {
   pre: 300_000n,
   post: 600_000n,


### PR DESCRIPTION
## Description
Add staging (barn) support for the Aave V3 flash-loan adapters on Base.

Aave deployed a barn adapter set on Base bound to the CoW staging settlement (0xf553d092b50bdcbddeD1A99aF2cA29FBE5E2CB13). Until now the SDK only carried the prod deployment, so consumers targeting barn got `InvalidEip1271Signature`, since the the prod adapter hashes orders against the prod settlement domain.

## Changes
- `const.ts`: Base-only `*_STAGING` address maps (factory + three hook adapters + `AAVE_HOOK_ADAPTER_PER_TYPE_STAGING`), matching the `AAVE_POOL_ADDRESS` style for chains without a deployment. Non-Base chains are `''` (staging is Base-only).
- `AaveCollateralSwapSdk`: optional `env?: CowEnv` (default `'prod'`). When no explicit `aaveAdapterFactory` / `hookAdapterPerType` override is given, it selects the prod or staging maps by env. An explicit override always wins, regardless of env.
  
Backward compatible: callers that pass no `env` keep the exact current behavior. `aavePoolAddress` stays prod for both envs — Aave's pool is not CoW-env-specific.

## Testing
- `pnpm typecheck`, `pnpm test` (144 pass), `pnpm lint` all green. Added tests assert.
- `env: 'staging'` resolves the Base factory/hook, and that an explicit override beats env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staging environment support for Aave collateral swaps on Base.
  * The SDK now automatically uses staging adapter addresses when configured for the staging environment.
  * Explicitly provided adapter factories continue to override environment-based defaults.

* **Tests**
  * Added coverage for staging address selection and custom adapter overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->