### PR TITLE
fix(order-book): buy order protocol fee reversal used sellAmount + feeAmount instead of sellAmount

### DIFF
--- a/packages/order-book/src/quoteAmountsAndCosts/README.md
+++ b/packages/order-book/src/quoteAmountsAndCosts/README.md
@@ -198,11 +198,13 @@ amountBeforeFee = amountAfterFee * 10000 / (10000 + feeBps)
 feeAmount       = amountAfterFee * feeBps / (10000 + feeBps)
 ```
 
-Applied to sell amount (where `sellAfterNetwork = sellAmount + feeAmount`):
+Applied to sell amount. Note `sellAmount` alone is the protocol-fee-inclusive base here —
+`feeAmount` (network costs) is reported separately by the API and is NOT baked into
+`sellAmount` for BUY orders (see section 4.2 below), so it must not be added in:
 
 ```
-protocolFeeAmount           = sellAfterNetwork * protocolFeeBps / (10000 + protocolFeeBps)
-sellAmountBeforeProtocolFee = sellAfterNetwork - protocolFeeAmount
+protocolFeeAmount           = sellAmount * protocolFeeBps / (10000 + protocolFeeBps)
+sellAmountBeforeProtocolFee = sellAmount - protocolFeeAmount
 ```
 
 > Source: [`getProtocolFeeAmount()`](./getProtocolFeeAmount.ts)

--- a/packages/order-book/src/quoteAmountsAndCosts/getProtocolFeeAmount.test.ts
+++ b/packages/order-book/src/quoteAmountsAndCosts/getProtocolFeeAmount.test.ts
@@ -68,12 +68,15 @@ describe('getProtocolFeeAmount', () => {
   })
 
   describe('BUY orders', () => {
-    it('reconstructs protocol fee from sellAmount + feeAmount', () => {
-      // API returned sellAmount with protocol fee already added
-      // Formula: protocolFeeAmount = (sellAmount + feeAmount) * feeBps / (10000 + feeBps)
+    it('reconstructs protocol fee from sellAmount alone (NOT sellAmount + feeAmount)', () => {
+      // API returned sellAmount with protocol fee already added, but network costs (feeAmount)
+      // are NOT baked into sellAmount for BUY orders -- see README.md's "How sellAmount differs
+      // between SELL and BUY orders" and getQuoteAmountsAndCosts.ts's own
+      // `beforeAllFees.sellAmount = sellAmount - protocolFeeAmount` (no feeAmount term there).
+      // Formula: protocolFeeAmount = sellAmount * feeBps / (10000 + feeBps)
       const protocolFeeBps = 20 // 0.20%
       const sellAmount = 168970833896526983n
-      const feeAmount = 2947344072902629n
+      const feeAmount = 2947344072902629n // present in the order but must NOT affect the fee base
 
       const result = getProtocolFeeAmount({
         orderParams: {
@@ -86,10 +89,9 @@ describe('getProtocolFeeAmount', () => {
         protocolFeeBps,
       })
 
-      const sellAfterNetwork = sellAmount + feeAmount
-      const expected = (sellAfterNetwork * 20n) / (10_000n + 20n)
+      const expected = (sellAmount * 20n) / (10_000n + 20n)
       expect(result).toBe(expected)
-      expect(result).toBe(343150055827204n)
+      expect(result).toBe(337267133526001n)
     })
 
     it('handles decimal protocolFeeBps', () => {
@@ -108,13 +110,71 @@ describe('getProtocolFeeAmount', () => {
         protocolFeeBps,
       })
 
-      const sellAfterNetwork = sellAmount + feeAmount
       const feeBpsBig = BigInt(protocolFeeBps * 100_000)
       const denominator = 10_000n * 100_000n + feeBpsBig
-      const expected = (sellAfterNetwork * feeBpsBig) / denominator
+      const expected = (sellAmount * feeBpsBig) / denominator
 
       expect(result).toBe(expected)
-      expect(result).toBe(12206189769n)
+      expect(result).toBe(11996928354n)
+    })
+
+    it('is invariant to feeAmount -- changing feeAmount alone must not change the result', () => {
+      // Direct regression for the bug: the old formula used (sellAmount + feeAmount) as its base,
+      // so two orders with identical sellAmount but different feeAmount would (wrongly) produce
+      // different protocol fee amounts. They must be identical.
+      const protocolFeeBps = 20
+      const sellAmount = 168970833896526983n
+
+      const resultA = getProtocolFeeAmount({
+        orderParams: {
+          kind: OrderKind.BUY,
+          sellAmount: sellAmount.toString(),
+          buyAmount: '2000000000',
+          feeAmount: '1',
+          ...otherFields,
+        },
+        protocolFeeBps,
+      })
+
+      const resultB = getProtocolFeeAmount({
+        orderParams: {
+          kind: OrderKind.BUY,
+          sellAmount: sellAmount.toString(),
+          buyAmount: '2000000000',
+          feeAmount: '999999999999999999',
+          ...otherFields,
+        },
+        protocolFeeBps,
+      })
+
+      expect(resultA).toBe(resultB)
+    })
+
+    it('round-trips against the forward fee-adding formula the API uses (independent oracle)', () => {
+      // Ground truth, independent of getProtocolFeeAmount's own internals:
+      // if beforeAllFees.sellAmount had protocolFeeBps added on top to produce orderParams.sellAmount,
+      // then adding the fee back to (sellAmount - fee) via the forward formula must reproduce the
+      // exact same fee, for every case. This is the invariant the old (sellAmount + feeAmount) base
+      // violated -- see getProtocolFeeAmount.ts's PR body / commit for the numeric counterexample.
+      const protocolFeeBps = 20
+      const sellAmount = 168970833896526983n
+
+      const fee = getProtocolFeeAmount({
+        orderParams: {
+          kind: OrderKind.BUY,
+          sellAmount: sellAmount.toString(),
+          buyAmount: '2000000000',
+          feeAmount: '2947344072902629',
+          ...otherFields,
+        },
+        protocolFeeBps,
+      })
+
+      const beforeAllFeesSell = sellAmount - fee
+      const feeBpsBig = BigInt(protocolFeeBps * 100_000)
+      const forwardRecomputedFee = (beforeAllFeesSell * feeBpsBig) / (10_000n * 100_000n)
+
+      expect(forwardRecomputedFee).toBe(fee)
     })
   })
 })

--- a/packages/order-book/src/quoteAmountsAndCosts/getProtocolFeeAmount.ts
+++ b/packages/order-book/src/quoteAmountsAndCosts/getProtocolFeeAmount.ts
@@ -39,10 +39,9 @@ export function getProtocolFeeAmount(params: ProtocolFeeAmountParams): bigint {
     return 0n
   }
 
-  const { sellAmount: sellAmountStr, buyAmount: buyAmountStr, feeAmount: feeAmountStr } = orderParams
+  const { sellAmount: sellAmountStr, buyAmount: buyAmountStr } = orderParams
   const sellAmount = BigInt(sellAmountStr)
   const buyAmount = BigInt(buyAmountStr)
-  const feeAmount = BigInt(feeAmountStr)
 
   const protocolFeeScale = PROTOCOL_FEE_BPS_SCALE
   // Keep 5 decimal places of bps precision while avoiding BigInt conversion from non-integer floats.
@@ -56,18 +55,23 @@ export function getProtocolFeeAmount(params: ProtocolFeeAmountParams): bigint {
     /**
      * SELL orders formula: protocolFeeInBuy = quoteBuyAmount * protocolFeeBps / (1 - protocolFeeBps)
      *
-     * The buyAmountAfterNetworkCosts already includes the protocol fee (it was deducted from buyAmount by the API).
-     * We need to reconstruct the original buyAmount and calculate the fee amount.
+     * `orderParams.buyAmount` already has the protocol fee deducted (it was subtracted from
+     * buyAmount by the API). We reverse just that one deduction to get the fee amount.
      */
     const denominator = ONE_HUNDRED_BPS * protocolFeeScale - protocolFeeBpsBig
     return (buyAmount * protocolFeeBpsBig) / denominator
   } else {
     /**
-     * BUY orders formula: protocolFeeInSell = (quoteSellAmount + feeAmount) * protocolFeeBps / (1 + protocolFeeBps)
-     * the sellAmountAfterNetworkCosts already includes the protocol fee (it was added to sellAmount by the API).
+     * BUY orders formula: protocolFeeInSell = quoteSellAmount * protocolFeeBps / (1 + protocolFeeBps)
+     *
+     * `orderParams.sellAmount` already has the protocol fee added (it was added to sellAmount by
+     * the API) but does NOT yet include network costs -- `feeAmount` is reported separately and
+     * must be added on top later, it must not be folded into this reversal (see README.md ->
+     * "How sellAmount differs between SELL and BUY orders", and getQuoteAmountsAndCosts.ts's own
+     * `beforeAllFees.sellAmount = sellAmount - protocolFeeAmount`, which only makes sense if
+     * `sellAmount` alone -- not `sellAmount + feeAmount` -- is the protocol-fee-inclusive base).
      */
     const denominator = ONE_HUNDRED_BPS * protocolFeeScale + protocolFeeBpsBig
-    // sellAmountAfterNetworkCosts is already sellAmount + networkCosts (check getQuoteAmountsWithNetworkCosts)
-    return ((sellAmount + feeAmount) * protocolFeeBpsBig) / denominator
+    return (sellAmount * protocolFeeBpsBig) / denominator
   }
 }

--- a/packages/order-book/src/quoteAmountsAndCosts/getQuoteAmountsAndCosts.test.ts
+++ b/packages/order-book/src/quoteAmountsAndCosts/getQuoteAmountsAndCosts.test.ts
@@ -326,12 +326,12 @@ describe('Calculation of before/after fees amounts', () => {
         })
 
         const sellAmount = BigInt(orderParams.sellAmount)
-        const feeAmount = BigInt(orderParams.feeAmount)
-        const sellAfterNetwork = sellAmount + feeAmount
 
+        // For BUY orders, protocol fee is baked into sellAmount alone -- feeAmount (network costs)
+        // is reported separately and is NOT part of the protocol-fee-inclusive base.
         const bps = BigInt(protocolFeeBps)
         const denominator = 10_000n + bps
-        const expectedProtocolFeeAmount = (sellAfterNetwork * bps) / denominator
+        const expectedProtocolFeeAmount = (sellAmount * bps) / denominator
 
         expect(result.costs.protocolFee.amount).toBe(expectedProtocolFeeAmount)
         // beforeNetworkCosts.sellAmount for BUY = afterProtocolFees.sellAmount = sellAmount (raw API value)
@@ -355,7 +355,8 @@ describe('Calculation of before/after fees amounts', () => {
 
         const protocolBps = BigInt(protocolFeeBps)
         const protocolDenominator = 10_000n + protocolBps
-        const expectedProtocolFeeAmount = (sellAfterNetwork * protocolBps) / protocolDenominator
+        // Protocol fee is baked into sellAmount alone for BUY orders, not sellAmount + feeAmount.
+        const expectedProtocolFeeAmount = (sellAmount * protocolBps) / protocolDenominator
 
         // beforeAllFees.sellAmount = sellAmount - protocolFeeAmount
         const sellBeforeAllFees = sellAmount - expectedProtocolFeeAmount
@@ -399,19 +400,18 @@ describe('Calculation of before/after fees amounts', () => {
       })
 
       const sellAmount = BigInt(orderParams.sellAmount)
-      const feeAmount = BigInt(orderParams.feeAmount)
-      const sellAfterNetwork = sellAmount + feeAmount
 
+      // For BUY orders, protocol fee is baked into sellAmount alone, not sellAmount + feeAmount.
       const bps = BigInt(protocolFeeBps * 100_000)
       const denominator = 10_000n * 100_000n + bps
-      const expectedProtocolFeeAmount = (sellAfterNetwork * bps) / denominator
+      const expectedProtocolFeeAmount = (sellAmount * bps) / denominator
 
       expect(result.costs.protocolFee.amount).toBe(expectedProtocolFeeAmount)
       // beforeNetworkCosts.sellAmount for BUY = sellAmount (raw API value)
       expect(result.beforeNetworkCosts.sellAmount).toBe(sellAmount)
 
       expect(result.costs.protocolFee).toEqual({
-        amount: 12206189769n,
+        amount: 11996928354n,
         bps: protocolFeeBps,
       })
     })

--- a/packages/order-book/src/quoteAmountsAndCosts/getQuoteAmountsAndCosts.ts
+++ b/packages/order-book/src/quoteAmountsAndCosts/getQuoteAmountsAndCosts.ts
@@ -8,7 +8,8 @@ import { getQuoteAmountsAfterSlippage } from './getQuoteAmountsAfterSlippage'
 /**
  * Calculates all quote amount stages and costs from a `/quote` API response.
  *
- * Takes the raw order parameters (where protocol fee and network costs are already baked in)
+ * Takes the raw order parameters (where protocol fee is already baked in, and network costs
+ * are also baked in for SELL orders but reported separately in `feeAmount` for BUY orders)
  * and reconstructs every intermediate amount stage: before all fees, after protocol fees,
  * after network costs, after partner fees, and after slippage.
  *


### PR DESCRIPTION
tl;dr `getProtocolFeeAmount`'s BUY branch reconstructs the protocol fee from `sellAmount + feeAmount`, but the `/quote` API only bakes the protocol fee into `sellAmount` for BUY orders -- `feeAmount` (network costs) is reported separately and was never supposed to be part of that base.

## What's actually wrong

`getQuoteAmountsAndCosts.ts` already assumes the correct base everywhere downstream:

```ts
const beforeAllFees = isSell
  ? { ... }
  : {
      sellAmount: sellAmount - protocolFeeAmount,   // <- no feeAmount term
      buyAmount: buyAmount,
    }
```

and the package's own README documents the same (before this PR, it documented the *other*, wrong formula in one place -- see below). But `getProtocolFeeAmount.ts`'s BUY branch computed:

```ts
return ((sellAmount + feeAmount) * protocolFeeBpsBig) / denominator
```

so every BUY-order quote with a nonzero protocol fee reconstructed a `protocolFeeAmount` that drifts further from the real one as `feeAmount` (gas cost) grows. That wrong amount flows straight into `beforeAllFees`, `afterProtocolFees`, and `amountsToSign` -- the sell amount that's actually signed. Not a display-only bug.

## Proof

Standalone round-trip script (add the fee back to `sellAmount - fee`, compare to the original `sellAmount`):

```
old (sellAmount + feeAmount base): diff = -5894688145805n   (off by ~5.9e12 wei on a realistic quote)
new (sellAmount alone):            diff = 0n
```

## Fix

- `getProtocolFeeAmount.ts`: BUY branch base is `sellAmount` alone. SELL branch untouched (verified via `git stash` A/B that its tests still pass byte-for-byte unmodified).
- `getProtocolFeeAmount.test.ts`: the existing BUY tests recomputed their own `expected` using the same buggy base, so they passed vacuously regardless of which formula was correct. Rewrote them plus added two new tests: a fee-amount-invariance check (two orders with the same `sellAmount` but different `feeAmount` must produce identical protocol fees) and an independent round-trip oracle test. Both fail against the old code, pass against the fix.
- `getQuoteAmountsAndCosts.test.ts`: same self-referential base in its BUY-order protocol-fee assertions, fixed the same way.
- `README.md` section 4.1 documented the buggy `sellAfterNetwork = sellAmount + feeAmount` formula for BUY protocol-fee reversal -- brought in line with the actual (now-fixed) implementation. Caught by an adversarial Codex pass, not by me first.

## receipts

```
$ pnpm jest   (packages/order-book)
Test Suites: 6 passed, 6 total
Tests:       66 passed, 66 total

$ pnpm typecheck
$ tsc --noEmit   -> clean

$ pnpm lint
$ eslint src/**/*.ts --quiet   -> clean
```

Red-before/green-after confirmed by stashing just the source fix and re-running the new BUY tests: 4/6 failed against old code, 6/6 pass with the fix restored.

Backend-only numeric fix, no UI to screenshot -- receipts above are the full test/typecheck/lint output plus the round-trip proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected BUY-order protocol fee calculations to use the reported sell amount without adding network fees.
  * Improved quote amount accuracy, including cases with decimal basis points.
  * Ensured protocol fee results remain consistent regardless of separately reported network costs.

* **Documentation**
  * Clarified how protocol and network fees are represented for BUY and SELL orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->