### PR TITLE
fix(bridging): across status mapper falls back to UNKNOWN on unmapped status

### DIFF
--- a/packages/bridging/src/providers/across/util.test.ts
+++ b/packages/bridging/src/providers/across/util.test.ts
@@ -185,6 +185,26 @@ describe('Across Utils', () => {
       expect(mapAcrossStatusToBridgeStatus('refunded')).toBe(BridgeStatus.REFUND)
       expect(mapAcrossStatusToBridgeStatus('slowFillRequested')).toBe(BridgeStatus.EXECUTED)
     })
+
+    it('should fall back to BridgeStatus.UNKNOWN for a status the map does not recognize, instead of returning undefined', () => {
+      // Guards against API drift: DepositStatusResponse['status'] is a hand-maintained type,
+      // not a contract the live Across API is bound to. A new/unrecognized wire value must
+      // not silently produce `undefined` where every caller expects a BridgeStatus.
+      expect(mapAcrossStatusToBridgeStatus('some-future-status-across-has-not-documented-yet')).toBe(
+        BridgeStatus.UNKNOWN,
+      )
+      expect(mapAcrossStatusToBridgeStatus('')).toBe(BridgeStatus.UNKNOWN)
+    })
+
+    it('should fall back to BridgeStatus.UNKNOWN for a prototype-chain property name, not resolve to an Object.prototype member', () => {
+      // A plain `AcrossStatusToBridgeStatus[status]` index (or a `??` fallback on that) would
+      // resolve 'constructor'/'toString'/'hasOwnProperty' to a function inherited from
+      // Object.prototype instead of falling through to undefined/UNKNOWN.
+      expect(mapAcrossStatusToBridgeStatus('constructor')).toBe(BridgeStatus.UNKNOWN)
+      expect(mapAcrossStatusToBridgeStatus('toString')).toBe(BridgeStatus.UNKNOWN)
+      expect(mapAcrossStatusToBridgeStatus('hasOwnProperty')).toBe(BridgeStatus.UNKNOWN)
+      expect(mapAcrossStatusToBridgeStatus('__proto__')).toBe(BridgeStatus.UNKNOWN)
+    })
   })
 
   const adapters = createAdapters()

--- a/packages/bridging/src/providers/across/util.ts
+++ b/packages/bridging/src/providers/across/util.ts
@@ -175,8 +175,23 @@ const AcrossStatusToBridgeStatus: Record<DepositStatusResponse['status'], Bridge
   refunded: BridgeStatus.REFUND,
 }
 
-export function mapAcrossStatusToBridgeStatus(status: DepositStatusResponse['status']): BridgeStatus {
-  return AcrossStatusToBridgeStatus[status]
+/**
+ * `DepositStatusResponse['status']` is a hand-maintained TS literal union describing Across'
+ * documented statuses, not a guarantee of what the live API will actually send - a wire value
+ * outside this union (a new status Across adds, or any other drift) must not silently produce
+ * `undefined` where every caller expects a `BridgeStatus`. Widen to `string` so the fallback
+ * below is real, not just satisfying an already-exhaustive type.
+ *
+ * `Object.hasOwn` (not a plain index/`??`) guards against prototype-chain keys - a status of
+ * `"constructor"` or `"toString"` would otherwise resolve to an `Object.prototype` member
+ * instead of `undefined`, silently bypassing the fallback.
+ */
+export function mapAcrossStatusToBridgeStatus(status: string): BridgeStatus {
+  if (!Object.hasOwn(AcrossStatusToBridgeStatus, status)) {
+    return BridgeStatus.UNKNOWN
+  }
+
+  return AcrossStatusToBridgeStatus[status as DepositStatusResponse['status']]
 }
 
 export function getAcrossDepositEvents(chainId: SupportedChainId, logs: Log[]): AcrossDepositEvent[] {


### PR DESCRIPTION
`mapAcrossStatusToBridgeStatus` (`packages/bridging/src/providers/across/util.ts`) indexes a `Record<DepositStatusResponse['status'], BridgeStatus>` with no fallback:

```ts
export function mapAcrossStatusToBridgeStatus(status: DepositStatusResponse['status']): BridgeStatus {
  return AcrossStatusToBridgeStatus[status]
}
```

`DepositStatusResponse['status']` is a hand-maintained TS union of Across' five documented statuses (`filled | pending | expired | refunded | slowFillRequested`) - a claim about the wire format, not something enforced at runtime. Any status value the live Across API sends outside this union produces `undefined` where the return type promises a `BridgeStatus`.

The other two bridge providers in this same package already guard against exactly this:

```ts
// near-intents/NearIntentsBridgeProvider.ts
status: NEAR_INTENTS_STATUS_TO_COW_STATUS[status.status] ?? BridgeStatus.UNKNOWN,
```

`across` is the one provider missing this fallback.

## Fix

Widened the parameter to `string` so a real fallback is possible (the exhaustive `Record` type made `?? BridgeStatus.UNKNOWN` dead code otherwise), and used an own-property check instead of a plain index:

```ts
export function mapAcrossStatusToBridgeStatus(status: string): BridgeStatus {
  if (!Object.hasOwn(AcrossStatusToBridgeStatus, status)) {
    return BridgeStatus.UNKNOWN
  }
  return AcrossStatusToBridgeStatus[status as DepositStatusResponse['status']]
}
```

A plain `AcrossStatusToBridgeStatus[status]` also walks the prototype chain - a status of `"constructor"` or `"toString"` resolves to an `Object.prototype` member instead of `undefined`, silently defeating a naive `?? BridgeStatus.UNKNOWN` fallback. `Object.hasOwn` closes that too. (Caught in review - the first version of this fix used a plain `??`, which the added `constructor`/`toString`/`hasOwnProperty`/`__proto__` test cases genuinely fail against.)

## Honest scoping

I could not find a live example of the Across API sending an unmapped status - the public deposit-status endpoint needs a real deposit ID and Across doesn't publish an OpenAPI spec. This is a **defensive-robustness fix against API drift and malformed input**, matching the fallback pattern the other two providers already use - not a report of an observed production incident.

## Testing

New tests cover: an unrecognized-but-plausible status string, an empty string, and four prototype-chain property names (`constructor`, `toString`, `hasOwnProperty`, `__proto__`) - the last group genuinely fails against a naive `?? ` fallback without the `Object.hasOwn` guard, verified via a real red-before/green-after cycle.

```
Test Suites: 24 passed, 3 skipped, 27 total
Tests:       625 passed, 42 skipped, 667 total
```

`tsc --noEmit` and `eslint` both clean on the affected package.
