### PR TITLE
fix(near-bridging): fix slippage being set as bridge fee

### DIFF
--- a/packages/bridging/package.json
+++ b/packages/bridging/package.json
@@ -40,7 +40,7 @@
     "@cowprotocol/sdk-order-book": "workspace:*",
     "@cowprotocol/sdk-trading": "workspace:*",
     "@cowprotocol/sdk-weiroll": "workspace:*",
-    "@defuse-protocol/one-click-sdk-typescript": "0.1.1-0.2",
+    "@defuse-protocol/one-click-sdk-typescript": "0.1.25",
     "json-stable-stringify": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.test.ts
+++ b/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.test.ts
@@ -144,6 +144,7 @@ adapterNames.forEach((adapterName) => {
       const mockStatus: GetExecutionStatusResponse = {
         status: GetExecutionStatusResponse.status.SUCCESS,
         updatedAt: '2025-09-05T12:01:33.000Z',
+        correlationId: 'test-correlation-id',
         swapDetails: {
           intentHashes: ['intentHash1'],
           nearTxHashes: ['nearTxHash1', 'nearTxHash2', 'nearTxHash3'],
@@ -163,6 +164,7 @@ adapterNames.forEach((adapterName) => {
         quoteResponse: {
           timestamp: '2025-09-05T12:00:38.695Z',
           signature: 'ed25519:signature',
+          correlationId: 'test-correlation-id',
           quoteRequest: {
             dry: false,
             swapType: QuoteRequest.swapType.EXACT_INPUT,
@@ -252,6 +254,7 @@ adapterNames.forEach((adapterName) => {
       const buildMockStatus = (destinationAsset: string): GetExecutionStatusResponse => ({
         status: GetExecutionStatusResponse.status.SUCCESS,
         updatedAt: '2025-09-05T12:01:33.000Z',
+        correlationId: 'test-correlation-id',
         swapDetails: {
           intentHashes: ['intentHash1'],
           nearTxHashes: ['nearTxHash1'],
@@ -271,6 +274,7 @@ adapterNames.forEach((adapterName) => {
         quoteResponse: {
           timestamp: '2025-09-05T12:00:38.695Z',
           signature: 'ed25519:signature',
+          correlationId: 'test-correlation-id',
           quoteRequest: {
             dry: false,
             swapType: QuoteRequest.swapType.EXACT_INPUT,
@@ -375,6 +379,7 @@ adapterNames.forEach((adapterName) => {
           },
           signature: 'ed25519:testSignature',
           timestamp: '2025-09-05T12:00:38.695Z',
+          correlationId: 'test-correlation-id',
         }
 
         jest.spyOn(api, 'getQuote').mockResolvedValue(mockQuoteResponse)
@@ -437,9 +442,9 @@ adapterNames.forEach((adapterName) => {
         const buyTokenAddress = '0x4200000000000000000000000000000000000006'
         const testQuoteHash = '0xtestFeeCurrencyQuoteHash'
 
-        // Sell token (USDC, 6 decimals) and buy token (ETH, 18 decimals) differ hugely in scale,
-        // and amountOut !== minAmountOut so the slippage-derived fees are non-zero. This makes a
-        // sell/buy-currency swap observable (with zero slippage, the fee is 0 and the swap hides).
+        // Sell token (USDC, 6 decimals) and buy token (ETH, 18 decimals) differ hugely in scale, and
+        // the quote carries both fees, so a sell/buy-currency swap is observable (with no fees at all
+        // both sides are 0 and the swap hides).
         const amountIn = '52000000' // 52 USDC (6 decimals)
         const amountOut = '11760237526222378' // ~0.01176 ETH (18 decimals)
         const minAmountOut = '11701433538591266'
@@ -456,6 +461,7 @@ adapterNames.forEach((adapterName) => {
             amountOutFormatted: '0.011760237526222378',
             amountOutUsd,
             minAmountOut,
+            withdrawFee: '560000000000',
             timeEstimate: 60,
             deadline: '2025-09-05T12:10:38.605Z',
             timeWhenInactive: '2025-09-05T12:10:38.605Z',
@@ -475,9 +481,11 @@ adapterNames.forEach((adapterName) => {
             recipient: '0x0000000000000000000000000000000000000000',
             recipientType: QuoteRequest.recipientType.DESTINATION_CHAIN,
             deadline: '2025-09-05T12:10:38.605Z',
+            appFees: [{ recipient: 'test.near', fee: 10 }],
           },
           signature: 'ed25519:testFeeSignature',
           timestamp: '2025-09-05T12:00:38.695Z',
+          correlationId: 'test-correlation-id',
         }
 
         jest.spyOn(api, 'getQuote').mockResolvedValue(mockQuoteResponse)
@@ -529,14 +537,21 @@ adapterNames.forEach((adapterName) => {
           signer: '0x0000000000000000000000000000000000000000',
         })
 
-        const slippage = (Number(amountOut) - Number(minAmountOut)) / Number(amountOut)
         const bridgingFee = quote.amountsAndCosts.costs.bridgingFee
 
         // The sell-currency fee must be denominated in the sell token (USDC, 6 decimals) and thus
-        // scaled by amountIn; the buy-currency fee in the buy token (ETH, 18 decimals), scaled by
-        // amountOut. Before the fix these two were swapped (each reported in the wrong token).
-        expect(bridgingFee.amountInSellCurrency).toBe(BigInt(Math.trunc(Number(amountIn) * slippage)))
-        expect(bridgingFee.amountInBuyCurrency).toBe(BigInt(Math.trunc(Number(amountOut) * slippage)))
+        // scaled by amountIn; the buy-currency fee in the buy token (ETH, 18 decimals). Before the
+        // fix these two were swapped (each reported in the wrong token).
+        // 10 bps appFee on 52 USDC = 52000 atoms, plus the 5.6e11 wei withdrawFee converted across.
+        expect(bridgingFee.amountInSellCurrency).toBe(54473n)
+        expect(bridgingFee.amountInBuyCurrency).toBe(12332570096318n)
+        // `fees.bridgeFee` mirrors the sell-currency amount, as documented in PROVIDER_README.md.
+        expect(quote.fees.bridgeFee).toBe(bridgingFee.amountInSellCurrency)
+
+        // The fee is the two 1Click fees, never the 50 bps slippage tolerance that separates
+        // amountOut from minAmountOut.
+        expect(bridgingFee.feeBps).toBe(10)
+        expect(quote.amountsAndCosts.slippageBps).toBe(50)
 
         // Sanity on magnitude: the sell fee is USDC-sized (small), the buy fee is ETH-sized (large).
         expect(bridgingFee.amountInSellCurrency < 1_000_000n).toBe(true)
@@ -578,6 +593,7 @@ adapterNames.forEach((adapterName) => {
           },
           signature: 'ed25519:testSignature',
           timestamp: '2025-09-05T12:00:38.695Z',
+          correlationId: 'test-correlation-id',
         }
 
         const mockAttestationSignature =
@@ -640,6 +656,7 @@ adapterNames.forEach((adapterName) => {
           },
           signature: 'ed25519:testBtcSignature',
           timestamp: '2025-09-05T12:00:38.695Z',
+          correlationId: 'test-correlation-id',
         }
 
         jest.spyOn(api, 'getQuote').mockResolvedValue(mockQuoteResponse)
@@ -719,6 +736,7 @@ adapterNames.forEach((adapterName) => {
             amountOutFormatted: '0.00007047',
             amountOutUsd: '4.6811',
             minAmountOut: '7011',
+            withdrawFee: '11', // ~15 bps of amountOut, the going rate for a BTC withdrawal
             timeEstimate: 470,
             deadline: '2026-06-19T12:03:12.000Z',
             timeWhenInactive: '2026-06-19T12:03:12.000Z',
@@ -738,9 +756,11 @@ adapterNames.forEach((adapterName) => {
             recipient: 'bc1qray0vz42y0sl4m0qwar58yel6lure25q8f22cn',
             recipientType: QuoteRequest.recipientType.DESTINATION_CHAIN,
             deadline: '2026-06-19T12:03:12.000Z',
+            appFees: [{ recipient: 'test.near', fee: 10 }],
           },
           signature: 'ed25519:testRealBtcSignature',
           timestamp: '2026-06-16T11:33:13.082Z',
+          correlationId: 'test-correlation-id',
         }
 
         jest.spyOn(api, 'getQuote').mockResolvedValue(mockQuoteResponse)
@@ -792,15 +812,261 @@ adapterNames.forEach((adapterName) => {
           signer: '0x0000000000000000000000000000000000000000',
         })
 
+        const bridgingFee = quote.amountsAndCosts.costs.bridgingFee
+
         // The BTC-denominated fee must never exceed the BTC amount being bridged (7047 sats).
-        expect(quote.fees.bridgeFee).toBeLessThan(quote.amountsAndCosts.beforeFee.buyAmount)
-        expect(quote.amountsAndCosts.costs.bridgingFee.amountInBuyCurrency).toBeLessThan(
-          quote.amountsAndCosts.beforeFee.buyAmount,
-        )
-        // With the swapped-currency bug this was 1,263,735 sats (bigger than the whole trade).
-        // Fixed value derived from amountOut (7047) vs minAmountOut (7011).
-        expect(quote.fees.bridgeFee).toBe(36n)
+        // With the swapped-currency bug it was 1,263,735 sats, bigger than the whole trade.
+        expect(bridgingFee.amountInBuyCurrency).toBeLessThan(quote.amountsAndCosts.beforeFee.buyAmount)
+        // 11 sats of withdrawFee, plus the 10 bps appFee converted from the USDC side.
+        expect(bridgingFee.amountInBuyCurrency).toBe(18n)
+        expect(bridgingFee.amountInSellCurrency).toBe(15202n)
+        expect(quote.fees.bridgeFee).toBe(bridgingFee.amountInSellCurrency)
+        // BTC is where withdrawFee dominates: 26 bps total against a 10 bps appFee. Deriving the fee
+        // from the USD values instead would have reported 2125 bps on this quote.
+        expect(bridgingFee.feeBps).toBe(26)
+        // Slippage stays what we asked Near for, and is reported separately from the fee.
         expect(quote.amountsAndCosts.slippageBps).toBe(51)
+        // amountOut is already net of both fees, so it carries through beforeFee and afterFee.
+        expect(quote.amountsAndCosts.beforeFee.buyAmount).toBe(7047n)
+        expect(quote.amountsAndCosts.afterFee.buyAmount).toBe(7047n)
+        expect(quote.amountsAndCosts.afterSlippage.buyAmount).toBe(7011n)
+      })
+
+      it('should not report the slippage tolerance as the bridging fee', async () => {
+        // Regression test for https://github.com/cowprotocol/cow-sdk/pull/929, which derived the fee
+        // from (amountOut - minAmountOut). That gap is just the slippageTolerance we send in the
+        // request, so every Near route reported a flat 0.5% fee. Real quote from an ETH -> ETH
+        // bridge where Near actually charged ~1 bp.
+        const api = new NearIntentsApi()
+        const sellTokenAddress = '0x0000000000000000000000000000000000000000'
+        const buyTokenAddress = '0x4200000000000000000000000000000000000006'
+        const testQuoteHash = '0xtestSlippageNotFeeQuoteHash'
+
+        const amountIn = '27627599418206933101'
+        const amountOut = '27624746408619420000'
+        const minAmountOut = '27486622676576326000' // amountOut - 50 bps
+        // The quote lost 1.03 bps end to end, less than a single bp of appFee would allow, so it
+        // carried none. What little it did cost was execution spread, which is not a fee.
+        const withdrawFee = '560000000000'
+
+        const mockQuoteResponse: QuoteResponse = {
+          quote: {
+            amountIn,
+            amountInFormatted: '27.627599418206933101',
+            amountInUsd: '69068.9985',
+            minAmountIn: amountIn,
+            amountOut,
+            amountOutFormatted: '27.62474640861942',
+            amountOutUsd: '69061.8660',
+            minAmountOut,
+            withdrawFee,
+            timeEstimate: 60,
+            deadline: '2026-08-28T12:10:38.605Z',
+            timeWhenInactive: '2026-08-28T12:10:38.605Z',
+            depositAddress: '0xAd8b7139196c5ae9fb66B71C91d87A1F9071687e',
+          },
+          quoteRequest: {
+            dry: false,
+            swapType: QuoteRequest.swapType.FLEX_INPUT,
+            depositMode: QuoteRequest.depositMode.SIMPLE,
+            slippageTolerance: 50,
+            originAsset: 'nep141:eth.omft.near',
+            depositType: QuoteRequest.depositType.ORIGIN_CHAIN,
+            destinationAsset: 'nep141:base.omft.near',
+            amount: amountIn,
+            refundTo: '0x0000000000000000000000000000000000000000',
+            refundType: QuoteRequest.refundType.ORIGIN_CHAIN,
+            recipient: '0x0000000000000000000000000000000000000000',
+            recipientType: QuoteRequest.recipientType.DESTINATION_CHAIN,
+            deadline: '2026-08-28T12:10:38.605Z',
+            appFees: [],
+          },
+          signature: 'ed25519:testSlippageNotFeeSignature',
+          timestamp: '2026-08-28T12:00:38.695Z',
+          correlationId: 'test-correlation-id',
+        }
+
+        jest.spyOn(api, 'getQuote').mockResolvedValue(mockQuoteResponse)
+        jest.spyOn(api, 'getTokens').mockResolvedValue([
+          {
+            assetId: 'nep141:eth.omft.near',
+            decimals: 18,
+            blockchain: TokenResponse.blockchain.ETH,
+            symbol: 'ETH',
+            price: 2500,
+            priceUpdatedAt: '2026-08-28T12:00:38.695Z',
+            contractAddress: sellTokenAddress,
+          },
+          {
+            assetId: 'nep141:base.omft.near',
+            decimals: 18,
+            blockchain: TokenResponse.blockchain.BASE,
+            symbol: 'ETH',
+            price: 2500,
+            priceUpdatedAt: '2026-08-28T12:00:38.695Z',
+            contractAddress: buyTokenAddress,
+          },
+        ])
+        jest.spyOn(api, 'getAttestation').mockResolvedValue({
+          version: 1,
+          signature:
+            '0x66edc32e2ab001213321ab7d959a2207fcef5190cc9abb6da5b0d2a8a9af2d4d2b0700e2c317c4106f337fd934fbbb0bf62efc8811a78603b33a8265d3b8f8cb1c',
+        })
+        provider.setApi(api)
+
+        jest.spyOn(provider, 'recoverDepositAddress').mockResolvedValue({
+          address: ATTESTATOR_ADDRESS,
+          quoteHash: testQuoteHash,
+          stringifiedQuote: '',
+          attestationSignature: '',
+        })
+
+        const quote = await provider.getQuote({
+          kind: OrderKind.SELL,
+          sellTokenChainId: SupportedChainId.MAINNET,
+          sellTokenAddress,
+          sellTokenDecimals: 18,
+          buyTokenChainId: 8453,
+          buyTokenAddress,
+          buyTokenDecimals: 18,
+          amount: BigInt(amountIn),
+          account: '0x0000000000000000000000000000000000000000',
+          appCode: 'test',
+          signer: '0x0000000000000000000000000000000000000000',
+        })
+
+        // 1Click's only charge here is the withdrawFee, well under a bp. The bug reported 49 bps
+        // (0.1381 ETH) -- five orders of magnitude more.
+        expect(quote.amountsAndCosts.costs.bridgingFee.feeBps).toBe(0)
+        expect(quote.fees.bridgeFee).toBe(560057823942n)
+        expect(quote.fees.bridgeFee).toBeLessThan(138123732043094000n)
+
+        // Slippage is reported on its own, and must not leak into the fee.
+        expect(quote.amountsAndCosts.slippageBps).toBe(49)
+        expect(quote.amountsAndCosts.costs.bridgingFee.feeBps).not.toBe(quote.amountsAndCosts.slippageBps)
+
+        // The fee is taken on the origin side, so amountOut carries through to afterFee, and
+        // afterSlippage is the guaranteed floor.
+        expect(quote.amountsAndCosts.afterFee.buyAmount).toBe(BigInt(amountOut))
+        expect(quote.amountsAndCosts.afterSlippage.buyAmount).toBe(BigInt(minAmountOut))
+      })
+
+      it('should match the real cost of a live 1Click quote on a same-asset route', async () => {
+        // Every field below is a verbatim 1Click response (dry quote, USDC Arbitrum -> USDC Base,
+        // slippageTolerance 50), including the appFees the API attaches to our quotes. Sell and buy
+        // are the same asset, so the total loss is exactly amountIn - amountOut = 1_104_298 atoms
+        // (11.04 bps), which splits into 10.02 bps of fees and 1.02 bps of execution spread.
+        const api = new NearIntentsApi()
+        const sellTokenAddress = '0xaf88d065e77c8cc2239327c5edb3a432268e5831'
+        const buyTokenAddress = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
+        const testQuoteHash = '0xtestLiveSameAssetQuoteHash'
+
+        const amountIn = '1000000000'
+        const amountOut = '998895702'
+        const minAmountOut = '993901223' // amountOut * (1 - 50 bps), i.e. pure slippage
+
+        const mockQuoteResponse: QuoteResponse = {
+          quote: {
+            amountIn,
+            amountInFormatted: '1000.0',
+            amountInUsd: '999.976000000000',
+            minAmountIn: '995000000',
+            amountOut,
+            amountOutFormatted: '998.895702',
+            amountOutUsd: '998.871728503152',
+            minAmountOut,
+            withdrawFee: '2400',
+            timeEstimate: 27,
+            deadline: '2026-08-29T12:00:00.000Z',
+            timeWhenInactive: '2026-08-29T12:00:00.000Z',
+            depositAddress: '0xAd8b7139196c5ae9fb66B71C91d87A1F9071687e',
+          },
+          quoteRequest: {
+            dry: false,
+            swapType: QuoteRequest.swapType.FLEX_INPUT,
+            depositMode: QuoteRequest.depositMode.SIMPLE,
+            slippageTolerance: 50,
+            originAsset: 'nep141:arb-0xaf88d065e77c8cc2239327c5edb3a432268e5831.omft.near',
+            depositType: QuoteRequest.depositType.ORIGIN_CHAIN,
+            destinationAsset: 'nep141:base-0x833589fcd6edb6e08f4c7c32d4f71b54bda02913.omft.near',
+            amount: amountIn,
+            refundTo: '0x0000000000000000000000000000000000000000',
+            refundType: QuoteRequest.refundType.ORIGIN_CHAIN,
+            recipient: '0x0000000000000000000000000000000000000000',
+            recipientType: QuoteRequest.recipientType.DESTINATION_CHAIN,
+            deadline: '2026-08-29T12:00:00.000Z',
+            appFees: [{ recipient: '5880ad2b362620fadf759cbceb1cd5737ce8c6ed7fb8e9942881e6731f9247dd', fee: 10 }],
+          },
+          signature: 'ed25519:testLiveSameAssetSignature',
+          timestamp: '2026-08-28T12:03:34.889Z',
+          correlationId: 'test-correlation-id',
+        }
+
+        jest.spyOn(api, 'getQuote').mockResolvedValue(mockQuoteResponse)
+        jest.spyOn(api, 'getTokens').mockResolvedValue([
+          {
+            assetId: 'nep141:arb-0xaf88d065e77c8cc2239327c5edb3a432268e5831.omft.near',
+            decimals: 6,
+            blockchain: TokenResponse.blockchain.ARB,
+            symbol: 'USDC',
+            price: 1,
+            priceUpdatedAt: '2026-08-28T12:03:34.889Z',
+            contractAddress: sellTokenAddress,
+          },
+          {
+            assetId: 'nep141:base-0x833589fcd6edb6e08f4c7c32d4f71b54bda02913.omft.near',
+            decimals: 6,
+            blockchain: TokenResponse.blockchain.BASE,
+            symbol: 'USDC',
+            price: 1,
+            priceUpdatedAt: '2026-08-28T12:03:34.889Z',
+            contractAddress: buyTokenAddress,
+          },
+        ])
+        jest.spyOn(api, 'getAttestation').mockResolvedValue({
+          version: 1,
+          signature:
+            '0x66edc32e2ab001213321ab7d959a2207fcef5190cc9abb6da5b0d2a8a9af2d4d2b0700e2c317c4106f337fd934fbbb0bf62efc8811a78603b33a8265d3b8f8cb1c',
+        })
+        provider.setApi(api)
+
+        jest.spyOn(provider, 'recoverDepositAddress').mockResolvedValue({
+          address: ATTESTATOR_ADDRESS,
+          quoteHash: testQuoteHash,
+          stringifiedQuote: '',
+          attestationSignature: '',
+        })
+
+        const quote = await provider.getQuote({
+          kind: OrderKind.SELL,
+          sellTokenChainId: SupportedChainId.ARBITRUM_ONE,
+          sellTokenAddress,
+          sellTokenDecimals: 6,
+          buyTokenChainId: 8453,
+          buyTokenAddress,
+          buyTokenDecimals: 6,
+          amount: BigInt(amountIn),
+          account: '0x0000000000000000000000000000000000000000',
+          appCode: 'test',
+          signer: '0x0000000000000000000000000000000000000000',
+        })
+
+        // 10 bps appFee on 1000 USDC = 1_000_000 atoms, plus the 2400 atom withdrawFee.
+        expect(quote.fees.bridgeFee).toBe(1002400n)
+        expect(quote.amountsAndCosts.costs.bridgingFee.feeBps).toBe(10)
+
+        // The remainder of the 1_104_298 atom total loss is execution spread, not a fee, so the
+        // reported fee sits just below it. Deriving the fee from the USD values would have swept
+        // that spread in -- harmless here, but 34 bps against 10 bps of fees on a cross-asset route.
+        const totalLoss = BigInt(amountIn) - BigInt(amountOut)
+        expect(totalLoss).toBe(1104298n)
+        expect(quote.fees.bridgeFee).toBeLessThan(totalLoss)
+        expect(totalLoss - quote.fees.bridgeFee).toBe(101898n)
+
+        // The 50 bps tolerance is slippage, and reporting it as the fee (the #929 bug) would have
+        // claimed 4.99 USDC of cost instead of 1.00.
+        expect(quote.amountsAndCosts.slippageBps).toBe(50)
+        expect(quote.fees.bridgeFee).toBeLessThan(BigInt(amountOut) - BigInt(minAmountOut))
       })
 
       it('should return quote when destination asset is solana', async () => {
@@ -841,6 +1107,7 @@ adapterNames.forEach((adapterName) => {
           },
           signature: 'ed25519:testSolSignature',
           timestamp: '2025-09-05T12:00:38.695Z',
+          correlationId: 'test-correlation-id',
         }
 
         jest.spyOn(api, 'getQuote').mockResolvedValue(mockQuoteResponse)

--- a/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.test.ts
+++ b/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.test.ts
@@ -826,8 +826,8 @@ adapterNames.forEach((adapterName) => {
         expect(bridgingFee.feeBps).toBe(26)
         // Slippage stays what we asked Near for, and is reported separately from the fee.
         expect(quote.amountsAndCosts.slippageBps).toBe(51)
-        // amountOut is already net of both fees, so it carries through beforeFee and afterFee.
-        expect(quote.amountsAndCosts.beforeFee.buyAmount).toBe(7047n)
+        // beforeFee -> afterFee is the fee, afterFee -> afterSlippage is the slippage.
+        expect(quote.amountsAndCosts.beforeFee.buyAmount).toBe(7065n)
         expect(quote.amountsAndCosts.afterFee.buyAmount).toBe(7047n)
         expect(quote.amountsAndCosts.afterSlippage.buyAmount).toBe(7011n)
       })
@@ -945,8 +945,8 @@ adapterNames.forEach((adapterName) => {
         expect(quote.amountsAndCosts.slippageBps).toBe(49)
         expect(quote.amountsAndCosts.costs.bridgingFee.feeBps).not.toBe(quote.amountsAndCosts.slippageBps)
 
-        // The fee is taken on the origin side, so amountOut carries through to afterFee, and
-        // afterSlippage is the guaranteed floor.
+        // afterFee is what 1Click quotes, afterSlippage is the guaranteed floor.
+        expect(quote.amountsAndCosts.beforeFee.buyAmount).toBe(27624746968619420000n)
         expect(quote.amountsAndCosts.afterFee.buyAmount).toBe(BigInt(amountOut))
         expect(quote.amountsAndCosts.afterSlippage.buyAmount).toBe(BigInt(minAmountOut))
       })
@@ -1067,6 +1067,125 @@ adapterNames.forEach((adapterName) => {
         // claimed 4.99 USDC of cost instead of 1.00.
         expect(quote.amountsAndCosts.slippageBps).toBe(50)
         expect(quote.fees.bridgeFee).toBeLessThan(BigInt(amountOut) - BigInt(minAmountOut))
+      })
+
+      it('should keep the expected buy amount above the minimum on a fee-heavy BTC route', async () => {
+        // Regression test for https://github.com/cowprotocol/cowswap/issues/7426. Consumers render
+        // "expected to receive" as `beforeFee.buyAmount - bridgingFee.amountInBuyCurrency`, so if
+        // `beforeFee.buyAmount` is left at `amountOut` -- which 1Click already reports net of
+        // `withdrawFee` -- the fee is subtracted twice and the result drops below `afterSlippage`.
+        // Verbatim 1Click response for 9.9923 USDC (Arbitrum) -> BTC, the quote from the bug report.
+        // BTC's withdrawFee is a flat 1900 sats no matter the size, which is 17% of a trade this
+        // small, so it is the sharpest case available.
+        const api = new NearIntentsApi()
+        const sellTokenAddress = '0xaf88d065e77c8cc2239327c5edb3a432268e5831'
+        const buyTokenAddress = BTC_CURRENCY_ADDRESS
+        const testQuoteHash = '0xtestBtcExpectedAboveMinQuoteHash'
+
+        const amountIn = '9992300'
+        const amountOut = '10813'
+        const minAmountOut = '10758'
+
+        const mockQuoteResponse: QuoteResponse = {
+          quote: {
+            amountIn,
+            amountInFormatted: '9.9923',
+            amountInUsd: '9.990561339800',
+            minAmountIn: '9942338',
+            amountOut,
+            amountOutFormatted: '0.00010813',
+            amountOutUsd: '8.489826950000',
+            minAmountOut,
+            withdrawFee: '1900',
+            refundFee: '5300',
+            timeEstimate: 470,
+            deadline: '2026-09-01T12:00:00.000Z',
+            timeWhenInactive: '2026-09-01T12:00:00.000Z',
+            depositAddress: '0xAd8b7139196c5ae9fb66B71C91d87A1F9071687e',
+          },
+          quoteRequest: {
+            dry: false,
+            swapType: QuoteRequest.swapType.FLEX_INPUT,
+            depositMode: QuoteRequest.depositMode.SIMPLE,
+            slippageTolerance: 50,
+            originAsset: 'nep141:arb-0xaf88d065e77c8cc2239327c5edb3a432268e5831.omft.near',
+            depositType: QuoteRequest.depositType.ORIGIN_CHAIN,
+            destinationAsset: '1cs_v1:btc:native:coin',
+            amount: amountIn,
+            refundTo: '0x0000000000000000000000000000000000000000',
+            refundType: QuoteRequest.refundType.ORIGIN_CHAIN,
+            recipient: 'bc1qray0vz42y0sl4m0qwar58yel6lure25q8f22cn',
+            recipientType: QuoteRequest.recipientType.DESTINATION_CHAIN,
+            deadline: '2026-09-01T12:00:00.000Z',
+            appFees: [{ recipient: '5880ad2b362620fadf759cbceb1cd5737ce8c6ed7fb8e9942881e6731f9247dd', fee: 10 }],
+          },
+          signature: 'ed25519:testBtcExpectedAboveMinSignature',
+          timestamp: '2026-08-31T10:00:00.000Z',
+          correlationId: 'test-correlation-id',
+        }
+
+        jest.spyOn(api, 'getQuote').mockResolvedValue(mockQuoteResponse)
+        jest.spyOn(api, 'getTokens').mockResolvedValue([
+          {
+            assetId: 'nep141:arb-0xaf88d065e77c8cc2239327c5edb3a432268e5831.omft.near',
+            decimals: 6,
+            blockchain: TokenResponse.blockchain.ARB,
+            symbol: 'USDC',
+            price: 1,
+            priceUpdatedAt: '2026-08-31T10:00:00.000Z',
+            contractAddress: sellTokenAddress,
+          },
+          {
+            assetId: '1cs_v1:btc:native:coin',
+            decimals: 8,
+            blockchain: TokenResponse.blockchain.BTC,
+            symbol: 'BTC(OMNI)',
+            price: 78518,
+            priceUpdatedAt: '2026-08-31T10:00:00.000Z',
+            contractAddress: 'coin',
+          },
+        ])
+        jest.spyOn(api, 'getAttestation').mockResolvedValue({
+          version: 1,
+          signature:
+            '0x66edc32e2ab001213321ab7d959a2207fcef5190cc9abb6da5b0d2a8a9af2d4d2b0700e2c317c4106f337fd934fbbb0bf62efc8811a78603b33a8265d3b8f8cb1c',
+        })
+        provider.setApi(api)
+
+        jest.spyOn(provider, 'recoverDepositAddress').mockResolvedValue({
+          address: ATTESTATOR_ADDRESS,
+          quoteHash: testQuoteHash,
+          stringifiedQuote: '',
+          attestationSignature: '',
+        })
+
+        const quote = await provider.getQuote({
+          kind: OrderKind.SELL,
+          sellTokenChainId: SupportedChainId.ARBITRUM_ONE,
+          sellTokenAddress,
+          sellTokenDecimals: 6,
+          buyTokenChainId: NonEvmChains.BITCOIN as number,
+          buyTokenAddress,
+          buyTokenDecimals: 8,
+          amount: BigInt(amountIn),
+          account: '0x0000000000000000000000000000000000000000',
+          appCode: 'test',
+          signer: '0x0000000000000000000000000000000000000000',
+        })
+
+        const { beforeFee, afterFee, afterSlippage, costs } = quote.amountsAndCosts
+
+        // 1900 sats of withdrawFee plus the 10 bps appFee converted across the swap rate.
+        expect(costs.bridgingFee.amountInBuyCurrency).toBe(1912n)
+
+        // Subtracting the fee from beforeFee must land exactly on what 1Click quotes, and that must
+        // stay above the guaranteed floor. Before the fix this was 10813 - 1912 = 8901 < 10758.
+        expect(beforeFee.buyAmount - costs.bridgingFee.amountInBuyCurrency).toBe(BigInt(amountOut))
+        expect(beforeFee.buyAmount).toBe(12725n)
+        expect(afterFee.buyAmount).toBe(BigInt(amountOut))
+        expect(afterSlippage.buyAmount).toBe(BigInt(minAmountOut))
+        expect(beforeFee.buyAmount - costs.bridgingFee.amountInBuyCurrency).toBeGreaterThan(afterSlippage.buyAmount)
+        expect(afterFee.buyAmount).toBeGreaterThan(afterSlippage.buyAmount)
       })
 
       it('should return quote when destination asset is solana', async () => {

--- a/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.ts
+++ b/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.ts
@@ -174,13 +174,37 @@ export class NearIntentsBridgeProvider implements ReceiverAccountBridgeProvider<
 
     const { quote, timestamp: isoDate } = quoteResponse
 
-    const amountOut = Number(quote.amountOut)
-    const minAmountOut = Number(quote.minAmountOut)
-    const slippage = amountOut > 0 ? (amountOut - minAmountOut) / amountOut : 0
-    const slippageBps = Math.trunc(slippage * 10_000)
-    const feeAmountInBuyCurrency = Math.trunc(amountOut * slippage)
-    const feeAmountInSellCurrency = Math.trunc(Number(quote.amountIn) * slippage)
-    const bridgeFee = feeAmountInBuyCurrency
+    const sellAmount = BigInt(quote.amountIn)
+    const buyAmount = BigInt(quote.amountOut)
+    const minBuyAmount = BigInt(quote.minAmountOut)
+
+    // Slippage is the tolerance we asked for. 1Click documents `minAmountOut` as "Minimum output
+    // amount after slippage is applied", and it comes back as exactly
+    // `amountOut * (1 - slippageTolerance)`, so this gap is *not* a fee.
+    const slippageBps = buyAmount > 0n ? Number(((buyAmount - minBuyAmount) * 10_000n) / buyAmount) : 0
+
+    // 1Click charges exactly two fees, both already reflected in `amountOut`:
+    //  - `appFees`, a share of `amountIn` in bps, taken off the input before the swap
+    //  - `withdrawFee`, the destination withdrawal cost, in units of the buy token
+    // Whatever else separates the two sides is the execution spread, which is not a fee. Deriving
+    // the fee from `amountInUsd`/`amountOutUsd` folds that spread in: those are oracle products
+    // (`amount * price`), so on cross-asset routes the gap measured 34 bps on USDC->ETH against
+    // 10 bps of actual fees, and on ETH->USDC came out *below* the known appFee.
+    // `refundFee` is deliberately excluded: it only applies when a swap is refunded.
+    const appFeeBps = (quoteResponse.quoteRequest.appFees ?? []).reduce((total, { fee }) => total + fee, 0)
+    const withdrawFee = BigInt(quote.withdrawFee ?? 0)
+
+    // The two fees sit on opposite sides of the swap, so converting between currencies uses the rate
+    // the swap actually got: gross output over net input.
+    const appFee = (sellAmount * BigInt(appFeeBps)) / 10_000n
+    const netSellAmount = sellAmount - appFee
+    const grossBuyAmount = buyAmount + withdrawFee
+
+    const feeAmountInSellCurrency =
+      grossBuyAmount > 0n ? appFee + (withdrawFee * netSellAmount) / grossBuyAmount : appFee
+    const feeAmountInBuyCurrency =
+      netSellAmount > 0n ? (appFee * grossBuyAmount) / netSellAmount + withdrawFee : withdrawFee
+    const feeBps = sellAmount > 0n ? Number((feeAmountInSellCurrency * 10_000n + sellAmount / 2n) / sellAmount) : 0
 
     return {
       id: recoveredDepositAddress.quoteHash,
@@ -193,31 +217,37 @@ export class NearIntentsBridgeProvider implements ReceiverAccountBridgeProvider<
       expectedFillTimeSeconds: quote.timeEstimate,
       limits: {
         minDeposit: BigInt(quote.minAmountIn),
-        maxDeposit: BigInt(quote.amountIn),
+        maxDeposit: sellAmount,
       },
       fees: {
-        bridgeFee: BigInt(bridgeFee), // The bridge fee is already included in `minAmountOut`. This means `bridgeFee` represents the maximum possible fee (worst case), but the actual fee may be lower.
+        // Denominated in the sell currency, i.e. the same value as
+        // `costs.bridgingFee.amountInSellCurrency`. This is the SDK's own cross-provider convention
+        // (PROVIDER_README.md, plus the Bungee and Across providers), not something 1Click dictates.
+        // Like Bungee's `routeFee` this is the fee only, and excludes execution spread.
+        bridgeFee: feeAmountInSellCurrency,
         destinationGasFee: BigInt(0),
       },
       amountsAndCosts: {
         beforeFee: {
-          sellAmount: BigInt(quote.amountIn),
-          buyAmount: BigInt(quote.amountOut),
+          sellAmount,
+          buyAmount,
         },
         afterFee: {
-          sellAmount: BigInt(quote.amountIn),
-          buyAmount: BigInt(quote.minAmountOut),
+          // `amountOut` is already net of every 1Click fee, so the buy amount does not change here.
+          // Same as the Bungee provider, where the fee is likewise not deducted from the output.
+          sellAmount,
+          buyAmount,
         },
         afterSlippage: {
-          sellAmount: BigInt(quote.amountIn),
-          buyAmount: BigInt(quote.minAmountOut),
+          sellAmount,
+          buyAmount: minBuyAmount,
         },
         slippageBps,
         costs: {
           bridgingFee: {
-            feeBps: slippageBps,
-            amountInSellCurrency: BigInt(feeAmountInSellCurrency),
-            amountInBuyCurrency: BigInt(feeAmountInBuyCurrency),
+            feeBps,
+            amountInSellCurrency: feeAmountInSellCurrency,
+            amountInBuyCurrency: feeAmountInBuyCurrency,
           },
         },
       },

--- a/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.ts
+++ b/packages/bridging/src/providers/near-intents/NearIntentsBridgeProvider.ts
@@ -229,12 +229,17 @@ export class NearIntentsBridgeProvider implements ReceiverAccountBridgeProvider<
       },
       amountsAndCosts: {
         beforeFee: {
+          // `amountOut` arrives already net of both fees, so the pre-fee buy amount has to add them
+          // back. Keeping `beforeFee.buyAmount` at `amountOut` makes consumers that render
+          // "expected to receive" as `beforeFee - bridgingFee` subtract the fee a second time, which
+          // can push it below `afterSlippage`. Bungee can hold both equal because its `routeFee` is
+          // taken in the source token; 1Click's `withdrawFee` comes out of the destination token.
           sellAmount,
-          buyAmount,
+          buyAmount: buyAmount + feeAmountInBuyCurrency,
         },
         afterFee: {
-          // `amountOut` is already net of every 1Click fee, so the buy amount does not change here.
-          // Same as the Bungee provider, where the fee is likewise not deducted from the output.
+          // The sell amount does not change: the user deposits the full `amountIn` and the fees are
+          // reported as costs, matching the Bungee and Across providers.
           sellAmount,
           buyAmount,
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 7.3.0(@swc/core@1.13.4(@swc/helpers@0.5.17))(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.4(@swc/helpers@0.5.17))(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3)
       turbo:
         specifier: latest
-        version: 2.10.4
+        version: 2.10.10
       typescript:
         specifier: ^5.2.2
         version: 5.8.3
@@ -316,7 +316,7 @@ importers:
         version: 2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)
       wagmi:
         specifier: latest
-        version: 3.7.1(@coinbase/wallet-sdk@4.3.6(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@18.3.1))(@types/react@18.3.26)(@walletconnect/ethereum-provider@2.21.1(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(porto@0.2.35)(react@18.3.1)(typescript@5.8.3)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))
+        version: 3.7.6(@coinbase/wallet-sdk@4.3.6(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@18.3.1))(@types/react@18.3.26)(@walletconnect/ethereum-provider@2.21.1(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(react@18.3.1)(typescript@5.8.3)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))
     devDependencies:
       '@types/react':
         specifier: ^18.3.1
@@ -443,8 +443,8 @@ importers:
         specifier: workspace:*
         version: link:../weiroll
       '@defuse-protocol/one-click-sdk-typescript':
-        specifier: 0.1.1-0.2
-        version: 0.1.1-0.2
+        specifier: 0.1.25
+        version: 0.1.25
       json-stable-stringify:
         specifier: ^1.3.0
         version: 1.3.0
@@ -1487,8 +1487,8 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@defuse-protocol/one-click-sdk-typescript@0.1.1-0.2':
-    resolution: {integrity: sha512-Jgt8uZlB5hQAo3UpyHH9XcXKNT6Vsqd7TTPy/vLEwuOvQ88Pag9qUxpU9Z2jYMD8SqOpxzaJrtgx+FSDb4lQ9A==}
+  '@defuse-protocol/one-click-sdk-typescript@0.1.25':
+    resolution: {integrity: sha512-y8fm8V7bPKYfJrhJOUWMG5/IFb1aMcIFHiM5PRDQngd33enhcDGGYJCNwM6y5o4pZZtlU1FroHB8OlA3NkxhzQ==}
     engines: {node: '>=16', pnpm: '>=8'}
 
   '@envelop/core@5.2.3':
@@ -3053,33 +3053,33 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@turbo/darwin-64@2.10.4':
-    resolution: {integrity: sha512-m1MUEI4MJ69r5CwfMYxmHi0H0rrgiYCBOp0tgBZ9x/YVvOb5uu/lRIDyDwdtH054R2yWeQaIigUGu6aCX9f8cA==}
+  '@turbo/darwin-64@2.10.10':
+    resolution: {integrity: sha512-gFDD+wRP5hWxBRghGyEbjpbLOY7aIU/wvsnKdMM7odQcp/wHMrnI83p0FyxxMRZnFH9ZD+S59MvcpOC5b+nrCA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.10.4':
-    resolution: {integrity: sha512-VQ1Yxs5zkPT+2z7t1P4mvn6JmcKLkOCAsPuK9XbOvuVj0DlTlETfIXNisX0771v/vTWHOQqiwoGi+TtAUq8efw==}
+  '@turbo/darwin-arm64@2.10.10':
+    resolution: {integrity: sha512-VZYsxZ6yjyDosUqtiroAVSXPLmx/qBxdHJgIxdMH9RyNmLdOLOWtJnYMnI4qckwCgQMK85G3fu94/xk5+iBCgw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.10.4':
-    resolution: {integrity: sha512-IzV1QovmwX7mfGnVinmE++2IB8tbeo38weltiuH5zNqwCTBjLs/DytyRKx+bmnhHdXIq9SheR8p0Nip/LBUPHg==}
+  '@turbo/linux-64@2.10.10':
+    resolution: {integrity: sha512-lAvW+yEnmsCKMEIwNugjozawvYytHKPhU0kfLBizu83MIs8OUb9KobYvkZ56L5akSM6K7+gBFLEIfQkaceh90g==}
     cpu: [x64]
-    os: [linux]
+    os: [android, linux]
 
-  '@turbo/linux-arm64@2.10.4':
-    resolution: {integrity: sha512-rfujSQkP5aYiRn0PgTM7F00WkJCP/bKDVZbOx3WmrZwa/vHA0bplhCl328kpX7VI9HH2vI90ISGwuSVgJgoqTw==}
+  '@turbo/linux-arm64@2.10.10':
+    resolution: {integrity: sha512-MSJ+NkRTd79Z9+YEZpUV9VOWVOOigFhE+v/ETNYJEuTJp3r00y9YgFvDXrmM+DP8Kal6tk3U6xSugD2/Ojh+Jg==}
     cpu: [arm64]
-    os: [linux]
+    os: [android, linux]
 
-  '@turbo/windows-64@2.10.4':
-    resolution: {integrity: sha512-NnspP7Wd5fa3Wwnqv9bKfhegqZzuHBgbPxdZU/idTLQcazx/vgKu95JlCx2YHY0hdvKCnPcARrDwM+KEUmaO7A==}
+  '@turbo/windows-64@2.10.10':
+    resolution: {integrity: sha512-ycWpXDkUfnDFDY9d+4Qna/UZotDB0wj+s9agrlmNt0Q7a3XHORhK8GPKJdzgzeutXu9EW5P/jyabTEHlohuDXw==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.10.4':
-    resolution: {integrity: sha512-Iv02YgOpaEShc2OkG7mgCJ2pEw1RUKiKbs0h8W5wAf4jZ5vpmraTEjuGTgHRuOORQnC1GN3KHo5WB+hu1abRMA==}
+  '@turbo/windows-arm64@2.10.10':
+    resolution: {integrity: sha512-PMk6zQN0csUFklLe+1hz/5G9uU1YmV0cEIey2R/bSeA6o69qcBTlN4A3jOqkgenOO5dOpMHmq2sEUZo8r1+Ssg==}
     cpu: [arm64]
     os: [win32]
 
@@ -3354,18 +3354,17 @@ packages:
       typescript:
         optional: true
 
-  '@wagmi/connectors@8.0.22':
-    resolution: {integrity: sha512-91fGrjf4ZOjd94DtN/p8/6FbPe5xA6j5camPiUkIoS30HqHqz00dYCsBX+dQ1DMFpHaGesgdpb9tz9AElS0Bxw==}
+  '@wagmi/connectors@8.1.0':
+    resolution: {integrity: sha512-ASlHXq9NC4pp617lalZdlPuPnZUhFeWNEKQfm3ngVSQKd4S2is5XXG4v3EOAhcxdLjSk1AMfGXlHgk5tX2WCZg==}
     peerDependencies:
       '@base-org/account': ^2.5.1
       '@coinbase/wallet-sdk': ^4.3.6
       '@metamask/connect-evm': ^2.1.0
       '@safe-global/safe-apps-provider': ~0.18.6
       '@safe-global/safe-apps-sdk': ^9.1.0
-      '@wagmi/core': 3.6.1
+      '@wagmi/core': 3.6.4
       '@walletconnect/ethereum-provider': ^2.21.1
       accounts: ~0.14
-      porto: ~0.2.35
       typescript: '>=5.9.3'
       viem: 2.x
     peerDependenciesMeta:
@@ -3383,13 +3382,11 @@ packages:
         optional: true
       accounts:
         optional: true
-      porto:
-        optional: true
       typescript:
         optional: true
 
-  '@wagmi/core@3.6.1':
-    resolution: {integrity: sha512-lmMLIBq0V+WM98ypeG6f4skowPlyuf8n+bWCD9SVJw3tww5sZL7Ab9rq2Js9+Yif1w9OKPy7yLWboIRT/EhRIA==}
+  '@wagmi/core@3.6.4':
+    resolution: {integrity: sha512-YERJ+vbFZw3UI6p4KoFU5DkxkqmtzBq5lddpgVAvcu5Tz7kSicKVA3DMCWvjVAFsikNdZYIs39FIkMGWfzpSMQ==}
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
       accounts: ~0.14
@@ -4407,6 +4404,7 @@ packages:
   eslint@9.27.0:
     resolution: {integrity: sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -4417,6 +4415,7 @@ packages:
   eslint@9.33.0:
     resolution: {integrity: sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -4834,10 +4833,6 @@ packages:
 
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
-
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
-    engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -5710,14 +5705,6 @@ packages:
       typescript:
         optional: true
 
-  ox@0.9.17:
-    resolution: {integrity: sha512-rKAnhzhRU3Xh3hiko+i1ZxywZ55eWQzeS/Q4HRKLx2PqfHOolisZHErSsJVipGlmQKHW5qwOED/GighEw9dbLg==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -5846,38 +5833,6 @@ packages:
   pony-cause@2.1.11:
     resolution: {integrity: sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==}
     engines: {node: '>=12.0.0'}
-
-  porto@0.2.35:
-    resolution: {integrity: sha512-gu9FfjjvvYBgQXUHWTp6n3wkTxVtEcqFotM7i3GEZeoQbvLGbssAicCz6hFZ8+xggrJWwi/RLmbwNra50SMmUQ==}
-    hasBin: true
-    peerDependencies:
-      '@tanstack/react-query': '>=5.59.0'
-      '@wagmi/core': '>=2.16.3'
-      expo-auth-session: '>=7.0.8'
-      expo-crypto: '>=15.0.7'
-      expo-web-browser: '>=15.0.8'
-      react: '>=18'
-      react-native: '>=0.81.4'
-      typescript: '>=5.4.0'
-      viem: '>=2.37.0'
-      wagmi: '>=2.0.0'
-    peerDependenciesMeta:
-      '@tanstack/react-query':
-        optional: true
-      expo-auth-session:
-        optional: true
-      expo-crypto:
-        optional: true
-      expo-web-browser:
-        optional: true
-      react:
-        optional: true
-      react-native:
-        optional: true
-      typescript:
-        optional: true
-      wagmi:
-        optional: true
 
   postcss-load-config@4.0.2:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
@@ -6523,9 +6478,12 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo@2.10.4:
-    resolution: {integrity: sha512-GQpduILaKjoaGljw097ScsSyKTtZSY7cZ3bJktzfTkPMyCf3ShKLuXK2IaOEN2Plziml+ArR7WJ1m+V4VbnaKQ==}
+  turbo@2.10.10:
+    resolution: {integrity: sha512-/90KTW+USzvYOPmafRZHVKLBsHXQ5810Ao/HdtJYAqguIhZ+XruS6eIUjqJUDtrSxaZYynNFht68qckGKAOWTA==}
     hasBin: true
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -6758,6 +6716,13 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
   valibot@1.4.2:
     resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
@@ -6765,13 +6730,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
-
-  v8-to-istanbul@9.3.0:
-    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
-    engines: {node: '>=10.12.0'}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -6883,8 +6841,8 @@ packages:
       yaml:
         optional: true
 
-  wagmi@3.7.1:
-    resolution: {integrity: sha512-CTocC9w6TW3X14d1NB2dDRpDz4qSM4IDttIGVaSAArjoHlptfJZIkBNXLktUNXk52dUfitLucvTwCWngy8NBAQ==}
+  wagmi@3.7.6:
+    resolution: {integrity: sha512-Zm/ppGHV6GYX9by3ERs1KVcNqpMZ4Vdno48Avdz9U+3QCjC5iFatOwruA9IMOl8poL7n/pJGQOcR1xj8N5c69w==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -7114,24 +7072,6 @@ packages:
 
   zustand@5.0.0:
     resolution: {integrity: sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ==}
-    engines: {node: '>=12.20.0'}
-    peerDependencies:
-      '@types/react': '>=18.0.0'
-      immer: '>=9.0.6'
-      react: '>=18.0.0'
-      use-sync-external-store: '>=1.2.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      immer:
-        optional: true
-      react:
-        optional: true
-      use-sync-external-store:
-        optional: true
-
-  zustand@5.0.14:
-    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -7602,10 +7542,14 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@defuse-protocol/one-click-sdk-typescript@0.1.1-0.2':
+  '@defuse-protocol/one-click-sdk-typescript@0.1.25':
     dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
       axios: 1.11.0
       form-data: 4.0.4
+      json-stable-stringify: 1.3.0
+      tweetnacl: 1.0.3
     transitivePeerDependencies:
       - debug
 
@@ -9886,22 +9830,22 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@turbo/darwin-64@2.10.4':
+  '@turbo/darwin-64@2.10.10':
     optional: true
 
-  '@turbo/darwin-arm64@2.10.4':
+  '@turbo/darwin-arm64@2.10.10':
     optional: true
 
-  '@turbo/linux-64@2.10.4':
+  '@turbo/linux-64@2.10.10':
     optional: true
 
-  '@turbo/linux-arm64@2.10.4':
+  '@turbo/linux-arm64@2.10.10':
     optional: true
 
-  '@turbo/windows-64@2.10.4':
+  '@turbo/windows-64@2.10.10':
     optional: true
 
-  '@turbo/windows-arm64@2.10.4':
+  '@turbo/windows-arm64@2.10.10':
     optional: true
 
   '@typechain/ethers-v5@11.1.2(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)':
@@ -9916,24 +9860,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.27.3
-      '@babel/types': 7.27.3
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.7
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.27.3
+      '@babel/types': 7.28.5
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.27.3
-      '@babel/types': 7.27.3
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
 
   '@types/babel__traverse@7.20.7':
     dependencies:
-      '@babel/types': 7.27.3
+      '@babel/types': 7.28.5
 
   '@types/debug@4.1.12':
     dependencies:
@@ -10319,19 +10263,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@wagmi/connectors@8.0.22(@coinbase/wallet-sdk@4.3.6(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@wagmi/core@3.6.1(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)))(@walletconnect/ethereum-provider@2.21.1(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(porto@0.2.35)(typescript@5.8.3)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))':
+  '@wagmi/connectors@8.1.0(@coinbase/wallet-sdk@4.3.6(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@wagmi/core@3.6.4(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)))(@walletconnect/ethereum-provider@2.21.1(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(typescript@5.8.3)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))':
     dependencies:
-      '@wagmi/core': 3.6.1(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))
+      '@wagmi/core': 3.6.4(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))
       viem: 2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)
     optionalDependencies:
       '@coinbase/wallet-sdk': 4.3.6(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)
       '@walletconnect/ethereum-provider': 2.21.1(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)
-      porto: 0.2.35(@tanstack/react-query@5.45.1(react@18.3.1))(@types/react@18.3.26)(@wagmi/core@3.6.1(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)))(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(wagmi@3.7.1)
       typescript: 5.8.3
 
-  '@wagmi/core@3.6.1(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))':
+  '@wagmi/core@3.6.4(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.8.3)
@@ -11818,7 +11761,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-toolkit@1.33.0:
     optional: true
@@ -12404,7 +12347,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
@@ -12631,7 +12574,6 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
-    optional: true
 
   he@1.2.0: {}
 
@@ -12645,9 +12587,6 @@ snapshots:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
-
-  hono@4.12.23:
-    optional: true
 
   hosted-git-info@2.8.9: {}
 
@@ -12754,7 +12693,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-core-module@2.16.2:
     dependencies:
@@ -13743,22 +13682,6 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.17(typescript@5.8.3)(zod@4.1.12):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.4(typescript@5.8.3)(zod@4.1.12)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - zod
-    optional: true
-
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -13884,27 +13807,6 @@ snapshots:
     optional: true
 
   pony-cause@2.1.11: {}
-
-  porto@0.2.35(@tanstack/react-query@5.45.1(react@18.3.1))(@types/react@18.3.26)(@wagmi/core@3.6.1(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)))(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(wagmi@3.7.1):
-    dependencies:
-      '@wagmi/core': 3.6.1(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))
-      hono: 4.12.23
-      idb-keyval: 6.2.5
-      mipd: 0.0.7(typescript@5.8.3)
-      ox: 0.9.17(typescript@5.8.3)(zod@4.1.12)
-      viem: 2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)
-      zod: 4.1.12
-      zustand: 5.0.14(@types/react@18.3.26)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
-    optionalDependencies:
-      '@tanstack/react-query': 5.45.1(react@18.3.1)
-      react: 18.3.1
-      typescript: 5.8.3
-      wagmi: 3.7.1(@coinbase/wallet-sdk@4.3.6(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@18.3.1))(@types/react@18.3.26)(@walletconnect/ethereum-provider@2.21.1(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(porto@0.2.35)(react@18.3.1)(typescript@5.8.3)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - use-sync-external-store
-    optional: true
 
   postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.4(@swc/helpers@0.5.17))(@types/node@20.17.52)(typescript@5.8.3)):
     dependencies:
@@ -14640,14 +14542,16 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo@2.10.4:
+  turbo@2.10.10:
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.4
-      '@turbo/darwin-arm64': 2.10.4
-      '@turbo/linux-64': 2.10.4
-      '@turbo/linux-arm64': 2.10.4
-      '@turbo/windows-64': 2.10.4
-      '@turbo/windows-arm64': 2.10.4
+      '@turbo/darwin-64': 2.10.10
+      '@turbo/darwin-arm64': 2.10.10
+      '@turbo/linux-64': 2.10.10
+      '@turbo/linux-arm64': 2.10.10
+      '@turbo/windows-64': 2.10.10
+      '@turbo/windows-arm64': 2.10.10
+
+  tweetnacl@1.0.3: {}
 
   type-check@0.4.0:
     dependencies:
@@ -14814,10 +14718,6 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  valibot@1.4.2(typescript@5.8.3):
-    optionalDependencies:
-      typescript: 5.8.3
-
   v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.3.0:
@@ -14825,6 +14725,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  valibot@1.4.2(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -14935,11 +14839,11 @@ snapshots:
       tsx: 4.19.4
       yaml: 2.8.0
 
-  wagmi@3.7.1(@coinbase/wallet-sdk@4.3.6(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@18.3.1))(@types/react@18.3.26)(@walletconnect/ethereum-provider@2.21.1(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(porto@0.2.35)(react@18.3.1)(typescript@5.8.3)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)):
+  wagmi@3.7.6(@coinbase/wallet-sdk@4.3.6(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@18.3.1))(@types/react@18.3.26)(@walletconnect/ethereum-provider@2.21.1(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(react@18.3.1)(typescript@5.8.3)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)):
     dependencies:
       '@tanstack/react-query': 5.45.1(react@18.3.1)
-      '@wagmi/connectors': 8.0.22(@coinbase/wallet-sdk@4.3.6(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@wagmi/core@3.6.1(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)))(@walletconnect/ethereum-provider@2.21.1(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(porto@0.2.35)(typescript@5.8.3)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))
-      '@wagmi/core': 3.6.1(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))
+      '@wagmi/connectors': 8.1.0(@coinbase/wallet-sdk@4.3.6(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(@wagmi/core@3.6.4(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)))(@walletconnect/ethereum-provider@2.21.1(@types/react@18.3.26)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))(typescript@5.8.3)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))
+      '@wagmi/core': 3.6.4(@tanstack/query-core@5.45.0)(@types/react@18.3.26)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))
       react: 18.3.1
       use-sync-external-store: 1.4.0(react@18.3.1)
       viem: 2.52.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)
@@ -14956,7 +14860,6 @@ snapshots:
       - '@walletconnect/ethereum-provider'
       - accounts
       - immer
-      - porto
 
   walker@1.0.8:
     dependencies:
@@ -15142,13 +15045,6 @@ snapshots:
       '@types/react': 18.3.26
       react: 18.3.1
       use-sync-external-store: 1.4.0(react@18.3.1)
-
-  zustand@5.0.14(@types/react@18.3.26)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)):
-    optionalDependencies:
-      '@types/react': 18.3.26
-      react: 18.3.1
-      use-sync-external-store: 1.4.0(react@18.3.1)
-    optional: true
 
   zustand@5.0.3(@types/react@18.3.26)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)):
     optionalDependencies:


### PR DESCRIPTION
# Summary

Fixes bug with Near provider where the slippage is being incorrectly returned as the bridge fee.

# Testing

- Unit tests
- Will test it on CoW Swap with the PKG versions from this PR
    - Test [PR](https://github.com/cowprotocol/cowswap/pull/8054)
    - Test [url](https://swap-dev-git-fix-near-bridge-fee-cowswap-dev.vercel.app/)

Comparing prod (left) vs pr with these changes (right)
<img width="1289" height="1189" alt="image" src="https://github.com/user-attachments/assets/bafc7e41-90dc-4cb4-a43c-9dda02c09d9e" />


# AI generated long description

## What changed

- Derive the Near bridging fee from 1Click's own fee fields — `appFees` (bps of `amountIn`) plus `withdrawFee` (buy-token units) — instead of `(amountOut - minAmountOut)`. `refundFee` is excluded; it only applies on refund.
- Report `slippageBps` and `bridgingFee.feeBps` as separate values; they were the same number.
- Fix `afterFee.buyAmount`, which was `minAmountOut` and therefore identical to `afterSlippage.buyAmount`. It is now `amountOut`, which 1Click already quotes net of both fees.
- Move `fees.bridgeFee` back to the sell currency, matching `costs.bridgingFee.amountInSellCurrency` per `PROVIDER_README.md` and the Bungee/Across providers.
- Bump `@defuse-protocol/one-click-sdk-typescript` `0.1.1-0.2` → `0.1.25`, which types `withdrawFee` and `refundFee`. Its only breaking change is `correlationId` becoming required on `QuoteResponse` and `GetExecutionStatusResponse`, which touches test mocks only.
- Switch the arithmetic to `bigint`. `Number(quote.amountIn)` silently lost precision on any 18-decimal amount.

## Why

Regression from #929, which switched the fee's source to `(amountOut - minAmountOut)`. That gap is just the `slippageTolerance` the SDK sends in its own request, so every Near route reported a flat 0.5% fee regardless of what Near charges. 1Click documents `minAmountOut` as *"Minimum output amount after slippage is applied"*, and a live quote returns it as exactly `amountOut * (1 - slippageTolerance)`.

Deriving the fee from `amountInUsd`/`amountOutUsd` was also rejected. Those are oracle products (`amount × price` from `/tokens`), so the gap between them is fee **plus execution spread**. Measured against live quotes:

| route | USD gap | appFee | withdrawFee | actual fees | spread |
| --- | --- | --- | --- | --- | --- |
| USDC→USDC | 11.04 bps | 10 | 0.02 | 10.02 | 1.02 |
| USDC→ETH | 33.85 bps | 10 | 0.01 | 10.01 | 23.83 |
| USDC→BTC | 31.98 bps | 10 | **15.10** | 25.10 | 6.88 |
| ETH→USDC | 8.98 bps | 10 | 0.05 | 10.05 | **−1.08** |

The last row is the disqualifier: the USD gap lands *below* the known appFee, so it is noise rather than a conservative estimate. The BTC row is why `withdrawFee` cannot be dropped — it is a real Bitcoin network cost and dominates that route.

Reported fees are now the fee only, no spread — the same semantics as Bungee's `routeFee`.

## QA Testing

Developer verification:
- `it('should match the real cost of a live 1Click quote on a same-asset route')` — every field, including `appFees` and `withdrawFee`, is a verbatim 1Click response. Asserts the 1,104,298 atom total loss splits into 1,002,400 of fees and 101,898 of spread.
- `it('should compute a sane BTC-denominated fee for a real production BTC bridge quote')` — 26 bps, the case where `withdrawFee` dominates. The USD-derived version reported 2125 bps here.
- `it('should not report the slippage tolerance as the bridging fee')` — production ETH→ETH quote from the bug report; fee is the `withdrawFee` alone against the 49 bps the bug claimed.
- Reverting `NearIntentsBridgeProvider.ts` to `ef6dc405` fails 12 tests across both adapters; the suite passes at 63/63 with the fix, and 620 across the package.
- Repo-wide `turbo run typecheck` passes 41/41 after the dependency bump.

Reviewer note:
- `fees.bridgeFee` changes denomination (buy → sell currency). Nothing in this repo reads it, so it is worth a grep in `cowswap` to confirm no consumer expects the buy-currency value #929 introduced.
- The reported fee now excludes execution spread by design, so Near will show a smaller number than the user's total cost. That is the tradeoff for being comparable to Bungee; the alternative folds a spread that swung 22–38 bps between quotes into a "fee".
- The 10 bps `appFee` is not universal — the ETH→ETH quote in the regression test carried none, so it may be keyed to the integration or have been added since. The code sums whatever `appFees` the response returns and falls back to zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved bridge quote accuracy by separating actual fees from slippage tolerance.
* Updated fee calculations to support currency-specific app and withdrawal fees.
* Corrected quote amounts and minimum output calculations for more reliable estimates.
* Improved fee-heavy Bitcoin route estimates to preserve guaranteed minimum outputs.
* Added coverage for Bitcoin, same-asset quotes, and scenarios where slippage should not be reported as a fee.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->