### PR TITLE
feat: allow fetching twap deltas

### DIFF
--- a/packages/composable/src/programmaticOrders/ProgrammaticOrderApi.ts
+++ b/packages/composable/src/programmaticOrders/ProgrammaticOrderApi.ts
@@ -50,7 +50,7 @@ export class ProgrammaticOrderApi {
    * @throws {@link ProgrammaticOrderApiError} when the input is invalid or the request fails.
    */
   async getTwapOrders(params: GetTwapOrdersParams, options: QueryOptions = {}): Promise<QueryPage<TwapOrder>> {
-    const { chainId, resolvedOwner } = parseInput(GET_TWAP_ORDERS_PARAMS_SCHEMA, params)
+    const { chainId, resolvedOwner, updatedAtBlockGte } = parseInput(GET_TWAP_ORDERS_PARAMS_SCHEMA, params)
     const {
       direction = DEFAULT_QUERY_DIRECTION,
       limit = DEFAULT_PAGE_LIMIT,
@@ -67,6 +67,7 @@ export class ProgrammaticOrderApi {
           offset,
           limit,
           direction,
+          ...(updatedAtBlockGte === undefined ? {} : { updatedAtBlockGte: updatedAtBlockGte.toString() }),
         },
         itemSchema: TWAP_PARENT_SCHEMA,
       })

--- a/packages/composable/src/programmaticOrders/twap-queries.ts
+++ b/packages/composable/src/programmaticOrders/twap-queries.ts
@@ -1,10 +1,11 @@
 export const TWAP_ORDERS_QUERY = `
-  query TwapOrders($resolvedOwner: String!, $chainId: Int!, $offset: Int!, $limit: Int!, $direction: String!) {
+  query TwapOrders($resolvedOwner: String!, $chainId: Int!, $offset: Int!, $limit: Int!, $direction: String!, $updatedAtBlockGte: BigInt) {
     twapOrders: conditionalOrderGenerators(
       where: {
         chainId: $chainId
         orderType: TWAP
         resolvedOwner: $resolvedOwner
+        updatedAtBlock_gte: $updatedAtBlockGte
       }
       offset: $offset
       limit: $limit

--- a/packages/composable/src/programmaticOrders/twap-schemas.ts
+++ b/packages/composable/src/programmaticOrders/twap-schemas.ts
@@ -18,6 +18,7 @@ import {
 export const GET_TWAP_ORDERS_PARAMS_SCHEMA = v.object({
   resolvedOwner: ADDRESS_SCHEMA,
   chainId: SUPPORTED_EVM_CHAIN_ID_SCHEMA,
+  updatedAtBlockGte: v.optional(v.pipe(v.bigint(), v.minValue(0n, 'must be a non-negative bigint'))),
 })
 
 export const GET_TWAP_PART_ORDERS_PARAMS_SCHEMA = v.object({

--- a/packages/composable/src/programmaticOrders/twap-types.ts
+++ b/packages/composable/src/programmaticOrders/twap-types.ts
@@ -9,6 +9,8 @@ export interface GetTwapOrdersParams {
   resolvedOwner: string
   /** Chain containing the TWAP orders. */
   chainId: SupportedChainId
+  /** Return only orders updated at or after this indexer block. */
+  updatedAtBlockGte?: bigint
 }
 
 /** Input for querying one page of TWAP part orders. */

--- a/packages/composable/tests/ProgrammaticOrderApi.spec.ts
+++ b/packages/composable/tests/ProgrammaticOrderApi.spec.ts
@@ -82,6 +82,13 @@ describe('ProgrammaticOrderApi', () => {
     await expect(api.getTwapPartOrders(null as unknown as GetTwapPartOrdersParams)).rejects.toThrow(
       'Invalid type: Expected Object but received null',
     )
+    await expect(
+      api.getTwapOrders({
+        resolvedOwner: EOA,
+        chainId: SupportedChainId.GNOSIS_CHAIN,
+        updatedAtBlockGte: -1n,
+      }),
+    ).rejects.toThrow('must be a non-negative bigint')
   })
 
   it('requests parent-only TWAPs by creation and preserves the returned order', async () => {
@@ -135,6 +142,32 @@ describe('ProgrammaticOrderApi', () => {
     expect(page.items[0]).not.toHaveProperty('partOrders')
   })
 
+  it('filters TWAP orders by an inclusive update block', async () => {
+    const fetchMock = jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { twapOrders: { items: [], totalCount: 2 } } }), {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+
+    const page = await new ProgrammaticOrderApi({ apiUrl: 'https://example.com' }).getTwapOrders(
+      {
+        resolvedOwner: EOA,
+        chainId: SupportedChainId.GNOSIS_CHAIN,
+        updatedAtBlockGte: 10n,
+      },
+      { limit: 1000 },
+    )
+    const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      query: string
+      variables: Record<string, unknown>
+    }
+
+    expect(request.query).toContain('updatedAtBlock_gte: $updatedAtBlockGte')
+    expect(request.variables.updatedAtBlockGte).toBe('10')
+    expect(page).toEqual({ items: [], totalCount: 2 })
+  })
   it('applies query options to a part-order page', async () => {
     const fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(
@@ -173,7 +206,6 @@ describe('ProgrammaticOrderApi', () => {
     })
     expect(page).toEqual({ items: [], totalCount: 12 })
   })
-
 })
 
 function twapParent(eventId: string, blockTimestamp: number): Record<string, unknown> {


### PR DESCRIPTION
# Summary

Part of: [FE-349](https://linear.app/cowswap/issue/FE-349/optimize-refreshes-to-fetch-only-twaps-that-changed)

Add an optional `updatedAtBlockGte` filter to `getTwapOrders`. Clients can fetch changed TWAP parents instead of the full list.

- Accept a non-negative `bigint` and serialize it for GraphQL.
- Preserve existing behavior when the filter is absent.
- Add tests for filter serialization and negative-value rejection.

# To Test

1. Call `getTwapOrders` without `updatedAtBlockGte`.

- [ ] Verify that existing pagination and ordering remain unchanged.

2. Call `getTwapOrders` with `updatedAtBlockGte` set to a known block.

- [ ] Verify that results contain only parents updated at or after that block.
- [ ] Verify that `totalCount` represents the filtered results, not all TWAPs.

3. Call `getTwapOrders` with `updatedAtBlockGte: -1n`.

- [ ] Verify that input validation rejects the request.

# Background

This filter supports delta polling in the frontend without a separate SDK method or GraphQL query.

The boundary is inclusive. Consecutive requests can return the same orders, so clients must merge results by order ID.

# Self-checks

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have manually tested changes on Vercel preview deployment
- [ ] I have done self-review and (or) AI review
- [ ] I have addressed all comments from @coderabbitai
- [ ] I have less than three open PRs/Stacks in this repo at the moment of creating this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `updatedAtBlockGte` filter when retrieving TWAP orders.
  - Users can now request only orders updated at or after a specified indexer block.
  - The filter accepts non-negative bigint values and is forwarded correctly when querying orders.

- **Bug Fixes**
  - Added validation to reject invalid negative block values with a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->