### PR TITLE
fix(viem-adapter): getChainId returns 0 without a static chain config

### DIFF
--- a/packages/contracts-ts/tests/viemAdapterGetChainId.test.ts
+++ b/packages/contracts-ts/tests/viemAdapterGetChainId.test.ts
@@ -1,0 +1,21 @@
+import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
+import { createPublicClient, http } from 'viem'
+
+import { TEST_CHAIN_ID, TEST_RPC_URL } from './setup'
+
+describe('ViemAdapter.getChainId', () => {
+  test('queries the live RPC instead of relying on a statically configured `chain`', async () => {
+    // No `chain` passed to createPublicClient - a valid, common viem setup (e.g. a custom
+    // RPC endpoint with no matching entry in viem/chains). `this._publicClient.chain` is
+    // `undefined` in this case, so a naive `chain?.id ?? 0` implementation silently returns 0.
+    const viemAdapter = new ViemAdapter({
+      provider: createPublicClient({
+        transport: http(TEST_RPC_URL),
+      }),
+    })
+
+    const chainId = await viemAdapter.getChainId()
+
+    expect(chainId).toBe(TEST_CHAIN_ID)
+  })
+})

--- a/packages/providers/viem-adapter/src/ViemAdapter.ts
+++ b/packages/providers/viem-adapter/src/ViemAdapter.ts
@@ -132,7 +132,11 @@ export class ViemAdapter extends AbstractProviderAdapter<ViemTypes> {
   }
 
   async getChainId(): Promise<number> {
-    return this._publicClient.chain?.id ?? 0
+    // `this._publicClient.chain?.id` only reflects the static config the client was built
+    // with (undefined when created without a `chain`, e.g. a custom RPC via `http(url)` alone),
+    // silently yielding chain id 0. `getChainId()` queries `eth_chainId` on the live RPC, matching
+    // how the ethers v5/v6 adapters derive it from `provider.getNetwork()`.
+    return this._publicClient.getChainId()
   }
 
   async getCode(address: string): Promise<string | undefined> {


### PR DESCRIPTION
Does what it says on the box.

`ViemAdapter.getChainId()` reads `this._publicClient.chain?.id ?? 0` - a static property that is `undefined` whenever the `PublicClient` is built without a `chain` (a valid, common setup: `createPublicClient({ transport: http(url) })` for a custom/unlisted RPC endpoint), silently returning chain id `0` instead of the real network id.

Both `EthersV5Adapter.getChainId()` and `EthersV6Adapter.getChainId()` instead derive the chain id from a live network call (`provider.getNetwork()`). Viem itself exposes the matching live action for exactly this - `publicClient.getChainId()`, which calls `eth_chainId` on the RPC - and it's already available on the `PublicClient` type this adapter holds, just wasn't being used.

## Fix

Swap `this._publicClient.chain?.id ?? 0` for `this._publicClient.getChainId()`, matching the ethers adapters' live-query semantics and viem's own idiomatic API.

## Test

Added `packages/contracts-ts/tests/viemAdapterGetChainId.test.ts`: constructs a `ViemAdapter` over a `PublicClient` with no `chain` passed (only `transport`), and asserts `getChainId()` still returns the real chain id via the live RPC call.

- Fails on old code: `Expected: 11155111, Received: 0`
- Passes on the fix

Ran the full `contracts-ts` suite locally after the change - 75/75 passing, no regressions. `tsc --noEmit` and `eslint` both clean on `sdk-viem-adapter`.

## Risk

Low - one-line swap to an existing, already-typed viem action; only touches a path where the caller omitted `chain` from their `PublicClient`, which previously produced a silently wrong (0) value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected chain ID detection for Viem-based connections without a predefined chain configuration.
  * Chain IDs are now retrieved from the connected network, preventing an incorrect value of `0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->