### PR TITLE
feat(bridge): increase buyTokens cache TTL

### DIFF
--- a/packages/bridging/src/BridgingSdk/BridgingSdk.ts
+++ b/packages/bridging/src/BridgingSdk/BridgingSdk.ts
@@ -13,7 +13,13 @@ import { findBridgeProviderFromHook } from './findBridgeProviderFromHook'
 import { SwapAdvancedSettings, TradingSdk } from '@cowprotocol/sdk-trading'
 import { OrderBookApi } from '@cowprotocol/sdk-order-book'
 import { ALL_SUPPORTED_CHAINS, ChainInfo, TokenInfo } from '@cowprotocol/sdk-config'
-import { AbstractProviderAdapter, enableLogging, getAddressKey, setGlobalAdapter, TTLCache } from '@cowprotocol/sdk-common'
+import {
+  AbstractProviderAdapter,
+  enableLogging,
+  getAddressKey,
+  setGlobalAdapter,
+  TTLCache,
+} from '@cowprotocol/sdk-common'
 import { BridgingSdkCacheConfig, BridgingSdkConfig, BridgingSdkOptions, GetOrderParams } from './types'
 import { getCacheKey } from './helpers'
 import { SingleQuoteStrategy, MultiQuoteStrategy, BestQuoteStrategy } from './strategies'
@@ -23,8 +29,8 @@ import { createBridgeRequestTimeoutPromise } from './utils'
 // Default cache configuration
 const DEFAULT_CACHE_CONFIG: BridgingSdkCacheConfig = {
   enabled: true,
-  intermediateTokensTtl: 5 * 60 * 1000, // 2 minutes
-  buyTokensTtl: 2 * 60 * 1000, // 2 minutes
+  intermediateTokensTtl: 5 * 60 * 1000, // 5 minutes
+  buyTokensTtl: 24 * 60 * 60 * 1000, // 24 hours
 }
 
 const DEFAULT_MULTI_PROVIDER_REQUEST_TIMEOUT = 10 * 1000 // 10 seconds

--- a/packages/bridging/src/BridgingSdk/BridgingSdk.ts
+++ b/packages/bridging/src/BridgingSdk/BridgingSdk.ts
@@ -30,7 +30,7 @@ import { createBridgeRequestTimeoutPromise } from './utils'
 const DEFAULT_CACHE_CONFIG: BridgingSdkCacheConfig = {
   enabled: true,
   intermediateTokensTtl: 5 * 60 * 1000, // 5 minutes
-  buyTokensTtl: 24 * 60 * 60 * 1000, // 24 hours
+  buyTokensTtl: 1 * 60 * 60 * 1000, // 1 hour
 }
 
 const DEFAULT_MULTI_PROVIDER_REQUEST_TIMEOUT = 10 * 1000 // 10 seconds


### PR DESCRIPTION
Fixes https://cowprotocol.sentry.io/issues/7218963635/?project=5905822

There are lots of `N+1 API Call` performance events in Sentry.

In CoW Swap, when a user opens the buy-token network selector, the app pre-checks route availability for every supported destination chain so it can render unreachable chains as disabled (createOutputChainsState consumes routesAvailability). 

Each check calls `getBuyTokens({ sellChainId, buyChainId })`, and each of those is one `GET .../bungee-manual/dest-tokens?fromChainId=…&toChainId=…&includeBridges=….` With ~N target chains fired in parallel via Promise.all, that's N near-simultaneous hits to the same parameterized endpoint inside a single page transaction — exactly what the N+1 detector flags.

Since reachable routes are near-static, we can enforce `buyTokensTtl` from 2 minutes to 24 hours. This is supposed to decrease count of the Sentry events.
It won't remove them at all, because we will still make ~11 requests every 24 hours. Ideally, there should be a batch API for such calls, but it's not a case now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the documented cache duration for intermediate tokens.
  - Extended the default buy-token cache lifetime from 2 minutes to 1 hour, reducing unnecessary refreshes.

- **Style**
  - Improved import formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->