### PR TITLE
fix: viem adapter must treat raw byte messages as raw in verifyMessage

### DIFF
--- a/packages/contracts-ts/tests/decodeSignatureOwner.test.ts
+++ b/packages/contracts-ts/tests/decodeSignatureOwner.test.ts
@@ -1,0 +1,52 @@
+import { createAdapters, TEST_ADDRESS } from './setup'
+import { setGlobalAdapter, TypedDataDomain } from '@cowprotocol/sdk-common'
+import {
+  ContractsOrder as Order,
+  ContractsOrderKind as OrderKind,
+  ContractsSigningScheme as SigningScheme,
+  decodeSignatureOwner,
+  signOrder,
+} from '../src'
+import { COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS, SupportedChainId } from '@cowprotocol/sdk-config'
+
+describe('decodeSignatureOwner', () => {
+  let adapters: ReturnType<typeof createAdapters>
+
+  const testDomain: TypedDataDomain = {
+    name: 'Cow Protocol',
+    version: '1',
+    chainId: 1,
+    verifyingContract: COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS[SupportedChainId.MAINNET],
+  }
+
+  const testOrder: Order = {
+    sellToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+    buyToken: '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+    sellAmount: '1000000000000000000', // 1 WETH
+    buyAmount: '2000000000000000000000', // 2000 DAI
+    validTo: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
+    appData: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    feeAmount: '5000000000000000', // 0.005 WETH
+    kind: OrderKind.SELL,
+    partiallyFillable: false,
+  }
+
+  beforeAll(() => {
+    adapters = createAdapters()
+  })
+
+  describe('ETHSIGN scheme', () => {
+    test.each(['ethersV5Adapter', 'ethersV6Adapter', 'viemAdapter'] as const)(
+      'recovers the real signer for an ETHSIGN-signed order (%s)',
+      async (adapterName) => {
+        setGlobalAdapter(adapters[adapterName])
+
+        const sig = await signOrder(testDomain, testOrder, SigningScheme.ETHSIGN, adapters[adapterName].signer)
+
+        const recoveredOwner = await decodeSignatureOwner(testDomain, testOrder, SigningScheme.ETHSIGN, sig.data)
+
+        expect(recoveredOwner.toLowerCase()).toEqual(TEST_ADDRESS.toLowerCase())
+      },
+    )
+  })
+})

--- a/packages/providers/viem-adapter/src/ViemUtils.ts
+++ b/packages/providers/viem-adapter/src/ViemUtils.ts
@@ -223,10 +223,11 @@ export class ViemUtils implements AdapterUtils {
     return { r, s, v }
   }
   async verifyMessage(message: string | Uint8Array, signature: `0x${string}`): Promise<string> {
-    const messageString = typeof message === 'string' ? message : new TextDecoder().decode(message)
-
     return recoverMessageAddress({
-      message: messageString,
+      // Raw bytes (e.g. an order digest hashed for ETHSIGN) are not UTF-8 text: decoding them
+      // as a string before hashing silently signs/recovers a different message. `{ raw }` tells
+      // viem to hash the bytes as-is, matching how ViemSignerAdapter.signMessage signs them.
+      message: typeof message === 'string' ? message : { raw: message },
       signature,
     })
   }


### PR DESCRIPTION
`ViemUtils.verifyMessage` decoded a `Uint8Array` message as UTF-8 text via `TextDecoder` before recovering the signer, instead of passing it through to viem as raw bytes.

Any binary message that isn't valid UTF-8 - notably an order digest hashed for the ETHSIGN signing scheme and passed via `decodeSignatureOwner` (`packages/contracts-ts/src/settlement.ts`) - gets silently mangled by the UTF-8 decode (replacement characters on invalid byte sequences) before being re-hashed with the `personal_sign` prefix, so the recovered address never matches the real signer.

`ViemSignerAdapter.signMessage` already handles the identical `Uint8Array` case correctly, using viem's `{ raw: bytes }` message form (`packages/providers/viem-adapter/src/ViemSignerAdapter.ts:37-48`) - so *signing* an ETHSIGN order with the viem adapter works fine, but *verifying*/recovering its owner does not. `ethers-v5`/`ethers-v6`'s `verifyMessage` handle a `Uint8Array` as raw bytes natively, so this drift was viem-only.

## Fix

Use `{ raw: message }` for the `Uint8Array` branch in `ViemUtils.verifyMessage`, matching the convention `ViemSignerAdapter.signMessage` already uses.

## Test

Added `packages/contracts-ts/tests/decodeSignatureOwner.test.ts`: signs a test order with the ETHSIGN scheme across all three adapters (ethers-v5, ethers-v6, viem) using the real per-adapter signer, then recovers the owner via `decodeSignatureOwner` and asserts it matches the signer's address.

- Before this fix: fails only for the viem adapter (recovers an unrelated address instead of the real signer).
- After this fix: passes for all three adapters.

No existing test exercised `decodeSignatureOwner` for the ETHSIGN scheme, or the viem adapter's raw-byte message path, at all - this was a real, silent, untested correctness gap in owner/signature verification specific to the viem adapter.

## Risk

Low - `verifyMessage`'s string branch is untouched; only the `Uint8Array` branch changes, from an incorrect UTF-8 decode to the raw-bytes form viem itself documents and that the adapter's own signer already uses.