### PR TITLE
fix: extractOrderUidParams DataView ignores byteOffset on non-zero-offset buffers

### DIFF
--- a/packages/contracts-ts/src/order.ts
+++ b/packages/contracts-ts/src/order.ts
@@ -239,7 +239,12 @@ export function extractOrderUidParams(orderUid: string): OrderUidParams {
     throw new Error('invalid order UID length')
   }
 
-  const view = new DataView(bytes.buffer)
+  // NOTE: `bytes` may be a view into a larger backing buffer (e.g. a pooled Node Buffer),
+  // so the DataView must be scoped to `bytes`'s own byteOffset/byteLength. Constructing it
+  // over the raw `bytes.buffer` would silently read from the wrong offset whenever
+  // `bytes.byteOffset !== 0`, and the `bytes.length` check above can't catch that since it
+  // only validates the view's own length, not the underlying buffer.
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
   return {
     orderDigest: adapter.utils.hexlify(bytes.subarray(0, 32)),
     owner: adapter.utils.getChecksumAddress(adapter.utils.hexlify(bytes.subarray(32, 52))),

--- a/packages/contracts-ts/tests/order.test.ts
+++ b/packages/contracts-ts/tests/order.test.ts
@@ -111,6 +111,35 @@ describe('Order Hashing and Signing', () => {
       const orderHash = hashOrder(testDomain, testOrder)
       expect(firstParams.orderDigest).toEqual(orderHash)
     })
+
+    test('should extract the correct validTo even when arrayify returns a view into a larger buffer', () => {
+      // Regression test: extractOrderUidParams used to build its DataView directly over
+      // bytes.buffer, ignoring bytes.byteOffset. That's fine for the shipped adapters (their
+      // arrayify implementations always return a byteOffset-0 Uint8Array), but any adapter
+      // whose arrayify returns a view into a larger backing buffer (e.g. a pooled Node
+      // Buffer, or a plain .subarray()) would silently read validTo from the wrong offset.
+      setGlobalAdapter(adapters.ethersV5Adapter)
+      const uid = computeOrderUid(testDomain, testOrder, TEST_ADDRESS)
+
+      const realArrayify = adapters.ethersV5Adapter.utils.arrayify.bind(adapters.ethersV5Adapter.utils)
+      const arrayifySpy = jest.spyOn(adapters.ethersV5Adapter.utils, 'arrayify').mockImplementation((hexString) => {
+        const realBytes = realArrayify(hexString)
+        // Simulate a byteOffset-shifted view: pack the real bytes into a larger backing
+        // buffer at a nonzero offset, then hand back a subarray view into it.
+        const padding = 20
+        const backing = new Uint8Array(padding + realBytes.length)
+        backing.set(realBytes, padding)
+        return backing.subarray(padding, padding + realBytes.length)
+      })
+
+      try {
+        const params = extractOrderUidParams(uid)
+        expect(params.validTo).toEqual(testOrder.validTo)
+        expect(params.owner).toEqual(TEST_ADDRESS)
+      } finally {
+        arrayifySpy.mockRestore()
+      }
+    })
   })
 
   describe('signOrder', () => {


### PR DESCRIPTION
`extractOrderUidParams` builds its `DataView` directly over the full backing `ArrayBuffer` of the bytes returned by `adapter.utils.arrayify(orderUid)`, with no `byteOffset`/`byteLength`:

```ts
const bytes = adapter.utils.arrayify(orderUid)
if (bytes.length != ORDER_UID_LENGTH) { throw new Error('invalid order UID length') }
const view = new DataView(bytes.buffer)   // ignores bytes.byteOffset
  ...
  validTo: view.getUint32(52),
```

If `bytes` is a view into a *larger* backing buffer — a pooled `Buffer`, or any plain `.subarray()` — `bytes.byteOffset` is non-zero and the `DataView` silently reads `validTo` from the wrong location. The `bytes.length` guard can't catch this: it validates the view's own length, not the offset into the underlying buffer, so nothing throws — it just returns a wrong value.

## Scope, honestly

This is currently **latent**. All three shipped adapters happen to always return `byteOffset: 0` arrays (`ethers.utils.arrayify` / `ethers.getBytes` / viem's `hexToBytes` all allocate fresh zero-offset `Uint8Array`s), so nothing ships broken today. But `AbstractProviderAdapter.arrayify(hexString: string): Uint8Array` (`packages/common/src/adapters/types/AdapterUtils.ts`) makes no such guarantee, and it's a documented public extension point — a custom adapter backed by, say, `Buffer.from(hex.slice(2), 'hex')` from a pooled allocation satisfies the interface exactly and would silently mis-decode `validTo`. `extractOrderUidParams` is also exported with no internal callers, so there's nothing catching a wrong-adapter mistake before it reaches a consumer.

Framing this as defensive/correctness hardening on a public API surface, not an active exploit.

## Fix

`new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)` instead of `new DataView(bytes.buffer)`.

## Receipts

Independent repro before touching any adapter code (`node`, real `DataView` behavior, not simulated):
```
case 1: fresh Uint8Array (byteOffset 0)          -> bad=1756745984 good=1756745984 expected=1756745984  (matches, as expected)
case 2: pooled-buffer-style view (byteOffset 144) -> bad=0          good=1756745984 expected=1756745984  (bad path returns garbage)
case 3: plain .subarray() view (byteOffset 8)     -> bad=3452816845 good=1756745984 expected=1756745984  (bad path returns garbage)
```

New regression test spies on a real adapter's `arrayify` to return a byteOffset-shifted view wrapping the real bytes (simulating a pooled-buffer-backed custom adapter), confirms it fails pre-fix and passes post-fix:
```
$ git stash push -- packages/contracts-ts/src/order.ts   # revert only the fix
$ npx jest tests/order.test.ts -t "larger buffer"
✕ should extract the correct validTo even when arrayify returns a view into a larger buffer
  Expected: 1788267624
  Received: 3719640337

$ git stash pop   # restore the fix
$ npx jest tests/order.test.ts
Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total

$ npx jest   # full package suite
Test Suites: 10 passed, 10 total
Tests:       75 passed, 75 total
```
Lint (`npx eslint src/order.ts tests/order.test.ts`) and `tsc --noEmit` both clean.
