### PR TITLE
fix(bridging): query across status by deposit tx hash, not order id

### DIFF
--- a/packages/bridging/src/providers/bungee/BungeeBridgeProvider.test.ts
+++ b/packages/bridging/src/providers/bungee/BungeeBridgeProvider.test.ts
@@ -400,6 +400,26 @@ adapterNames.forEach((adapterName) => {
           status: BridgeStatus.UNKNOWN,
         })
       })
+
+      it('should query the across API with the deposit tx hash, not the order id, and report EXPIRED', async () => {
+        const mockBungeeApi = new BungeeApi()
+        const pendingDestEvents: BungeeEvent[] = [
+          { ...mockEvents[0]!, destTxStatus: BungeeEventStatus.PENDING, destTransactionHash: undefined },
+        ]
+        jest.spyOn(mockBungeeApi, 'getEvents').mockResolvedValue(pendingDestEvents)
+        const getAcrossStatus = jest.spyOn(mockBungeeApi, 'getAcrossStatus').mockResolvedValue('expired')
+        provider.setApi(mockBungeeApi)
+
+        const status = await provider.getStatus('123')
+
+        // must be looked up by the on-chain deposit tx hash (srcTransactionHash), never the CoW order id
+        expect(getAcrossStatus).toHaveBeenCalledWith('0x123')
+        expect(getAcrossStatus).not.toHaveBeenCalledWith('123')
+        expect(status).toEqual({
+          status: BridgeStatus.EXPIRED,
+          depositTxHash: '0x123',
+        })
+      })
     })
 
     describe('getCancelBridgingTx', () => {

--- a/packages/bridging/src/providers/bungee/BungeeBridgeProvider.ts
+++ b/packages/bridging/src/providers/bungee/BungeeBridgeProvider.ts
@@ -224,7 +224,9 @@ export class BungeeBridgeProvider implements HookBridgeProvider<BungeeQuoteResul
 
     if (!event) return null
 
-    const status = await getBridgingStatusFromEvents(events, (orderId) => this.api.getAcrossStatus(orderId))
+    const status = await getBridgingStatusFromEvents(events, (depositTxHash) =>
+      this.api.getAcrossStatus(depositTxHash),
+    )
 
     const params: BridgingDepositParams = {
       inputTokenAddress: event.srcTokenAddress,
@@ -258,7 +260,7 @@ export class BungeeBridgeProvider implements HookBridgeProvider<BungeeQuoteResul
     // fetch indexed event from api
     const events = await this.api.getEvents({ orderId: _bridgingId })
 
-    return getBridgingStatusFromEvents(events, (orderId) => this.api.getAcrossStatus(orderId))
+    return getBridgingStatusFromEvents(events, (depositTxHash) => this.api.getAcrossStatus(depositTxHash))
   }
 
   async getCancelBridgingTx(_bridgingId: string): Promise<EvmCall> {

--- a/packages/bridging/src/providers/bungee/getBridgingStatusFromEvents.ts
+++ b/packages/bridging/src/providers/bungee/getBridgingStatusFromEvents.ts
@@ -22,10 +22,10 @@ export async function getBridgingStatusFromEvents(
   // if srcTxStatus = completed & destTxStatus = pending,
   if (event.srcTxStatus === BungeeEventStatus.COMPLETED && event.destTxStatus === BungeeEventStatus.PENDING) {
     // if bridgeName = across,
-    if (event.bridgeName === BungeeBridgeName.ACROSS) {
+    if (event.bridgeName === BungeeBridgeName.ACROSS && event.srcTransactionHash) {
       try {
         // check across api to check status is expired or refunded
-        const acrossStatus = await getAcrossStatus(event.orderId)
+        const acrossStatus = await getAcrossStatus(event.srcTransactionHash)
         if (acrossStatus === 'expired') {
           return { status: BridgeStatus.EXPIRED, depositTxHash: event.srcTransactionHash }
         }


### PR DESCRIPTION
tl;dr `getBridgingStatusFromEvents` was asking Across about the CoW order UID instead of the actual deposit tx hash, so an expired/refunded Bungee+Across bridge was never detected.

## What's broken

In `packages/bridging/src/providers/bungee/getBridgingStatusFromEvents.ts`, when a Bungee event's source leg is `COMPLETED` and the destination leg is still `PENDING` for an Across-routed bridge, the code asks the Across API for the deposit status:

```ts
const acrossStatus = await getAcrossStatus(event.orderId)
```

`getAcrossStatus` (see `BungeeApi.ts`) hits Across's `/deposit/status?depositTxHash=...` endpoint - it needs the **on-chain deposit transaction hash**, not `orderId` (which is CoW's own order UID / Bungee's request identifier and has no meaning to Across).

Since Across never recognizes the order UID as a deposit hash, the lookup fails, the error is swallowed by the surrounding `try/catch` (`console.error` only), and the function falls through to `IN_PROGRESS`. Net effect: a bridge that Across has actually marked `expired` or `refunded` is reported as perpetually `IN_PROGRESS` and never surfaces `BridgeStatus.EXPIRED` / `BridgeStatus.REFUND` to callers.

Also added a guard for the case `srcTransactionHash` is undefined (per the type, only guaranteed once `srcTxStatus === COMPLETED`, but TS still types it optional) so this compiles cleanly and doesn't attempt a lookup with `undefined`.

## Fix

Pass `event.srcTransactionHash` (the real deposit tx hash) instead of `event.orderId`. Also renamed the misleading callback parameter name at both call sites in `BungeeBridgeProvider.ts` (it was itself named `orderId`, which is likely how this slipped in) to `depositTxHash` to match what the callback's type signature actually expects.

## receipts

no runtime changes visually - this is backend/status-polling logic with no UI surface. Added a regression test (`BungeeBridgeProvider.test.ts`) that:
- asserts `getAcrossStatus` is called with the deposit tx hash (`'0x123'`), never the order id (`'123'`)
- asserts the resulting status correctly comes back as `EXPIRED` (previously would have been swallowed into `IN_PROGRESS`)

Confirmed the added test fails against the pre-fix code (wrong arg passed) and passes after the fix, across all 3 SDK adapters (ethers v5, ethers v6, viem).

## Test plan

- [x] `pnpm jest BungeeBridgeProvider.test.ts` - 48/48 passing across all adapters
- [x] `pnpm turbo run typecheck --filter=@cowprotocol/sdk-bridging`
- [x] `pnpm turbo run lint --filter=@cowprotocol/sdk-bridging`
- [x] Verified new test fails on old code (reverted fix locally, re-ran - confirmed the exact mismatch: expected deposit tx hash, received order id) and passes on the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bridge status checks now use the deposit transaction hash when querying Across.
  * Pending destination events without a source transaction hash no longer trigger an invalid status lookup.
  * Expired bridge responses are correctly reported with the associated deposit transaction hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->