### PR TITLE
fix: Twap.isValid() never validates the derived per-part amounts

### DIFF
--- a/packages/composable/src/orderTypes/Twap.ts
+++ b/packages/composable/src/orderTypes/Twap.ts
@@ -277,6 +277,14 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
         if (!(durationOfPart.duration <= timeBetweenParts)) return 'InvalidSpan'
       }
 
+      // Verify that the per-part amounts (floor division of the aggregate amounts by
+      // numberOfParts, as computed in `transformDataToStruct`) are non-zero. The on-chain
+      // TWAPOrder handler reverts when `partSellAmount` or `minPartLimit` is zero, so an
+      // order whose aggregate amounts pass but whose derived per-part amounts round down to
+      // zero looks valid here while every poll against the contract fails.
+      if (!(this.staticInput.partSellAmount > ZERO)) return 'InvalidPartSellAmount'
+      if (!(this.staticInput.minPartLimit > ZERO)) return 'InvalidMinPartLimit'
+
       // Verify that the staticInput derived from the data is ABI-encodable
       if (!isValidAbi(TWAP_STRUCT_ABI, [this.staticInput])) return 'InvalidData'
 

--- a/packages/composable/tests/Twap.spec.ts
+++ b/packages/composable/tests/Twap.spec.ts
@@ -375,6 +375,54 @@ describe('TWAP Order - Multi-Adapter Tests', () => {
       })
     })
 
+    test('should invalidate a per-part sell amount that floors to zero across all adapters', () => {
+      // sellAmount/numberOfParts floors to 0 even though the aggregate sellAmount is non-zero.
+      // The on-chain TWAPOrder handler reverts on a zero partSellAmount, so this must be caught here.
+      const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
+      const results: any[] = []
+
+      for (const adapterName of adapterNames) {
+        setGlobalAdapter(adapters[adapterName])
+        const result = Twap.fromData({ ...TWAP_PARAMS_TEST, sellAmount: BigInt(90), numberOfParts: BigInt(100) }).isValid()
+        results.push(result)
+      }
+
+      // All results should be identical
+      const [firstResult, ...remainingResults] = results
+      remainingResults.forEach((result) => {
+        expect(result).toEqual(firstResult)
+      })
+
+      expect(firstResult).toEqual({
+        isValid: false,
+        reason: 'InvalidPartSellAmount',
+      })
+    })
+
+    test('should invalidate a per-part min limit that floors to zero across all adapters', () => {
+      // buyAmount/numberOfParts floors to 0 even though the aggregate buyAmount is non-zero.
+      // The on-chain TWAPOrder handler reverts on a zero minPartLimit, so this must be caught here.
+      const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
+      const results: any[] = []
+
+      for (const adapterName of adapterNames) {
+        setGlobalAdapter(adapters[adapterName])
+        const result = Twap.fromData({ ...TWAP_PARAMS_TEST, buyAmount: BigInt(90), numberOfParts: BigInt(100) }).isValid()
+        results.push(result)
+      }
+
+      // All results should be identical
+      const [firstResult, ...remainingResults] = results
+      remainingResults.forEach((result) => {
+        expect(result).toEqual(firstResult)
+      })
+
+      expect(firstResult).toEqual({
+        isValid: false,
+        reason: 'InvalidMinPartLimit',
+      })
+    })
+
     test('should invalidate negative start time across all adapters', () => {
       const adapterNames = Object.keys(adapters) as Array<keyof typeof adapters>
       const results: any[] = []


### PR DESCRIPTION
`Twap.isValid()` checks the aggregate `sellAmount`/`buyAmount` but never the derived per-part `partSellAmount`/`minPartLimit` (floor division by `numberOfParts`, computed once in the base constructor via `transformDataToStruct` and stored on `this.staticInput`). The on-chain `TWAPOrder` handler validates the derived quantities directly and reverts when either is zero:

```solidity
// composable-cow, TWAPOrder.sol
if (!(self.partSellAmount > 0)) revert IConditionalOrder.OrderNotValid(INVALID_PART_SELL_AMOUNT);
if (!(self.minPartLimit  > 0)) revert IConditionalOrder.OrderNotValid(INVALID_MIN_PART_LIMIT);
```

Concrete failing case: `{ sellAmount: 90n, numberOfParts: 100n }` → `partSellAmount = 90n / 100n = 0n` (BigInt floor division). The SDK's `isValid()` reports the order valid, but the on-chain handler reverts on every attempt.

`ConditionalOrder.poll()` gates on `isValid()` for its `DONT_TRY_AGAIN` short-circuit (`packages/composable/src/ConditionalOrder.ts:264-269`), so an order built this way never gets that clean signal — it just keeps failing against the contract instead of being recognized as invalid up front.

## Fix

Add the two missing checks in `isValid()`, mirroring the Solidity, reusing the value already computed in the constructor (`this.staticInput.partSellAmount` / `.minPartLimit`) rather than re-deriving it.

## Receipts

New unit tests fail on the pre-fix code and pass after:
```
$ git stash push -- packages/composable/src/orderTypes/Twap.ts   # revert only the fix
$ npx jest -t "floors to zero"
✕ should invalidate a per-part sell amount that floors to zero across all adapters
  - "isValid": false, "reason": "InvalidPartSellAmount"
  + "isValid": true
✕ should invalidate a per-part min limit that floors to zero across all adapters
  - "isValid": false, "reason": "InvalidMinPartLimit"
  + "isValid": true
Tests: 8 failed, 275 skipped, 283 total

$ git stash pop   # restore the fix
$ npx jest
Test Suites: 9 passed, 9 total
Tests:       283 passed, 283 total
```
Lint (`npx eslint src/orderTypes/Twap.ts`) and `tsc --noEmit` both clean.

Adversarially reviewed with Codex (GPT-5.6) against the diff directly: verdict `SHIP`, no blocking findings — confirmed `staticInput` reflects the correct floor-divided values for every construction path (`fromData`, raw constructor, `deserialize`), confirmed no existing valid fixture regresses, and confirmed check ordering can't produce a false result. It also flagged a separate, pre-existing, out-of-scope concern (case-sensitive same-token address comparison in the `InvalidSameToken` check) — noting here for visibility, not fixing it in this PR to keep the diff focused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TWAP order validation to reject orders whose per-part sell or minimum buy amounts round down to zero.
  - Prevents invalid orders from being submitted when their aggregate amounts appear valid but individual parts cannot execute.

- **Tests**
  - Added coverage for zero-value per-part sell and buy amounts caused by rounding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->