### PR TITLE
feat(trading): default to verified quotes

### DIFF
--- a/packages/trading/README.md
+++ b/packages/trading/README.md
@@ -654,6 +654,8 @@ However, you can provide additional parameters to customize the order creation.
 #### Swap
 
 1. `quoteRequest` - the quote request object. It is used to get a quote from the quote API ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/cow-sdk/modules#orderquoterequest))
+
+   `priceQuality` defaults to `verified`: the backend simulates quotes and prefers verified ones over higher unverified ones. Pass `optimal` to get the highest quote without simulation (faster, but a higher risk the order turns out unfillable). Do not pass `fast` for orders you intend to place: fast quotes have no `id`.
 2. `appData` - the order's metadata ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/app-data/modules#appdataparams))
 
 ##### Example

--- a/packages/trading/README.md
+++ b/packages/trading/README.md
@@ -655,7 +655,7 @@ However, you can provide additional parameters to customize the order creation.
 
 1. `quoteRequest` - the quote request object. It is used to get a quote from the quote API ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/cow-sdk/modules#orderquoterequest))
 
-   `priceQuality` defaults to `verified`: the backend simulates quotes and prefers verified ones over higher unverified ones. Pass `optimal` to get the highest quote without simulation (faster, but a higher risk the order turns out unfillable). Do not pass `fast` for orders you intend to place: fast quotes have no `id`.
+   `priceQuality` defaults to `verified`: the backend simulates quotes and prefers verified ones over higher unverified ones. Pass `optimal` to get the highest quote without simulation (faster, but a higher risk the order turns out unfillable).
 2. `appData` - the order's metadata ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/app-data/modules#appdataparams))
 
 ##### Example

--- a/packages/trading/src/README.md
+++ b/packages/trading/src/README.md
@@ -432,7 +432,7 @@ However, you can provide additional parameters to customize the order creation.
 
 1. `quoteRequest` - the quote request object. It is used to get a quote from the quote API ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/cow-sdk/modules#orderquoterequest))
 
-   `priceQuality` defaults to `verified`: the backend simulates quotes and prefers verified ones over higher unverified ones. Pass `optimal` to get the highest quote without simulation (faster, but a higher risk the order turns out unfillable). Do not pass `fast` for orders you intend to place: fast quotes have no `id`.
+   `priceQuality` defaults to `verified`: the backend simulates quotes and prefers verified ones over higher unverified ones. Pass `optimal` to get the highest quote without simulation (faster, but a higher risk the order turns out unfillable).
 2. `appData` - the order's metadata ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/app-data/modules#appdataparams))
 
 ##### Example

--- a/packages/trading/src/README.md
+++ b/packages/trading/src/README.md
@@ -431,6 +431,8 @@ However, you can provide additional parameters to customize the order creation.
 #### Swap
 
 1. `quoteRequest` - the quote request object. It is used to get a quote from the quote API ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/cow-sdk/modules#orderquoterequest))
+
+   `priceQuality` defaults to `verified`: the backend simulates quotes and prefers verified ones over higher unverified ones. Pass `optimal` to get the highest quote without simulation (faster, but a higher risk the order turns out unfillable). Do not pass `fast` for orders you intend to place: fast quotes have no `id`.
 2. `appData` - the order's metadata ([read more](https://docs.cow.fi/cow-protocol/reference/sdks/app-data/modules#appdataparams))
 
 ##### Example

--- a/packages/trading/src/getQuote.test.ts
+++ b/packages/trading/src/getQuote.test.ts
@@ -2,7 +2,7 @@ import { ETH_FLOW_DEFAULT_SLIPPAGE_BPS } from './consts'
 import { getQuoteWithSigner, getQuoteWithoutSigner } from './getQuote'
 import { QuoterParameters, SwapParameters } from './types'
 import { ETH_ADDRESS, WRAPPED_NATIVE_CURRENCIES, SupportedChainId } from '@cowprotocol/sdk-config'
-import { OrderBookApi, OrderKind, OrderQuoteResponse } from '@cowprotocol/sdk-order-book'
+import { OrderBookApi, OrderKind, OrderQuoteResponse, PriceQuality } from '@cowprotocol/sdk-order-book'
 import { AdaptersTestSetup, createAdapters } from '../tests/setup'
 import { AccountAddress, setGlobalAdapter } from '@cowprotocol/sdk-common'
 
@@ -182,12 +182,28 @@ describe('getQuote', () => {
       }
     })
 
-    it('priceQuality must always be OPTIMAL', async () => {
+    it('priceQuality defaults to VERIFIED', async () => {
       const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
 
       for (const adapterName of adapterNames) {
         setGlobalAdapter(adapters[adapterName])
         await getQuoteWithSigner({ ...defaultOrderParams, signer: adapters[adapterName].signer }, {}, orderBookApiMock)
+
+        const call = getQuoteMock.mock.calls[0][0]
+        expect(call.priceQuality).toBe('verified')
+      }
+    })
+
+    it('priceQuality can be overridden, for example with OPTIMAL', async () => {
+      const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
+
+      for (const adapterName of adapterNames) {
+        setGlobalAdapter(adapters[adapterName])
+        await getQuoteWithSigner(
+          { ...defaultOrderParams, signer: adapters[adapterName].signer },
+          { quoteRequest: { priceQuality: PriceQuality.OPTIMAL } },
+          orderBookApiMock,
+        )
 
         const call = getQuoteMock.mock.calls[0][0]
         expect(call.priceQuality).toBe('optimal')

--- a/packages/trading/src/getQuote.ts
+++ b/packages/trading/src/getQuote.ts
@@ -125,7 +125,12 @@ export async function getQuoteRaw(
     ...(typeof validTo === 'number' ? { validTo } : { validFor: effectiveValidFor }),
     appData: fullAppData,
     appDataHash: appDataKeccak256,
-    priceQuality: PriceQuality.OPTIMAL, // Do not change this parameter because we rely on the fact that quote has id
+    // Defaults to VERIFIED: the backend simulates the quote and prefers verified quotes over higher
+    // unverified ones, which is what we want for order placement. Override via
+    // `advancedSettings.quoteRequest.priceQuality` (e.g. OPTIMAL for the highest, unsimulated quote).
+    // Never use FAST here: fast quotes are not persisted by the backend, so they have no `id`,
+    // which order placement relies on.
+    priceQuality: PriceQuality.VERIFIED,
     signingScheme: SigningScheme.EIP712,
     ...(isEthFlow ? ETH_FLOW_AUX_QUOTE_PARAMS : {}),
     ...(isSell

--- a/packages/trading/src/getQuote.ts
+++ b/packages/trading/src/getQuote.ts
@@ -125,11 +125,8 @@ export async function getQuoteRaw(
     ...(typeof validTo === 'number' ? { validTo } : { validFor: effectiveValidFor }),
     appData: fullAppData,
     appDataHash: appDataKeccak256,
-    // Defaults to VERIFIED: the backend simulates the quote and prefers verified quotes over higher
-    // unverified ones, which is what we want for order placement. Override via
-    // `advancedSettings.quoteRequest.priceQuality` (e.g. OPTIMAL for the highest, unsimulated quote).
-    // Never use FAST here: fast quotes are not persisted by the backend, so they have no `id`,
-    // which order placement relies on.
+    // Simulated quote: preferred over a higher unverified one for order placement.
+    // Override via `advancedSettings.quoteRequest.priceQuality` (spread below).
     priceQuality: PriceQuality.VERIFIED,
     signingScheme: SigningScheme.EIP712,
     ...(isEthFlow ? ETH_FLOW_AUX_QUOTE_PARAMS : {}),

--- a/packages/trading/src/resolveSlippageSuggestion.test.ts
+++ b/packages/trading/src/resolveSlippageSuggestion.test.ts
@@ -58,8 +58,8 @@ describe('resolveSlippageSuggestion', () => {
     suggestSlippageBps.mockReturnValue(100)
   })
 
-  describe('When priceQuality defaults to OPTIMAL', () => {
-    it('Should call getSlippageSuggestion when priceQuality is undefined (defaults to OPTIMAL)', async () => {
+  describe('When priceQuality defaults to VERIFIED', () => {
+    it('Should call getSlippageSuggestion when priceQuality is undefined (defaults to VERIFIED)', async () => {
       const mockGetSlippageSuggestion = jest.fn().mockResolvedValue({ slippageBps: 200 })
       const advancedSettings: SwapAdvancedSettings = {
         getSlippageSuggestion: mockGetSlippageSuggestion,

--- a/packages/trading/src/resolveSlippageSuggestion.test.ts
+++ b/packages/trading/src/resolveSlippageSuggestion.test.ts
@@ -58,8 +58,8 @@ describe('resolveSlippageSuggestion', () => {
     suggestSlippageBps.mockReturnValue(100)
   })
 
-  describe('When priceQuality defaults to VERIFIED', () => {
-    it('Should call getSlippageSuggestion when priceQuality is undefined (defaults to VERIFIED)', async () => {
+  describe('When priceQuality is not set', () => {
+    it('Should call getSlippageSuggestion when priceQuality is undefined', async () => {
       const mockGetSlippageSuggestion = jest.fn().mockResolvedValue({ slippageBps: 200 })
       const advancedSettings: SwapAdvancedSettings = {
         getSlippageSuggestion: mockGetSlippageSuggestion,

--- a/packages/trading/src/resolveSlippageSuggestion.ts
+++ b/packages/trading/src/resolveSlippageSuggestion.ts
@@ -23,12 +23,9 @@ export async function resolveSlippageSuggestion(
   }
   const getSlippageSuggestion = advancedSettings?.getSlippageSuggestion
 
-  // Keep in sync with the default in getQuote()
-  const priceQuality = advancedSettings?.quoteRequest?.priceQuality ?? PriceQuality.VERIFIED
-
   const defaultSuggestion = suggestSlippageBps(suggestSlippageParams)
 
-  if (priceQuality === PriceQuality.FAST || !getSlippageSuggestion) {
+  if (advancedSettings?.quoteRequest?.priceQuality === PriceQuality.FAST || !getSlippageSuggestion) {
     return { slippageBps: defaultSuggestion }
   }
 

--- a/packages/trading/src/resolveSlippageSuggestion.ts
+++ b/packages/trading/src/resolveSlippageSuggestion.ts
@@ -23,7 +23,8 @@ export async function resolveSlippageSuggestion(
   }
   const getSlippageSuggestion = advancedSettings?.getSlippageSuggestion
 
-  const priceQuality = advancedSettings?.quoteRequest?.priceQuality ?? PriceQuality.OPTIMAL
+  // Keep in sync with the default in getQuote()
+  const priceQuality = advancedSettings?.quoteRequest?.priceQuality ?? PriceQuality.VERIFIED
 
   const defaultSuggestion = suggestSlippageBps(suggestSlippageParams)
 


### PR DESCRIPTION
# Summary

Make default quote quality `verified`, instead of `optimal`.
Right now, `verified` and `optimal` are identical.
That will change on https://github.com/cowprotocol/services/pull/4805.

We want our default to be `verified`, keeping the same behaviour we currently have.

The sdk still accepts `optimal` as a parameter, so consumers will be able to choose.

# Testing

- Unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap quotes now default to **verified** pricing for more reliable order placement.
  * Added support for selecting **optimal** pricing to receive the highest available quote without simulation.
  * Documented the available pricing options and their trade-offs.

* **Bug Fixes**
  * Improved slippage handling so fast pricing is recognized only when explicitly selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->