### PR TITLE
fix(composable): twap already-present handler ignores span when checking expiry

### DIFF
--- a/packages/composable/src/orderTypes/Twap.ts
+++ b/packages/composable/src/orderTypes/Twap.ts
@@ -419,7 +419,10 @@ export class Twap extends ConditionalOrder<TwapData, TwapStruct> {
         error: undefined,
       }
     }
-    const expireTime = Number(numberOfParts * BigInt(timeBetweenParts) + BigInt(startTimestamp))
+    // NOTE: must match `endTimestamp()`'s formula, which shortens the last part's window when
+    // `durationOfPart` is `LIMIT_DURATION` (span). Re-deriving it here from `numberOfParts * timeBetweenParts`
+    // alone silently drops that adjustment and overstates how long a spanned TWAP is still active for.
+    const expireTime = this.endTimestamp(startTimestamp)
     if (blockTimestamp >= expireTime) {
       return {
         result: PollResultCode.UNEXPECTED_ERROR,

--- a/packages/composable/tests/Twap.spec.ts
+++ b/packages/composable/tests/Twap.spec.ts
@@ -1091,6 +1091,43 @@ describe('TWAP Order - Multi-Adapter Tests', () => {
         error: undefined,
       })
     })
+    test('should return UNEXPECTED_ERROR at the span-shortened expiry of a LIMIT_DURATION TWAP', async () => {
+      setGlobalAdapter(adapters.viemAdapter)
+
+      // With durationOfPart = LIMIT_DURATION(50), the last part's window ends 50 seconds after the
+      // start of the last part, not a full `timeBetweenParts` (100s) later: expiry is
+      // startTimestamp + (10 - 1) * 100 + 50 = startTimestamp + 950, matching `endTimestamp()`.
+      // A naive `numberOfParts * timeBetweenParts` calculation would instead say expiry is at +1000,
+      // wrongly reporting the TWAP as still active at +960.
+      const pollParams = getPollParams({
+        blockTimestamp: startTimestamp + 960,
+      })
+
+      const twap = new MockTwap({
+        handler: TWAP_ADDRESS,
+        data: {
+          ...TWAP_PARAMS_TEST,
+          timeBetweenParts: BigInt(timeBetweenParts),
+          numberOfParts: BigInt(10),
+          durationOfPart: {
+            durationType: DurationType.LIMIT_DURATION,
+            duration: BigInt(50),
+          },
+          startTime: {
+            startType: StartTimeValue.AT_EPOCH,
+            epoch: BigInt(startTimestamp),
+          },
+        },
+      })
+
+      const result = await twap.handlePollFailedAlreadyPresent(orderId, order, pollParams)
+
+      expect(result).toEqual({
+        result: PollResultCode.UNEXPECTED_ERROR,
+        reason: 'TWAP is expired. Expired at 1700000950 (2023-11-14T22:29:10.000Z)',
+        error: undefined,
+      })
+    })
     test('should handle polling when blockInfo is not provided', async () => {
       setGlobalAdapter(adapters.viemAdapter)
 


### PR DESCRIPTION
\`Twap.handlePollFailedAlreadyPresent()\` (used by the watch tower when a TWAP part's order already exists in the order book) re-derives the TWAP's expiry as:

\`\`\`ts
const expireTime = Number(numberOfParts * BigInt(timeBetweenParts) + BigInt(startTimestamp))
\`\`\`

That's the same class's \`endTimestamp()\` — but only its \`AUTO\`-duration branch. When \`durationOfPart\` is \`LIMIT_DURATION\` (a "span" shorter than \`timeBetweenParts\`), \`endTimestamp()\` correctly shortens the last part's window to \`startTimestamp + (numberOfParts - 1) * timeBetweenParts + duration\`, but this duplicated formula ignores \`span\` entirely and always uses the full \`numberOfParts * timeBetweenParts\`.

Net effect: a spanned TWAP whose last part has already expired gets reported as still active for up to \`timeBetweenParts - span\` seconds longer than it actually is, so the watch tower keeps treating it as pollable instead of returning "TWAP is expired".

Fix: call \`this.endTimestamp(startTimestamp)\` (already used correctly by the sibling \`pollValidate\`) instead of re-deriving the formula.

Added a test that constructs a 10-part TWAP with \`timeBetweenParts=100\`, \`span=50\`, and polls at \`+960s\` (past the correct \`+950\` span-adjusted expiry but before the naive \`+1000\`) — it fails without the fix and passes with it.

## Test plan
- [x] \`pnpm turbo run test --filter=@cowprotocol/sdk-composable\` — 276/276 passing, including the new case
- [x] \`pnpm turbo run lint --filter=@cowprotocol/sdk-composable\` clean
- [x] \`tsc --noEmit\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected expiration handling for TWAP orders with span-limited durations.
  - Prevented expired TWAPs from being incorrectly reported as still active.
- **Tests**
  - Added coverage verifying the corrected expiration time and error response for expired TWAPs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->