### PR TITLE
feat: include scheduled parts

### DIFF
--- a/packages/composable/src/programmaticOrders/ProgrammaticOrderApi.ts
+++ b/packages/composable/src/programmaticOrders/ProgrammaticOrderApi.ts
@@ -42,7 +42,7 @@ export class ProgrammaticOrderApi {
   /**
    * Returns one page of TWAP orders created by an EOA or Safe.
    *
-   * Results are sorted by creation time, newest first by default. Use {@link getTwapPartOrders} to fetch part orders.
+   * Results are sorted by event ID, descending by default. Use {@link getTwapPartOrders} to fetch part orders.
    *
    * @param params - EOA or Safe address and chain. Do not pass a CoWShed proxy address.
    * @param options - Pagination and sort direction.
@@ -79,7 +79,7 @@ export class ProgrammaticOrderApi {
   }
 
   /**
-   * Returns one page of part orders for a TWAP order, newest first by default.
+   * Returns known parts, including unconfirmed candidates, sorted by expiry and UID, descending by default.
    *
    * @param params - Parent event ID and chain.
    * @param options - Pagination and sort direction.

--- a/packages/composable/src/programmaticOrders/twap-queries.ts
+++ b/packages/composable/src/programmaticOrders/twap-queries.ts
@@ -1,6 +1,6 @@
 export const TWAP_ORDERS_QUERY = `
   query TwapOrders($resolvedOwner: String!, $chainId: Int!, $offset: Int!, $limit: Int!, $direction: String!, $updatedAtBlockGte: BigInt) {
-    twapOrders: conditionalOrderGenerators(
+    twapOrders: programmaticOrders(
       where: {
         chainId: $chainId
         orderType: TWAP
@@ -21,13 +21,9 @@ export const TWAP_ORDERS_QUERY = `
         status
         updatedAtBlock
         additionalData
-        partOrders: discreteOrders(limit: 1) {
-          totalCount
-        }
+        partOrdersCount
         schedule: decodedParams
-        transaction {
-          blockTimestamp
-        }
+        createdAt: creationDate
       }
       totalCount
     }
@@ -36,14 +32,14 @@ export const TWAP_ORDERS_QUERY = `
 
 export const TWAP_PART_ORDERS_QUERY = `
   query TwapPartOrders($chainId: Int!, $parentEventId: String!, $offset: Int!, $limit: Int!, $direction: String!) {
-    partOrders: discreteOrders(
+    partOrders: partOrders(
       where: {
         chainId: $chainId
         conditionalOrderGeneratorId: $parentEventId
       }
       offset: $offset
       limit: $limit
-      orderBy: "creationDate"
+      orderBy: "sortKey"
       orderDirection: $direction
     ) {
       items {

--- a/packages/composable/src/programmaticOrders/twap-schemas.ts
+++ b/packages/composable/src/programmaticOrders/twap-schemas.ts
@@ -58,25 +58,17 @@ export const TWAP_PARENT_SCHEMA = v.pipe(
       executedBuyAmount: UINT256_SCHEMA,
       executedFee: UINT256_SCHEMA,
     }),
-    partOrders: v.object({ totalCount: SAFE_INTEGER_SCHEMA }),
-    transaction: v.object({ blockTimestamp: TIMESTAMP_SCHEMA }),
+    partOrdersCount: v.pipe(SAFE_INTEGER_SCHEMA, v.minValue(0)),
+    createdAt: TIMESTAMP_SCHEMA,
     schedule: TWAP_SCHEDULE_SCHEMA,
   }),
   v.transform(
-    ({
-      additionalData: { executedSellAmount, executedBuyAmount, executedFee },
-      partOrders,
-      schedule,
-      transaction,
-      ...parent
-    }) => {
+    ({ additionalData: { executedSellAmount, executedBuyAmount, executedFee }, schedule, createdAt, ...parent }) => {
       const { t0, n, t, span, ...scheduleParams } = schedule
-      const createdAt = transaction.blockTimestamp
 
       return {
         ...parent,
         createdAt,
-        partOrdersCount: partOrders.totalCount,
         executedAmounts: {
           executedSellAmount,
           executedBuyAmount,
@@ -97,7 +89,14 @@ export const TWAP_PARENT_SCHEMA = v.pipe(
 /** @see https://github.com/cowprotocol/cow-programmatic-orders-api/blob/main/src/api/gql-docs/discrete-order.ts */
 export const TWAP_PART_ORDER_SCHEMA = v.object({
   orderUid: ORDER_UID_SCHEMA,
-  status: v.picklist([OrderStatus.OPEN, OrderStatus.FULFILLED, OrderStatus.EXPIRED, OrderStatus.CANCELLED, 'unfilled']),
+  status: v.picklist([
+    OrderStatus.OPEN,
+    OrderStatus.FULFILLED,
+    OrderStatus.EXPIRED,
+    OrderStatus.CANCELLED,
+    'unfilled',
+    'unconfirmed',
+  ]),
   sellAmount: UINT256_SCHEMA,
   buyAmount: UINT256_SCHEMA,
   feeAmount: UINT256_SCHEMA,

--- a/packages/composable/src/programmaticOrders/twap-types.ts
+++ b/packages/composable/src/programmaticOrders/twap-types.ts
@@ -22,7 +22,7 @@ export interface GetTwapPartOrdersParams {
 }
 
 /**
- * Orderbook status of a TWAP part order.
+ * Indexer status of a TWAP part order, including unconfirmed candidates.
  *
  * Unlike `OrderStatus` from `@cowprotocol/sdk-order-book`, this API reports
  * `unfilled` when an order leaves the orderbook without settling, and does not
@@ -36,6 +36,7 @@ export type TwapPartOrderStatus =
   | OrderStatus.EXPIRED
   | OrderStatus.CANCELLED
   | 'unfilled'
+  | 'unconfirmed'
 
 /**
  * Schedule for a TWAP order. Unlike {@link TwapStruct}, `effectiveStartTime`
@@ -106,7 +107,7 @@ export interface TwapOrder {
   createdAt: number
   /** Block in which the indexer last updated this TWAP or one of its part orders. */
   updatedAtBlock: bigint
-  /** Number of part orders currently reported for this parent. */
+  /** Number of known parts, including unconfirmed candidates, without duplicates. */
   partOrdersCount: number
   schedule: TwapSchedule
   executedAmounts: TwapExecutedAmounts

--- a/packages/composable/tests/ProgrammaticOrderApi.spec.ts
+++ b/packages/composable/tests/ProgrammaticOrderApi.spec.ts
@@ -140,16 +140,16 @@ describe('ProgrammaticOrderApi', () => {
       durationOfPart: 0,
     })
     expect(page.items[0]).not.toHaveProperty('partOrders')
+    expect(page.items[0]?.partOrdersCount).toBe(2)
+    expect(request.query).toContain('twapOrders: programmaticOrders(')
   })
 
   it('filters TWAP orders by an inclusive update block', async () => {
-    const fetchMock = jest
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ data: { twapOrders: { items: [], totalCount: 2 } } }), {
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      )
+    const fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { twapOrders: { items: [], totalCount: 2 } } }), {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
 
     const page = await new ProgrammaticOrderApi({ apiUrl: 'https://example.com' }).getTwapOrders(
       {
@@ -195,7 +195,8 @@ describe('ProgrammaticOrderApi', () => {
       variables: Record<string, unknown>
     }
 
-    expect(request.query).toContain('orderBy: "creationDate"')
+    expect(request.query).toContain('partOrders: partOrders(')
+    expect(request.query).toContain('orderBy: "sortKey"')
     expect(request.query).toContain('orderDirection: $direction')
     expect(request.variables).toEqual({
       chainId: SupportedChainId.GNOSIS_CHAIN,
@@ -205,6 +206,54 @@ describe('ProgrammaticOrderApi', () => {
       direction: 'desc',
     })
     expect(page).toEqual({ items: [], totalCount: 12 })
+  })
+
+  it('returns unconfirmed candidates without inventing executed amounts', async () => {
+    const orderUid = `0x${'1'.repeat(112)}`
+    jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            partOrders: {
+              items: [
+                {
+                  orderUid,
+                  status: 'unconfirmed',
+                  sellAmount: '10',
+                  buyAmount: '5',
+                  feeAmount: '0',
+                  validTo: 2000,
+                  createdAt: '1000',
+                  executedSellAmount: null,
+                  executedBuyAmount: null,
+                  executedFeeAmount: null,
+                },
+              ],
+              totalCount: 1,
+            },
+          },
+        }),
+      ),
+    )
+
+    const page = await new ProgrammaticOrderApi().getTwapPartOrders({
+      eventId: 'parent',
+      chainId: SupportedChainId.GNOSIS_CHAIN,
+    })
+    expect(page.items).toEqual([
+      {
+        orderUid,
+        status: 'unconfirmed',
+        sellAmount: 10n,
+        buyAmount: 5n,
+        feeAmount: 0n,
+        validTo: 2000,
+        createdAt: 1000,
+        executedSellAmount: null,
+        executedBuyAmount: null,
+        executedFeeAmount: null,
+      },
+    ])
   })
 })
 
@@ -222,7 +271,7 @@ function twapParent(eventId: string, blockTimestamp: number): Record<string, unk
       executedBuyAmount: '0',
       executedFee: '0',
     },
-    partOrders: { totalCount: 0 },
+    partOrdersCount: 2,
     schedule: {
       sellToken: EOA,
       buyToken: EOA,
@@ -235,6 +284,6 @@ function twapParent(eventId: string, blockTimestamp: number): Record<string, unk
       span: '0',
       appData: `0x${'2'.repeat(64)}`,
     },
-    transaction: { blockTimestamp: String(blockTimestamp) },
+    createdAt: String(blockTimestamp),
   }
 }


### PR DESCRIPTION
Instead of querying only "discrete" parts, now we query candidates as well (scheduled).

Depends on https://github.com/cowprotocol/cow-programmatic-orders-api/pull/7

Part of [FE-479 Show Sheduled parts for TWAPs for EOAs](https://linear.app/cowswap/issue/FE-479/show-sheduled-parts-for-twaps-for-eoas)