### PR TITLE
fix(order-book): uploadAppData returns AppDataHash, not AppDataObject

### DIFF
--- a/packages/order-book/src/api.spec.ts
+++ b/packages/order-book/src/api.spec.ts
@@ -1,7 +1,7 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 import { CowError } from '@cowprotocol/sdk-common'
 import { OrderBookApi } from './api'
-import { BuyTokenDestination, OrderKind, SellTokenSource, SigningScheme } from './generated'
+import { AppDataHash, BuyTokenDestination, OrderKind, SellTokenSource, SigningScheme } from './generated'
 import { EcdsaSigningScheme } from './signingSchemes'
 import { SupportedChainId, ETH_ADDRESS } from '@cowprotocol/sdk-config'
 import { AUCTION } from './mock'
@@ -684,6 +684,10 @@ describe('CoW Api', () => {
       }),
     )
     expect(appDataHashResult).toEqual(appDataHash)
+    // Pin the return type: if this ever regresses to `AppDataObject`, tsc fails here
+    // rather than the mismatch surviving until someone hits it at runtime.
+    const typedResult: AppDataHash = appDataHashResult
+    expect(typeof typedResult).toBe('string')
   })
 
   test('Valid: Get solver competition by auctionId', async () => {

--- a/packages/order-book/src/api.ts
+++ b/packages/order-book/src/api.ts
@@ -417,13 +417,13 @@ export class OrderBookApi {
    * @param appDataHash `bytes32` hash of the app data
    * @param fullAppData Full app data to be uploaded
    * @param contextOverride Optional context override for this request.
-   * @returns The string encoding of the full app data that was uploaded.
+   * @returns The `appDataHash` the full app data was registered under.
    */
   uploadAppData(
     appDataHash: AppDataHash,
     fullAppData: string,
     contextOverride: PartialApiContext = {},
-  ): Promise<AppDataObject> {
+  ): Promise<AppDataHash> {
     return this.fetch(
       { path: `/api/v1/app_data/${appDataHash}`, method: 'PUT', body: { fullAppData } },
       contextOverride,


### PR DESCRIPTION
Closes #193

`OrderBookApi.uploadAppData()` is typed as returning `Promise<AppDataObject>`. It doesn't - the orderbook returns the `appDataHash`, a plain hex string.

Straight from the OpenAPI spec this package pins its own codegen to ([services@5341875](https://github.com/cowprotocol/services/blob/5341875c9498b2026d1b6f67c840b086e4696dcd/crates/orderbook/openapi.yml)), `PUT /api/v1/app_data/{app_data_hash}`:

```yaml
responses:
  "200":
    description: The full `appData` already exists.
    content:
      application/json:
        schema:
          $ref: "#/components/schemas/AppDataHash"
  "201":
    description: The full `appData` was successfully registered.
    content:
      application/json:
        schema:
          $ref: "#/components/schemas/AppDataHash"
```

And `AppDataHash` is `type: string`, while `AppDataObject` is an object with a `fullAppData` property. So it's not a doc nit, the return type is just wrong.

The funny part is our own test already knew. `api.spec.ts` mocks a bare string and asserts the result equals the hash - it even names the variable `appDataHashResult`. Only the type disagreed.

## what changed

- `uploadAppData` now returns `Promise<AppDataHash>`
- fixed the `@returns` docblock, it claimed "the string encoding of the full app data"
- pinned the return type in the existing test so a regression fails `tsc` instead of surviving until someone hits it at runtime

No consumer needed touching. Every call site in `trading/` and `bridging/` already ignores the return value, and the mocks resolve strings or `undefined`.

## receipts

Reverting just the return type to `AppDataObject`, leaving the new assertion in place:

```
$ pnpm typecheck
src/api.spec.ts(689,11): error TS2322: Type 'AppDataObject' is not assignable to type 'string'.
```

With the fix:

```
$ pnpm typecheck
$ tsc --noEmit
(exit 0)
```

```
$ pnpm test
PASS src/signingSchemes.test.ts
PASS src/quoteAmountsAndCosts/getProtocolFeeAmount.test.ts
PASS src/transformOrder.test.ts
PASS src/quoteAmountsAndCosts/getQuoteAmountsAndCosts.test.ts
PASS src/request.test.ts
PASS src/api.spec.ts

Test Suites: 6 passed, 6 total
Tests:       64 passed, 64 total
```

## risk

Low, but it *is* a breaking type change on a public method - anyone who wrote `const { fullAppData } = await uploadAppData(...)` was already getting `undefined` at runtime, they just weren't told. Happy to land it behind a major if you'd rather.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated app data uploads to return the registered app data hash.
  * Added validation to ensure upload responses contain the expected hash format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->