### PR TITLE
fix(cow-shed): account code cache leaks across chains via shared localStorage key

### DIFF
--- a/packages/cow-shed/src/contracts/CoWShedHooks.test.ts
+++ b/packages/cow-shed/src/contracts/CoWShedHooks.test.ts
@@ -951,5 +951,64 @@ describe('CowShedHooks', () => {
         adapter.getCode = originalGetCode
       }
     })
+
+    it('should NOT leak account code cache across different chains for the same account', async () => {
+      // TTLCache persists to real `localStorage` when it's available (its default backend), and
+      // every CowShedHooks instance builds its accountCodeCache with the same hardcoded keyPrefix
+      // ('cowshed-account-code') regardless of chainId. If doesAccountHaveCode() keys its cache
+      // entry on `account` alone, two CowShedHooks instances for DIFFERENT chains but backed by the
+      // same browser localStorage will read each other's cached hasCode result for the same
+      // address -- even though an address can be a deployed contract on one chain and undeployed
+      // (no code) on another (e.g. a counterfactual Safe address, or a CREATE2 deploy that only
+      // landed on one chain so far).
+      const sharedLocalStorageMap = new Map<string, string>()
+      ;(globalThis as any).localStorage = {
+        getItem: (key: string) => sharedLocalStorageMap.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          sharedLocalStorageMap.set(key, value)
+        },
+        removeItem: (key: string) => {
+          sharedLocalStorageMap.delete(key)
+        },
+        get length() {
+          return sharedLocalStorageMap.size
+        },
+        key: (index: number) => Array.from(sharedLocalStorageMap.keys())[index] ?? null,
+      }
+
+      const adapter = adapters.viemAdapter
+      const originalGetCode = adapter.getCode
+
+      try {
+        setGlobalAdapter(adapter)
+
+        const chain1Hooks = new CowShedHooks(1, {
+          factoryAddress: MOCK_COW_SHED_FACTORY,
+          implementationAddress: MOCK_COW_SHED_IMPLEMENTATION,
+          proxyCreationCode: MOCK_INIT_CODE,
+        })
+        const chain100Hooks = new CowShedHooks(100, {
+          factoryAddress: MOCK_COW_SHED_FACTORY,
+          implementationAddress: MOCK_COW_SHED_IMPLEMENTATION,
+          proxyCreationCode: MOCK_INIT_CODE,
+        })
+
+        // Chain 1: account IS a deployed contract.
+        adapter.getCode = jest.fn().mockResolvedValue('0x608060405234801561001057600080fd5b50')
+        const chain1Result = await (chain1Hooks as any).doesAccountHaveCode(USER_MOCK)
+        expect(chain1Result).toBe(true)
+
+        // Chain 100: the SAME address has no code yet on this chain.
+        const chain100GetCodeMock = jest.fn().mockResolvedValue('0x')
+        adapter.getCode = chain100GetCodeMock
+        const chain100Result = await (chain100Hooks as any).doesAccountHaveCode(USER_MOCK)
+
+        expect(chain100Result).toBe(false)
+        expect(chain100GetCodeMock).toHaveBeenCalledWith(USER_MOCK)
+      } finally {
+        adapter.getCode = originalGetCode
+        delete (globalThis as any).localStorage
+      }
+    })
   })
 })

--- a/packages/cow-shed/src/contracts/CoWShedHooks.ts
+++ b/packages/cow-shed/src/contracts/CoWShedHooks.ts
@@ -202,8 +202,17 @@ export class CowShedHooks {
   }
 
   private async doesAccountHaveCode(account: string): Promise<boolean> {
+    // TTLCache persists to real browser localStorage by default, and every CowShedHooks instance
+    // uses the same hardcoded keyPrefix ('cowshed-account-code') regardless of chainId -- so the
+    // cache key itself must carry the chain ID, or two CowShedHooks instances for different chains
+    // (see CowShedSdk's one-instance-per-chainId cache) would read/write the SAME localStorage
+    // entry for the same address. An address can be a deployed contract on one chain and
+    // undeployed on another (e.g. a counterfactual Safe address, or a CREATE2 deploy that only
+    // landed on one chain so far).
+    const cacheKey = `${this.chainId}:${account}`
+
     // Check cache first
-    const cachedResult = this.accountCodeCache.get(account)
+    const cachedResult = this.accountCodeCache.get(cacheKey)
     if (cachedResult !== undefined) {
       return cachedResult
     }
@@ -215,7 +224,7 @@ export class CowShedHooks {
     const hasCode = !!userAccountCode && userAccountCode !== '0x'
 
     // Store result in cache
-    this.accountCodeCache.set(account, hasCode)
+    this.accountCodeCache.set(cacheKey, hasCode)
 
     return hasCode
   }


### PR DESCRIPTION
tl;dr `CowShedHooks.doesAccountHaveCode()` caches `adapter.getCode(account)` results keyed on `account` alone. `TTLCache` (in `@cowprotocol/sdk-common`) persists to real browser `localStorage` by default, and every `CowShedHooks` instance builds this cache with the exact same hardcoded prefix (`'cowshed-account-code'`) regardless of chain. Two chains, same browser, same address -> same cache entry.

## What's actually wrong

`CowShedSdk` keeps one `CowShedHooks` instance per chain:

```ts
protected hooksCache = new Map<SupportedChainId, CowShedHooks>()
```

Each instance constructs its own `TTLCache` object, but `TTLCache`'s storage backend is real `localStorage` (a genuinely global, origin-wide key-value store, not per-instance) unless it's unavailable:

```ts
this.storage = useLocalStorage ? new LocalStorageWrapper() : new MemoryStorage()
```

and the storage key is just `${keyPrefix}:${key}`. `accountCodeCache`'s `keyPrefix` (`'cowshed-account-code'`) never varies by chain, and `doesAccountHaveCode` never included chain in the `key` it passed in. So in a browser dapp, calling this SDK for the same account on mainnet then Gnosis (or any two chains) hits the exact same `localStorage` entry for a full 5-minute TTL.

This matters because an address's contract status genuinely differs by chain -- a counterfactual Safe address that's deployed on one chain and not yet on another is a completely normal, common state. The cached (wrong-chain) result feeds `shouldValidateEip1271Signature`, which gates an extra RPC call and can throw `CoWShedEip1271SignatureInvalid`:

```ts
const isAccountSmartContract = await this.doesAccountHaveCode(user)
const shouldValidateEip1271Signature = isAccountSmartContract && signingScheme === ContractsSigningScheme.EIP712
```

A stale "has code" from chain A can make the SDK attempt (and potentially fail) EIP-1271 validation on chain B where the account is a plain EOA. A stale "no code" can make it silently skip EIP-1271 validation on a chain where the account really is a contract wallet.

## Fix

`doesAccountHaveCode`'s cache key is now `` `${this.chainId}:${account}` `` instead of `account` alone.

The sibling `eip1271SignatureCache` does **not** have this problem -- its key already includes the EIP-712 typed-data hash, and that hash covers the signing domain, whose `chainId` comes from `this.chainId` (see `getDomain()`/`infoToSign()`). Confirmed via an adversarial Codex pass reading both caches side by side; left untouched.

## Proof

Regression test spins up a real (in-memory but interface-faithful) `localStorage`, shared across two `CowShedHooks` instances for chainId `1` and `100`. Account has code on chain 1, no code on chain 100.

- **Old code**: chain 100's `doesAccountHaveCode` returns `true` (the stale chain-1 result) and never even calls chain 100's `getCode` mock -- confirmed by actually running this test against the unfixed source (`git stash` A/B).
- **New code**: chain 100 correctly calls its own `getCode` and returns `false`.

## receipts

```
$ pnpm jest   (packages/cow-shed)
Test Suites: 2 passed, 2 total
Tests:       1 skipped, 29 passed, 30 total

$ pnpm typecheck
$ tsc --noEmit   -> clean

$ pnpm lint
$ eslint src/**/*.ts --quiet   -> clean
```

Backend-only correctness/cache fix, no UI to screenshot -- receipts above are the full test/typecheck/lint output plus the red-before/green-after A/B via git stash.