### PR TITLE
ci: remove conversation lock after pr merge

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,3 +20,4 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/cowprotocol/cla/blob/main/CLA.md'
           allowlist: '*[bot]'
+          lock-pullrequest-aftermerge: 'false'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,6 @@ When you merge a PR into `main`, release-please will create a new release PR if 
 
 You must then merge that PR to create a new release.
 
-Note: *DO NOT* forget to unlock the conversation after merging, otherwise the GH Action will fail.
-
 ## Publishing to npm
 
 In this project packages we use `workspace:*` as version for local packages in `package.json` dependencies.


### PR DESCRIPTION
I think the culprit is the CLA action. This should simplify the deployment flow a little bit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines by removing outdated post-merge instructions.

* **Chores**
  * Adjusted pull request workflow behavior to avoid locking conversations after merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->