### PR TITLE
fix(trading): a 0 bps slippage suggestion is not a falsy value

### DIFF
--- a/packages/trading/src/getQuote.test.ts
+++ b/packages/trading/src/getQuote.test.ts
@@ -498,6 +498,33 @@ describe('getQuote', () => {
       })
     })
 
+    it('Should use suggested 0 slippage as-is, not fall back to the default and not skip the rebuild branch', async () => {
+      resolveSlippageSuggestion.mockResolvedValue({ slippageBps: 0 })
+      const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
+      const results: any[] = []
+
+      for (const adapterName of adapterNames) {
+        setGlobalAdapter(adapters[adapterName])
+        const result = await getQuoteWithSigner(
+          {
+            ...defaultOrderParams,
+            signer: adapters[adapterName].signer,
+            slippageBps: undefined, // AUTO slippage
+          },
+          {},
+          orderBookApiMock,
+        )
+        results.push(result)
+      }
+
+      results.forEach(({ result }) => {
+        expect(result.suggestedSlippageBps).toBe(0)
+        // If the rebuild branch (line 170) were skipped, appData would keep defaultOrderParams' fixture slippage (50)
+        const appData = JSON.parse(result.appDataInfo.fullAppData)
+        expect(appData.metadata.quote.slippageBips).toBe(0)
+      })
+    })
+
     it('Should pass getSlippageSuggestion callback from advanced settings', async () => {
       const mockCallback = jest.fn().mockResolvedValue({ slippageBps: 300 })
       const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>

--- a/packages/trading/src/getQuote.test.ts
+++ b/packages/trading/src/getQuote.test.ts
@@ -514,6 +514,33 @@ describe('getQuote', () => {
       })
     })
 
+    it('Should use suggested 0 slippage as-is, not fall back to the default and not skip the rebuild branch', async () => {
+      resolveSlippageSuggestion.mockResolvedValue({ slippageBps: 0 })
+      const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
+      const results: any[] = []
+
+      for (const adapterName of adapterNames) {
+        setGlobalAdapter(adapters[adapterName])
+        const result = await getQuoteWithSigner(
+          {
+            ...defaultOrderParams,
+            signer: adapters[adapterName].signer,
+            slippageBps: undefined, // AUTO slippage
+          },
+          {},
+          orderBookApiMock,
+        )
+        results.push(result)
+      }
+
+      results.forEach(({ result }) => {
+        expect(result.suggestedSlippageBps).toBe(0)
+        // If the rebuild branch (line 170) were skipped, appData would keep defaultOrderParams' fixture slippage (50)
+        const appData = JSON.parse(result.appDataInfo.fullAppData)
+        expect(appData.metadata.quote.slippageBips).toBe(0)
+      })
+    })
+
     it('Should pass getSlippageSuggestion callback from advanced settings', async () => {
       const mockCallback = jest.fn().mockResolvedValue({ slippageBps: 300 })
       const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>

--- a/packages/trading/src/getQuote.ts
+++ b/packages/trading/src/getQuote.ts
@@ -169,9 +169,7 @@ export async function getQuoteRaw(
   if (slippageBps === undefined) {
     if (suggestedSlippageBps != null) {
       // Recursive call, this time using the suggested slippage
-      log(
-        `Suggested slippage is greater than ${defaultSlippageBps} BPS (default), using the suggested slippage (${suggestedSlippageBps} BPS)`,
-      )
+      log(`Using suggested slippage (${suggestedSlippageBps} BPS) instead of the default (${defaultSlippageBps} BPS)`)
 
       const newAppDataInfo = await buildAppData(
         {

--- a/packages/trading/src/getQuote.ts
+++ b/packages/trading/src/getQuote.ts
@@ -162,12 +162,12 @@ export async function getQuoteRaw(
     isEthFlow,
     quote,
     orderBookApi,
-    suggestedSlippageBps: suggestedSlippageBps || defaultSlippageBps,
+    suggestedSlippageBps: suggestedSlippageBps ?? defaultSlippageBps,
   }
 
   // If no slippage is specified. AUTO slippage is used
   if (slippageBps === undefined) {
-    if (suggestedSlippageBps) {
+    if (suggestedSlippageBps != null) {
       // Recursive call, this time using the suggested slippage
       log(
         `Suggested slippage is greater than ${defaultSlippageBps} BPS (default), using the suggested slippage (${suggestedSlippageBps} BPS)`,

--- a/packages/trading/src/getQuote.ts
+++ b/packages/trading/src/getQuote.ts
@@ -164,12 +164,12 @@ export async function getQuoteRaw(
     isEthFlow,
     quote,
     orderBookApi,
-    suggestedSlippageBps: suggestedSlippageBps || defaultSlippageBps,
+    suggestedSlippageBps: suggestedSlippageBps ?? defaultSlippageBps,
   }
 
   // If no slippage is specified. AUTO slippage is used
   if (slippageBps === undefined) {
-    if (suggestedSlippageBps) {
+    if (suggestedSlippageBps != null) {
       // Recursive call, this time using the suggested slippage
       log(
         `Suggested slippage is greater than ${defaultSlippageBps} BPS (default), using the suggested slippage (${suggestedSlippageBps} BPS)`,

--- a/packages/trading/src/getQuote.ts
+++ b/packages/trading/src/getQuote.ts
@@ -171,9 +171,7 @@ export async function getQuoteRaw(
   if (slippageBps === undefined) {
     if (suggestedSlippageBps != null) {
       // Recursive call, this time using the suggested slippage
-      log(
-        `Suggested slippage is greater than ${defaultSlippageBps} BPS (default), using the suggested slippage (${suggestedSlippageBps} BPS)`,
-      )
+      log(`Using suggested slippage (${suggestedSlippageBps} BPS) instead of the default (${defaultSlippageBps} BPS)`)
 
       const newAppDataInfo = await buildAppData(
         {

--- a/packages/trading/src/resolveSlippageSuggestion.test.ts
+++ b/packages/trading/src/resolveSlippageSuggestion.test.ts
@@ -223,6 +223,37 @@ describe('resolveSlippageSuggestion', () => {
     })
   })
 
+  describe('When getSlippageSuggestion returns a legitimate 0 slippageBps', () => {
+    it('Should call suggestSlippageBps with 0 volumeMultiplierPercent, not fall through to the default suggestion', async () => {
+      suggestSlippageBps.mockReturnValue(0)
+      const mockGetSlippageSuggestion = jest.fn().mockResolvedValue({ slippageBps: 0 })
+      const advancedSettings: SwapAdvancedSettings = {
+        quoteRequest: { priceQuality: PriceQuality.OPTIMAL },
+        getSlippageSuggestion: mockGetSlippageSuggestion,
+      }
+
+      const result = await resolveSlippageSuggestion(
+        SupportedChainId.GNOSIS_CHAIN,
+        mockTradeParameters,
+        mockTrader,
+        mockQuoteResponse,
+        false,
+        advancedSettings,
+      )
+
+      expect(result).toEqual({ slippageBps: 0 })
+      expect(suggestSlippageBps).toHaveBeenCalledTimes(2)
+      expect(suggestSlippageBps).toHaveBeenLastCalledWith({
+        isEthFlow: false,
+        quote: mockQuoteResponse,
+        tradeParameters: mockTradeParameters,
+        trader: mockTrader,
+        advancedSettings,
+        volumeMultiplierPercent: 0, // 0 BPS = 0%
+      })
+    })
+  })
+
   describe('EthFlow orders', () => {
     it('Should pass isEthFlow flag to suggestSlippageBps', async () => {
       await resolveSlippageSuggestion(

--- a/packages/trading/src/resolveSlippageSuggestion.ts
+++ b/packages/trading/src/resolveSlippageSuggestion.ts
@@ -50,12 +50,13 @@ export async function resolveSlippageSuggestion(
     const suggestedSlippageBps = suggestedSlippage.slippageBps
 
     return {
-      slippageBps: suggestedSlippageBps
-        ? suggestSlippageBps({
-            ...suggestSlippageParams,
-            volumeMultiplierPercent: bpsToPercentage(suggestedSlippageBps),
-          })
-        : defaultSuggestion,
+      slippageBps:
+        suggestedSlippageBps != null
+          ? suggestSlippageBps({
+              ...suggestSlippageParams,
+              volumeMultiplierPercent: bpsToPercentage(suggestedSlippageBps),
+            })
+          : defaultSuggestion,
     }
   } catch (e: unknown) {
     log(`getSlippageSuggestion() error: ${(e as Error).message || String(e)}`)

--- a/packages/trading/src/resolveSlippageSuggestion.ts
+++ b/packages/trading/src/resolveSlippageSuggestion.ts
@@ -52,12 +52,13 @@ export async function resolveSlippageSuggestion(
     const suggestedSlippageBps = suggestedSlippage.slippageBps
 
     return {
-      slippageBps: suggestedSlippageBps
-        ? suggestSlippageBps({
-            ...suggestSlippageParams,
-            volumeMultiplierPercent: bpsToPercentage(suggestedSlippageBps),
-          })
-        : defaultSuggestion,
+      slippageBps:
+        suggestedSlippageBps != null
+          ? suggestSlippageBps({
+              ...suggestSlippageParams,
+              volumeMultiplierPercent: bpsToPercentage(suggestedSlippageBps),
+            })
+          : defaultSuggestion,
     }
   } catch (e: unknown) {
     log(`getSlippageSuggestion() error: ${(e as Error).message || String(e)}`)


### PR DESCRIPTION
Found by inspection, no filed issue.

`SlippageToleranceResponse.slippageBps` is typed `number | null`, with `null` as
the explicit "no suggestion" sentinel, distinct from a legitimate `0`. Three call
sites in `packages/trading/` checked this with plain truthiness instead of a
null-check, so a partner explicitly supplying `slippageBps: 0` via the public
`advancedSettings.getSlippageSuggestion` extension point (e.g. their own model
concluding a highly-correlated pair like USDC/USDT needs zero slippage buffer) got
silently discarded and replaced with the nonzero default:

- `resolveSlippageSuggestion.ts:55` fell through to `defaultSuggestion` instead of
  routing `0` through `suggestSlippageBps()`.
- `getQuote.ts:165` corrupted the `suggestedSlippageBps` metadata field returned to
  callers/UIs (a UI showing "AUTO: 0%" would instead show "AUTO: 0.5%").
- `getQuote.ts:170` skipped the order-rebuild branch entirely, leaving the order
  built with a stale nonzero slippage instead of the partner's explicit `0`.

Fix: swapped the truthy checks for `!= null` / `??` at all three sites.

One precision worth calling out: honoring a `0` suggestion doesn't produce a
zero-slippage order outright. `suggestSlippageBps()` always adds a fee-derived
component on top of the volume component it's fed (`suggestSlippageBps.ts:47-60`)
- a `0` suggestion only zeroes the volume part, same treatment as any other
suggested value. Final slippage is typically a few bps from the fee component
alone, `0` only when the fee itself rounds to `0`. That's the correct, consistent
behavior for this input - just flagging it so the fix doesn't read like a
straight `0`-in/`0`-out passthrough.

## Direction is safe either way

Checked `getQuoteAmountsAfterSlippage.ts` and `getOrderToSign.ts`: sell orders
subtract slippage from the min-receive amount, buy orders add it to the max-pay
amount. Honoring a smaller (or `0`) suggestion means a *tighter* limit in both
directions - the user can never end up with a worse execution price than quoted,
only a higher chance of no-fill. Grepped the rest of the monorepo (order-book,
bridging, composable, examples) for anything relying on the old behavior - nothing
does; every current caller either passes an explicit `slippageBps` (bypassing the
AUTO/suggestion lane entirely) or forwards its own slippage value directly. The
only lane whose output changes is a partner callback that actually returns `0`.

## Testing

New test cases in `resolveSlippageSuggestion.test.ts` and `getQuote.test.ts`
covering the `slippageBps === 0` suggestion at all three sites. Guard-validated
per-site: reverting each fix individually causes its corresponding new test to
fail with the exact predicted wrong value (falls to `defaultSuggestion`/50 BPS, or
the rebuild branch gets skipped so `appData.metadata.quote.slippageBips` stays at
the stale default instead of reflecting `0`), restoring passes. Also fixed a
pre-existing misleading log line in the branch this change makes always-taken when
a suggestion exists (was unconditionally claiming the suggestion is "greater than"
the default, which is false at `0` and in general).

Full `packages/trading` suite: 256 passed / 2 skipped (pre-existing, unrelated) /
258 total. `typecheck` and `lint` both clean. `prettier --check` clean on all
changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved an explicitly suggested slippage of 0 for AUTO-slippage quotes.
  * Prevented zero-value slippage suggestions from falling back to the default.
  * Ensured quote calculations and volume adjustments correctly handle zero slippage.

* **Tests**
  * Added regression coverage for zero-slippage quote and suggestion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->