### PR TITLE
fix(order-signing): fail loudly when appData is a document, not a hash

### DIFF
--- a/packages/order-signing/src/utils.ts
+++ b/packages/order-signing/src/utils.ts
@@ -41,6 +41,41 @@ const V3_ERROR_MSG_REGEX = /eth_signTypedData_v3 does not exist/i
 const RPC_REQUEST_FAILED_REGEX = /RPC request failed/i
 const METAMASK_STRING_CHAINID_REGEX = /provided chainid .* must match the active chainid/i
 
+/**
+ * The `appData` field of the order struct is a `bytes32`, so it can only ever hold the
+ * appData *hash*, never the document itself.
+ */
+const APP_DATA_HASH_REGEX = /^0x[0-9a-fA-F]{64}$/
+
+/**
+ * Guards against passing a full (or stringified) appData document where the order struct
+ * expects the `bytes32` appData hash.
+ *
+ * Without this, the document reaches the EIP-712 encoder and surfaces as an opaque
+ * `invalid hex string (argument="value", ... code=INVALID_ARGUMENT)` from the underlying
+ * signing lib, which gives no hint about what was actually wrong.
+ *
+ * Deliberately does NOT hash the document for you: the canonical hash is keccak256 over the
+ * *deterministically* stringified document, and it has to match the one registered with the
+ * orderbook. Hashing an arbitrary string here would happily produce a valid-looking hash that
+ * no one can resolve back to any appData.
+ */
+function assertAppDataHash(appData: UnsignedOrder['appData']): void {
+  if (typeof appData === 'string' && APP_DATA_HASH_REGEX.test(appData)) return
+
+  const received =
+    typeof appData === 'string'
+      ? `a ${appData.length}-character string starting with "${appData.slice(0, 24)}..."`
+      : `a ${typeof appData}`
+
+  throw new CowError(
+    `Invalid order.appData: expected the bytes32 appData hash (0x + 64 hex chars), got ${received}. ` +
+      `The order struct signs appData as bytes32, so the full appData document cannot be passed here. ` +
+      `Derive the hash first with getAppDataInfo() from @cowprotocol/app-data and sign its appDataHex, ` +
+      `uploading the full document with OrderBookApi.uploadAppData().`,
+  )
+}
+
 const mapSigningSchema: Record<EcdsaSigningScheme, EcdsaSigningSchemeContract> = {
   [EcdsaSigningScheme.EIP712]: SigningScheme.EIP712,
   [EcdsaSigningScheme.ETHSIGN]: SigningScheme.ETHSIGN,
@@ -184,6 +219,8 @@ export async function signOrder(
   signer: Signer,
   options?: ProtocolOptions,
 ): Promise<SigningResult> {
+  assertAppDataHash(order.appData)
+
   const { env, settlementContractOverride } = options ?? {}
   return _signPayload({ order, chainId, env, settlementContractOverride }, _signOrder, signer)
 }

--- a/packages/order-signing/tests/orderSigningUtils.test.ts
+++ b/packages/order-signing/tests/orderSigningUtils.test.ts
@@ -1,5 +1,5 @@
 import { AdaptersTestSetup, createAdapters, TEST_ADDRESS } from './setup'
-import { setGlobalAdapter } from '@cowprotocol/sdk-common'
+import { CowError, setGlobalAdapter } from '@cowprotocol/sdk-common'
 import { OrderSigningUtils } from '../src/orderSigningUtils'
 import {
   COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS,
@@ -42,9 +42,13 @@ describe('OrderSigningUtils', () => {
       for (const [, adapter] of Object.entries(adapters)) {
         setGlobalAdapter(adapter)
 
-        await expect(
-          OrderSigningUtils.signOrder({ ...testOrder, appData: fullAppData }, SupportedChainId.SEPOLIA, adapter.signer),
-        ).rejects.toThrow(/expected the bytes32 appData hash/)
+        const promise = OrderSigningUtils.signOrder(
+          { ...testOrder, appData: fullAppData },
+          SupportedChainId.SEPOLIA,
+          adapter.signer,
+        )
+        await expect(promise).rejects.toThrow(CowError)
+        await expect(promise).rejects.toThrow(/expected the bytes32 appData hash/)
       }
     })
 
@@ -52,9 +56,13 @@ describe('OrderSigningUtils', () => {
       const [, adapter] = Object.entries(adapters)[0]
       setGlobalAdapter(adapter)
 
-      await expect(
-        OrderSigningUtils.signOrder({ ...testOrder, appData: '0xdeadbeef' }, SupportedChainId.SEPOLIA, adapter.signer),
-      ).rejects.toThrow(/expected the bytes32 appData hash/)
+      const promise = OrderSigningUtils.signOrder(
+        { ...testOrder, appData: '0xdeadbeef' },
+        SupportedChainId.SEPOLIA,
+        adapter.signer,
+      )
+      await expect(promise).rejects.toThrow(CowError)
+      await expect(promise).rejects.toThrow(/expected the bytes32 appData hash/)
     })
 
     test('should consistently sign orders across different adapters', async () => {

--- a/packages/order-signing/tests/orderSigningUtils.test.ts
+++ b/packages/order-signing/tests/orderSigningUtils.test.ts
@@ -30,6 +30,33 @@ describe('OrderSigningUtils', () => {
       partiallyFillable: true,
     }
 
+    test('should reject a full appData document instead of surfacing an opaque hex error', async () => {
+      // What you get back from OrderQuoteResponse if you pass it straight through
+      const fullAppData = JSON.stringify({
+        appCode: 'Decentralized CoW',
+        environment: 'prod',
+        metadata: { orderClass: { orderClass: 'limit' }, quote: { slippageBips: '50' } },
+        version: '0.11.0',
+      })
+
+      for (const [, adapter] of Object.entries(adapters)) {
+        setGlobalAdapter(adapter)
+
+        await expect(
+          OrderSigningUtils.signOrder({ ...testOrder, appData: fullAppData }, SupportedChainId.SEPOLIA, adapter.signer),
+        ).rejects.toThrow(/expected the bytes32 appData hash/)
+      }
+    })
+
+    test('should reject an appData hash that is not 32 bytes', async () => {
+      const [, adapter] = Object.entries(adapters)[0]
+      setGlobalAdapter(adapter)
+
+      await expect(
+        OrderSigningUtils.signOrder({ ...testOrder, appData: '0xdeadbeef' }, SupportedChainId.SEPOLIA, adapter.signer),
+      ).rejects.toThrow(/expected the bytes32 appData hash/)
+    })
+
     test('should consistently sign orders across different adapters', async () => {
       const signatures: Record<string, string> = {}
 


### PR DESCRIPTION
Closes #192

If you pass a `OrderQuoteResponse`'s `appData` straight into `OrderSigningUtils.signOrder()`, the document reaches the EIP-712 encoder and you get this:

```
Error: invalid hex string (argument="value", value="{\"appCode\":\"Decentralized CoW\",\"environment\":\"prod\",\"metadata\":{\"orderClass\":{\"orderClass\":\"limit\"},\"quote\":{\"slippageBips\":\"50\"}},\"version\":\"0.11.0\"}", code=INVALID_ARGUMENT, version=bytes/5.7.0)
```

Which tells you nothing about what you did wrong. `appData` in the order struct is a `bytes32`, so it can only hold the *hash* - but nothing says so until ethers chokes on it deep in the signing path.

This validates `order.appData` up front and throws a `CowError` that actually names the problem and points at `getAppDataInfo()`.

## why it doesn't just hash it for you

The issue suggests the SDK should "hash the correct parts" itself. I went the other way on purpose, and I'm happy to be overruled.

The canonical `appDataHex` is keccak256 over the **deterministically** stringified document - that's what `stringifyDeterministic` in `@cowprotocol/app-data` exists for. Hashing whatever string the caller happened to pass would produce a perfectly valid-looking bytes32 that doesn't match the document registered with the orderbook. You'd sign an order pointing at appData nobody can resolve, and you'd find out much later than you'd like.

Failing fast at the call site felt like the safer default for something that ends up in a signature. If you'd rather it auto-hash via `getAppDataInfo()` I'll happily switch it, it's a small change - it just means `order-signing` takes a dependency on `app-data`, which it currently doesn't have.

## receipts

Guard removed, so you get today's behaviour - note it reproduces the exact error from the issue:

```
$ pnpm test
Error: invalid hex string (argument="value", value="{\"appCode\":\"Decentralized CoW\",...}", code=INVALID_ARGUMENT, version=bytes/5.7.0)
  reason: 'invalid hex string',
  code: 'INVALID_ARGUMENT',

✕ should reject a full appData document instead of surfacing an opaque hex error
✕ should reject an appData hash that is not 32 bytes

Tests: 2 failed, 13 passed, 15 total
```

With the guard:

```
$ pnpm test
✓ should reject a full appData document instead of surfacing an opaque hex error (7 ms)
✓ should reject an appData hash that is not 32 bytes (1 ms)

Test Suites: 1 passed, 1 total
Tests:       15 passed, 15 total
```

Both new tests run across all three adapters (ethers v5, ethers v6, viem) via the existing `createAdapters()` setup.

## risk

Low-ish, but it's a new throw on a public method. Anything that was passing a non-bytes32 `appData` was already failing, just with a worse message - so no working call site changes behaviour. Only thing that'd break is someone relying on the ethers error type/message, which seems unlikely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure order app data is a valid `0x`-prefixed bytes32 hash before signing.
  * Clear errors are now shown when full documents or incorrectly sized values are provided.
* **Tests**
  * Added coverage for invalid app data formats across supported signing adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->