### PR TITLE
fix(trading)!: eth-flow order-id collision avoidance was completely inert

### DIFF
--- a/packages/trading/src/calculateUniqueOrderId.test.ts
+++ b/packages/trading/src/calculateUniqueOrderId.test.ts
@@ -92,6 +92,72 @@ describe('calculateUniqueOrderId', () => {
         expect(chainId).toBe(SupportedChainId.MAINNET)
         expect(order.buyAmount).toBe('99')
       })
+
+      it('Then the returned order (not just the id) reflects the adjusted amounts', async () => {
+        // Regression test: calculateUniqueOrderId used to return a bare orderId string,
+        // silently discarding the adjusted order that actually produced it. A caller
+        // building a transaction from its original input (rather than this returned
+        // order) would recreate the exact order that was just detected as colliding.
+        let alreadyCalled = false
+
+        const checkEthFlowOrderExists = jest.fn().mockImplementation(() => {
+          return Promise.resolve(
+            (() => {
+              if (alreadyCalled) return false
+              alreadyCalled = true
+
+              return true
+            })(),
+          )
+        })
+
+        const result = await calculateUniqueOrderId(SupportedChainId.MAINNET, orderMock, checkEthFlowOrderExists)
+
+        expect(result.orderId).toBe('0xab444')
+        expect(result.order.buyAmount).toBe('99')
+        // Every other field must be preserved unchanged from the original order.
+        expect(result.order.sellAmount).toBe(orderMock.sellAmount)
+        expect(result.order.sellToken).toBe(orderMock.sellToken)
+        expect(result.order.buyToken).toBe(orderMock.buyToken)
+        expect(result.order.validTo).toBe(orderMock.validTo)
+      })
+    })
+
+    describe('When checkEthFlowOrderExists returns false (no collision)', () => {
+      it('Then the returned order is exactly the original order, unmodified', async () => {
+        const checkEthFlowOrderExists = jest.fn().mockResolvedValue(false)
+
+        const result = await calculateUniqueOrderId(SupportedChainId.MAINNET, orderMock, checkEthFlowOrderExists)
+
+        expect(result.orderId).toBe('0xab444')
+        expect(result.order).toEqual(orderMock)
+      })
+    })
+
+    describe('When buyAmount cannot be nudged further down without going to zero or below', () => {
+      it('Then it throws instead of silently producing an invalid order', async () => {
+        const checkEthFlowOrderExists = jest.fn().mockResolvedValue(true)
+
+        await expect(
+          calculateUniqueOrderId(
+            SupportedChainId.MAINNET,
+            { ...orderMock, buyAmount: '1' },
+            checkEthFlowOrderExists,
+          ),
+        ).rejects.toThrow(/too small to adjust further/)
+      })
+
+      it('Then a buyAmount of 0 also throws (never even reachable via nudging, but guard it anyway)', async () => {
+        const checkEthFlowOrderExists = jest.fn().mockResolvedValue(true)
+
+        await expect(
+          calculateUniqueOrderId(
+            SupportedChainId.MAINNET,
+            { ...orderMock, buyAmount: '0' },
+            checkEthFlowOrderExists,
+          ),
+        ).rejects.toThrow(/too small to adjust further/)
+      })
     })
   })
 

--- a/packages/trading/src/calculateUniqueOrderId.ts
+++ b/packages/trading/src/calculateUniqueOrderId.ts
@@ -11,12 +11,23 @@ import type { ContractsOrder as Order } from '@cowprotocol/sdk-contracts-ts'
 import { EthFlowOrderExistsCallback } from './types'
 import { unsignedOrderForSigning } from './utils/order'
 
+export interface UniqueOrderIdResult {
+  orderId: string
+  /**
+   * The order that actually produced `orderId`. On a collision this differs from the
+   * `order` argument (its `buyAmount` has been nudged) — callers MUST build the on-chain
+   * transaction from this order, not from their original input, or they'll recreate the
+   * exact order that was just detected as colliding.
+   */
+  order: UnsignedOrder
+}
+
 export async function calculateUniqueOrderId(
   chainId: SupportedChainId,
   order: UnsignedOrder,
   checkEthFlowOrderExists?: EthFlowOrderExistsCallback,
   options?: ProtocolOptions,
-): Promise<string> {
+): Promise<UniqueOrderIdResult> {
   const { env, ethFlowContractOverride } = options ?? {}
   const { orderDigest, orderId } = await OrderSigningUtils.generateOrderId(
     chainId,
@@ -48,7 +59,7 @@ export async function calculateUniqueOrderId(
     )
   }
 
-  return orderId
+  return { orderId, order }
 }
 
 function adjustAmounts(order: UnsignedOrder): UnsignedOrder {
@@ -58,6 +69,14 @@ function adjustAmounts(order: UnsignedOrder): UnsignedOrder {
   // Also, we don't want to touch the sell amount.
   // If we move it down, the price might become "too good", if we move it up, the user might not have enough funds!
   // Thus, we make the buy amount a tad bit worse by 1 wei.
-  // We can only hope this doesn't happen for an order buying 0 a decimals token 🤞
+  if (buyAmount <= BigInt(1)) {
+    // A zero (or negative, on a second collision) buyAmount can't be nudged further down
+    // without producing an invalid order — fail loudly instead of silently building a
+    // transaction with buyAmount 0 (or a BigInt that can't encode as uint256).
+    throw new Error(
+      `[calculateUniqueOrderId] Cannot resolve order-id collision: buyAmount (${order.buyAmount}) is too small to adjust further`,
+    )
+  }
+
   return { ...order, buyAmount: (buyAmount - BigInt(1)).toString() }
 }

--- a/packages/trading/src/getEthFlowTransaction.test.ts
+++ b/packages/trading/src/getEthFlowTransaction.test.ts
@@ -149,6 +149,77 @@ describe('getEthFlowTransaction', () => {
     )
   })
 
+  describe('when a collision is detected by checkEthFlowOrderExists', () => {
+    it('builds the on-chain transaction from the adjusted order, not the original — and returns a consistent orderToSign', async () => {
+      setGlobalAdapter(adapters.ethersV5Adapter)
+
+      // Baseline: what buyAmount getOrderToSign computes with no collision at all
+      // (it applies its own slippage adjustment, so this is NOT literally params.buyAmount).
+      const baseline = await getEthFlowTransaction(
+        appDataKeccak256,
+        params,
+        chainId,
+        { checkEthFlowOrderExists: jest.fn().mockResolvedValue(false) },
+        adapters.ethersV5Adapter.signer,
+      )
+
+      let alreadyCalled = false
+      const checkEthFlowOrderExists = jest.fn().mockImplementation(() => {
+        return Promise.resolve(
+          (() => {
+            if (alreadyCalled) return false
+            alreadyCalled = true
+            return true
+          })(),
+        )
+      })
+
+      const result = await getEthFlowTransaction(
+        appDataKeccak256,
+        params,
+        chainId,
+        { checkEthFlowOrderExists },
+        adapters.ethersV5Adapter.signer,
+      )
+
+      // Regression: this used to build the transaction from the ORIGINAL (pre-collision)
+      // order even after a collision was detected, silently recreating the exact order
+      // that would revert on-chain with OrderIsAlreadyOwned. The returned order must be
+      // nudged by exactly 1 wei relative to the no-collision baseline.
+      expect(result.orderToSign.buyAmount).toBe((BigInt(baseline.orderToSign.buyAmount) - BigInt(1)).toString())
+
+      // The encoded calldata (what actually gets sent on-chain) must reflect the same
+      // adjusted amount as what's returned to the caller — not the original input.
+      expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith(
+        'createOrder',
+        expect.arrayContaining([expect.objectContaining({ buyAmount: result.orderToSign.buyAmount })]),
+      )
+    })
+
+    it('does not adjust anything when no collision is ever detected', async () => {
+      setGlobalAdapter(adapters.ethersV5Adapter)
+
+      const noCollision = jest.fn().mockResolvedValue(false)
+
+      const resultA = await getEthFlowTransaction(
+        appDataKeccak256,
+        params,
+        chainId,
+        { checkEthFlowOrderExists: noCollision },
+        adapters.ethersV5Adapter.signer,
+      )
+      const resultB = await getEthFlowTransaction(
+        appDataKeccak256,
+        params,
+        chainId,
+        { checkEthFlowOrderExists: noCollision },
+        adapters.ethersV5Adapter.signer,
+      )
+
+      expect(resultA.orderToSign.buyAmount).toBe(resultB.orderToSign.buyAmount)
+    })
+  })
+
   describe('ethFlowContractOverride', () => {
     it('should use default ETH flow contract address when no override provided', async () => {
       setGlobalAdapter(adapters.ethersV5Adapter)

--- a/packages/trading/src/getEthFlowTransaction.ts
+++ b/packages/trading/src/getEthFlowTransaction.ts
@@ -57,23 +57,32 @@ export async function getEthFlowTransaction(
     params,
     appDataKeccak256,
   )
-  const orderId = await calculateUniqueOrderId(chainId, orderToSign, checkEthFlowOrderExists, protocolOptions)
+  // `uniqueOrder` may differ from `orderToSign` when a collision was detected and the
+  // amounts were nudged to produce `orderId` — the on-chain transaction and everything
+  // returned to the caller MUST be built from `uniqueOrder`, not the original input,
+  // or the transaction recreates the exact order that was just detected as colliding.
+  const { orderId, order: uniqueOrder } = await calculateUniqueOrderId(
+    chainId,
+    orderToSign,
+    checkEthFlowOrderExists,
+    protocolOptions,
+  )
 
   const ethOrderParams: EthFlowOrderData = {
-    buyToken: orderToSign.buyToken,
-    receiver: orderToSign.receiver,
-    sellAmount: orderToSign.sellAmount,
-    buyAmount: orderToSign.buyAmount,
-    feeAmount: orderToSign.feeAmount,
-    partiallyFillable: orderToSign.partiallyFillable,
+    buyToken: uniqueOrder.buyToken,
+    receiver: uniqueOrder.receiver,
+    sellAmount: uniqueOrder.sellAmount,
+    buyAmount: uniqueOrder.buyAmount,
+    feeAmount: uniqueOrder.feeAmount,
+    partiallyFillable: uniqueOrder.partiallyFillable,
     quoteId,
     appData: appDataKeccak256,
-    validTo: orderToSign.validTo.toString(),
+    validTo: uniqueOrder.validTo.toString(),
   }
 
   const estimatedGas = contract.estimateGas.createOrder
     ? await contract.estimateGas
-        .createOrder(ethOrderParams, { value: orderToSign.sellAmount })
+        .createOrder(ethOrderParams, { value: uniqueOrder.sellAmount })
         // TODO: the res type is any, before it was BigNumber from ethers
         .then((res) => {
           return BigInt(res.toHexString ? res.toHexString() : `0x${res.toString(16)}`)
@@ -89,12 +98,12 @@ export async function getEthFlowTransaction(
 
   return {
     orderId,
-    orderToSign,
+    orderToSign: uniqueOrder,
     transaction: {
       data,
       gasLimit: '0x' + calculateGasMargin(estimatedGas).toString(16),
       to: contract.address,
-      value: '0x' + BigInt(orderToSign.sellAmount).toString(16),
+      value: '0x' + BigInt(uniqueOrder.sellAmount).toString(16),
     },
   }
 }


### PR DESCRIPTION
## tl;dr

`calculateUniqueOrderId`'s entire job is to avoid eth-flow order-id collisions. It never actually did — the transaction it hands back always recreates the exact colliding order, which reverts on-chain with `OrderIsAlreadyOwned` and burns the user's gas.

## The bug

`calculateUniqueOrderId` (`packages/trading/src/calculateUniqueOrderId.ts`) detects a collision, nudges `buyAmount` down 1 wei, and recurses to compute a fresh, collision-free `orderId` — but it only ever returned that bare `orderId` string, never the adjusted order that produced it:

```ts
function adjustAmounts(order: UnsignedOrder): UnsignedOrder {
  return { ...order, buyAmount: (buyAmount - BigInt(1)).toString() }   // new object, discarded
}
// ...
return orderId   // just the id — the adjusted order it came from is gone
```

The caller, `getEthFlowTransaction.ts`, builds the actual on-chain transaction from its own **original**, un-nudged order:

```ts
const orderId = await calculateUniqueOrderId(chainId, orderToSign, checkEthFlowOrderExists, protocolOptions)
const ethOrderParams: EthFlowOrderData = {
  ...
  buyAmount: orderToSign.buyAmount,     // the ORIGINAL, unadjusted amount
}
const data = contract.interface.encodeFunctionData('createOrder', [ethOrderParams])
```

So the returned `orderId` describes an order that never actually gets built. The transaction that gets sent recreates the exact order `checkEthFlowOrderExists` just reported as colliding, and `CoWSwapEthFlow.createOrder` reverts with `OrderIsAlreadyOwned`. This also flows into the public `OrderPostingResult` returned by `postSellNativeCurrencyOrder` — any caller polling `orderId` tracks an order that will never exist.

## The fix

`calculateUniqueOrderId` now returns `{ orderId, order }` — the order that actually produced that id — and `getEthFlowTransaction` builds `ethOrderParams`, the gas estimate, the tx `value`, and its own returned `orderToSign` from that `order`, not from its original input.

**BREAKING CHANGE:** `calculateUniqueOrderId`'s return type changes from `Promise<string>` to `Promise<{ orderId: string; order: UnsignedOrder }>`. It's exported public API (`index.ts`); any external caller reading the bare string needs to destructure `.orderId`. Given the old signature was silently unusable for its stated purpose, I think this is worth doing now rather than deprecating in place — happy to go a different route if maintainers prefer.

Also added a guard while I was in there: the nudge-by-1 logic had no floor. A `buyAmount` of `1` (or a second collision hitting an already-adjusted order) would silently produce `buyAmount: 0` or a negative `BigInt` that can't encode as `uint256`. It now throws a clear error instead of building an invalid order.

## Out of scope (not fixed here, flagging for a maintainer)

- `calculateUniqueOrderId` hashes `order.kind` as supplied, but the EthFlow contract always treats orders as `SELL`. For a `BUY`-kind order, the computed id could diverge from the transaction's real id. This is pre-existing and unrelated to the collision bug — didn't want to conflate two different fixes in one PR.
- `getEthFlowTransaction`'s gas-estimation `.catch()` swallows errors (including a TOCTOU `OrderIsAlreadyOwned` revert from a *different* order created between the collision check and submission) and falls back to a default gas limit rather than surfacing them. Also pre-existing, also a separate concern from what this PR fixes.

## Testing

Real repro before touching code — ported the control flow of both functions with a stubbed `checkEthFlowOrderExists` reporting a collision, confirmed the returned `orderId` didn't match what the returned transaction's calldata would actually create, and confirmed unfixed code returns the *original* colliding `buyAmount`.

New regression tests confirmed to fail on unfixed code and pass on fixed code (verified via `git stash` back to the original source with the new tests still in place):

```
● calculateUniqueOrderId › ... Then the returned order (not just the id) reflects the adjusted amounts
● calculateUniqueOrderId › ... Then the returned order is exactly the original order, unmodified
● getEthFlowTransaction › ... builds the on-chain transaction from the adjusted order, not the original
```
All three fail on `main`, all three (plus 2 new underflow-guard tests) pass after the fix.

Full package suite: `261 passed, 2 skipped` (pre-existing skips, unrelated to this change). `pnpm run typecheck` clean across the whole monorepo (confirms no other consumer of the changed return type broke). `eslint` clean on all four touched files.

Ran Codex (GPT-5.6) as an adversarial reviewer against the diff. It found two real issues, both fixed in this PR: the `buyAmount` underflow case above, and correctly noting the `kind`/TOCTOU items are pre-existing and out of scope (both listed above rather than folded in).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate order identifiers by consistently applying adjusted order amounts throughout transaction creation.
  * Prevented order adjustments when the buy amount is too small to change safely; a clear error is now returned.
  * Ensured transaction data, gas estimates, and payment values reflect the finalized order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->