### PR TITLE
fix(bridging): slowFillRequested is not a completed Across deposit

### DIFF
--- a/packages/bridging/src/providers/across/types.ts
+++ b/packages/bridging/src/providers/across/types.ts
@@ -209,8 +209,9 @@ export interface DepositStatusResponse {
    * - pending: Deposit not yet filled
    * - expired: Deposit expired and will be refunded
    * - refunded: Deposit expired and depositor refunded on originChain
-   * - slowFillRequested: Across' relayer fills without requiring another relayer to front capital
-   *   (requires input token and output token to be the same asset)
+   * - slowFillRequested: A slow fill has been requested for the deposit but not yet executed. The deposit will be
+   *   filled in the next root bundle unless a relayer fills it first via a fast fill in the meantime.
+   *   The destination funds have NOT arrived yet.
    */
   status: 'filled' | 'pending' | 'expired' | 'refunded' | 'slowFillRequested'
 

--- a/packages/bridging/src/providers/across/util.test.ts
+++ b/packages/bridging/src/providers/across/util.test.ts
@@ -183,7 +183,7 @@ describe('Across Utils', () => {
       expect(mapAcrossStatusToBridgeStatus('pending')).toBe(BridgeStatus.IN_PROGRESS)
       expect(mapAcrossStatusToBridgeStatus('expired')).toBe(BridgeStatus.EXPIRED)
       expect(mapAcrossStatusToBridgeStatus('refunded')).toBe(BridgeStatus.REFUND)
-      expect(mapAcrossStatusToBridgeStatus('slowFillRequested')).toBe(BridgeStatus.EXECUTED)
+      expect(mapAcrossStatusToBridgeStatus('slowFillRequested')).toBe(BridgeStatus.IN_PROGRESS)
     })
   })
 

--- a/packages/bridging/src/providers/across/util.ts
+++ b/packages/bridging/src/providers/across/util.ts
@@ -169,7 +169,7 @@ export function applyBps(amount: bigint, bps: number): bigint {
 
 const AcrossStatusToBridgeStatus: Record<DepositStatusResponse['status'], BridgeStatus> = {
   filled: BridgeStatus.EXECUTED,
-  slowFillRequested: BridgeStatus.EXECUTED,
+  slowFillRequested: BridgeStatus.IN_PROGRESS,
   pending: BridgeStatus.IN_PROGRESS,
   expired: BridgeStatus.EXPIRED,
   refunded: BridgeStatus.REFUND,


### PR DESCRIPTION
Found by code inspection while continuing the standing bug-hunt on the Across bridge provider (same area as #983/#992).

## Bug

`AcrossStatusToBridgeStatus` in `packages/bridging/src/providers/across/util.ts` mapped Across' `slowFillRequested` deposit status to `BridgeStatus.EXECUTED` - same bucket as `filled`:

```ts
const AcrossStatusToBridgeStatus: Record<DepositStatusResponse['status'], BridgeStatus> = {
  filled: BridgeStatus.EXECUTED,
  slowFillRequested: BridgeStatus.EXECUTED, // wrong
  pending: BridgeStatus.IN_PROGRESS,
  expired: BridgeStatus.EXPIRED,
  refunded: BridgeStatus.REFUND,
}
```

Per Across' own docs/semantics, `slowFillRequested` means a slow fill has been *requested* for the deposit but not yet executed - it gets filled in the next root bundle unless a relayer fast-fills it first in the meantime. The destination funds have **not arrived** at this status.

`getStatus()` (`AcrossBridgeProvider.ts`) is the live polling entrypoint SDK consumers use to know whether a bridge transfer has completed. With the bug, any consumer polling status during a slow-fill window sees `executed` and will treat the transfer as done - funds settled, safe to proceed - while the recipient hasn't actually received anything yet.

The existing test was pinning the wrong behavior:
```ts
expect(mapAcrossStatusToBridgeStatus('slowFillRequested')).toBe(BridgeStatus.EXECUTED)
```

## Direction safety

Low risk, one-line semantic fix. `IN_PROGRESS` is already the correct/expected value for "deposit not yet filled" (used for `pending`), so this reclassifies `slowFillRequested` into an existing, already-handled bucket - no new state, no new branch, nothing else in the mapper touched.

## Fix

- `slowFillRequested` now maps to `BridgeStatus.IN_PROGRESS`, matching `pending`.
- Corrected the misleading JSDoc on `DepositStatusResponse['status']` (previously described `slowFillRequested` as a relayer-capital-fronting detail unrelated to its actual not-yet-filled meaning).
- Fixed the test that was asserting the wrong mapping.

## Test coverage

- `mapAcrossStatusToBridgeStatus` unit test updated - fails on unfixed code (`Expected: "in_progress", Received: "executed"`), passes after the fix. Verified both directions locally (stashed the source fix, confirmed the test goes red; restored it, confirmed green).
- Full `packages/bridging` suite: 620 passed / 23 suites, unaffected.
- `tsc --noEmit` on the package shows 12 pre-existing, unrelated Near Intents errors (`correlationId`/`withdrawFee`) present identically on `main` before this change - confirmed by diffing against a clean checkout.
- eslint clean on touched files. Prettier clean on the two files I added lines to (`types.ts`, `util.test.ts`); `util.ts` has a pre-existing prettier formatting nit (import block) unrelated to this diff and present on `main`, left untouched.

closes N/A - no tracking issue, found and fixed directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh6V2uPTUqauqq45BM7m5k


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deposits awaiting a slow fill are now shown as **In Progress** rather than **Executed**.
  * Status details now more accurately reflect that destination funds have not yet arrived.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->