### PR TITLE
feat: replace sol on wsol in quiotes

### DIFF
--- a/packages/sdk-trading-solana/src/getSolanaQuote.test.ts
+++ b/packages/sdk-trading-solana/src/getSolanaQuote.test.ts
@@ -2,7 +2,13 @@ import fetchMock from 'jest-fetch-mock'
 import { PublicKey } from '@solana/web3.js'
 import { getAssociatedTokenAddressSync, TOKEN_2022_PROGRAM_ID } from '@solana/spl-token'
 import { OrderKind } from '@cowprotocol/sdk-order-book'
-import { SOLANA_SETTLEMENT_PROGRAM_ID, SOLANA_SETTLEMENT_PROGRAM_ID_STAGING } from '@cowprotocol/sdk-config'
+import {
+  SOL_NATIVE_CURRENCY_ADDRESS,
+  SOLANA_SETTLEMENT_PROGRAM_ID,
+  SOLANA_SETTLEMENT_PROGRAM_ID_STAGING,
+  SupportedChainId,
+  WRAPPED_NATIVE_CURRENCIES,
+} from '@cowprotocol/sdk-config'
 
 import { getSolanaQuote } from './getSolanaQuote'
 import { findOrderPda } from './orderPda'
@@ -181,6 +187,106 @@ describe('getSolanaQuote', () => {
 
     const calledUrl = new URL(fetchMock.mock.calls[0]?.[0] as string)
     expect(calledUrl.searchParams.get('swapMode')).toBe('ExactOut')
+  })
+
+  describe('selling native SOL', () => {
+    const wsolMint = new PublicKey(WRAPPED_NATIVE_CURRENCIES[SupportedChainId.SOLANA].address)
+    const usdcMint = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
+
+    function mockJupiterOrder(): void {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          inputMint: wsolMint.toBase58(),
+          outputMint: usdcMint.toBase58(),
+          inAmount: '1000000000',
+          outAmount: '150000000',
+          swapMode: 'ExactIn',
+          slippageBps: 50,
+        }),
+      )
+    }
+
+    function quoteNativeSell(): ReturnType<typeof getSolanaQuote> {
+      return getSolanaQuote({
+        ownerAddress: owner,
+        receiverAddress: receiver,
+        sellTokenAddress: SOL_NATIVE_CURRENCY_ADDRESS,
+        sellTokenDecimals: 9,
+        buyTokenAddress: usdcMint,
+        buyTokenDecimals: 6,
+        amount: 1_000_000_000n,
+        kind: OrderKind.SELL,
+      })
+    }
+
+    it('asks Jupiter for the WSOL mint, since the native sentinel is not a token mint', async () => {
+      mockJupiterOrder()
+
+      await quoteNativeSell()
+
+      const calledUrl = new URL(fetchMock.mock.calls[0]?.[0] as string)
+      expect(calledUrl.searchParams.get('inputMint')).toBe(wsolMint.toBase58())
+      expect(calledUrl.searchParams.get('inputMint')).not.toBe(SOL_NATIVE_CURRENCY_ADDRESS)
+    })
+
+    it('builds the intent against the WSOL account the wrap step funds, not the System Program', async () => {
+      mockJupiterOrder()
+
+      const { solanaQuote } = await quoteNativeSell()
+
+      expect(solanaQuote.intent.sellMint.toBase58()).toBe(wsolMint.toBase58())
+      expect(solanaQuote.intent.sellTokenAccount.toBase58()).toBe(
+        getAssociatedTokenAddressSync(wsolMint, owner, false, undefined).toBase58(),
+      )
+      expect(solanaQuote.intent.sellTokenAccount.toBase58()).not.toBe(
+        getAssociatedTokenAddressSync(new PublicKey(SOL_NATIVE_CURRENCY_ADDRESS), owner, false, undefined).toBase58(),
+      )
+    })
+
+    it('reports the requested sell token back, so callers do not see it as a changed parameter', async () => {
+      mockJupiterOrder()
+
+      const { quoteResults } = await quoteNativeSell()
+
+      expect(quoteResults.tradeParameters.sellToken).toBe(SOL_NATIVE_CURRENCY_ADDRESS)
+    })
+
+    it('places the order against WSOL, which is what actually gets settled', async () => {
+      mockJupiterOrder()
+
+      const { quoteResults } = await quoteNativeSell()
+
+      expect(quoteResults.quoteResponse.quote.sellToken).toBe(wsolMint.toBase58())
+    })
+
+    it('leaves an SPL sell mint untouched', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          inputMint: usdcMint.toBase58(),
+          outputMint: wsolMint.toBase58(),
+          inAmount: '150000000',
+          outAmount: '1000000000',
+          swapMode: 'ExactIn',
+          slippageBps: 50,
+        }),
+      )
+
+      const { solanaQuote, quoteResults } = await getSolanaQuote({
+        ownerAddress: owner,
+        receiverAddress: receiver,
+        sellTokenAddress: usdcMint,
+        sellTokenDecimals: 6,
+        buyTokenAddress: wsolMint,
+        buyTokenDecimals: 9,
+        amount: 150_000_000n,
+        kind: OrderKind.SELL,
+      })
+
+      const calledUrl = new URL(fetchMock.mock.calls[0]?.[0] as string)
+      expect(calledUrl.searchParams.get('inputMint')).toBe(usdcMint.toBase58())
+      expect(solanaQuote.intent.sellMint.toBase58()).toBe(usdcMint.toBase58())
+      expect(quoteResults.tradeParameters.sellToken).toBe(usdcMint.toBase58())
+    })
   })
 
   it('derives buyTokenAccount for the receiver and sellTokenAccount for the owner', async () => {

--- a/packages/sdk-trading-solana/src/getSolanaQuote.ts
+++ b/packages/sdk-trading-solana/src/getSolanaQuote.ts
@@ -1,6 +1,11 @@
 import { PublicKey } from '@solana/web3.js'
 import { getAssociatedTokenAddressSync } from '@solana/spl-token'
-import { CowEnv } from '@cowprotocol/sdk-config'
+import {
+  CowEnv,
+  SOL_NATIVE_CURRENCY_ADDRESS,
+  SupportedChainId,
+  WRAPPED_NATIVE_CURRENCIES,
+} from '@cowprotocol/sdk-config'
 import { getQuoteAmountsAndCosts, OrderKind, OrderParameters, OrderQuoteResponse } from '@cowprotocol/sdk-order-book'
 
 import { JupiterAPI } from './jupiterApi'
@@ -16,6 +21,23 @@ const DEFAULT_VALID_FOR_SECONDS = 30 * 60
 const ZERO_APP_DATA = new Uint8Array(32)
 
 const jupiterApi = new JupiterAPI()
+
+/** The chain's native-currency sentinel — the System Program address, which is not a token mint. */
+const NATIVE_SOL_MINT = new PublicKey(SOL_NATIVE_CURRENCY_ADDRESS)
+const WSOL_MINT = new PublicKey(WRAPPED_NATIVE_CURRENCIES[SupportedChainId.SOLANA].address)
+
+/**
+ * Jupiter routes and the settlement intent both address tokens by SPL mint, and native SOL has none.
+ * Callers pass the native sentinel, so substitute WSOL — the same adjustment `getQuote` makes for EVM
+ * eth-flow orders via `adjustEthFlowOrderParams`. Both have 9 decimals, so amounts carry over unchanged.
+ *
+ * This has to happen before the intent is built, not just before the Jupiter call: the intent's
+ * `sellTokenAccount` is the associated token account of this mint, and only the WSOL one can ever hold
+ * the wrapped lamports the caller's wrap step produces.
+ */
+function toSplMint(mint: PublicKey): PublicKey {
+  return mint.equals(NATIVE_SOL_MINT) ? WSOL_MINT : mint
+}
 
 export async function getSolanaQuote(
   params: SolanaQuoteParameters,
@@ -40,7 +62,8 @@ export async function getSolanaQuote(
 
   const owner = new PublicKey(ownerAddress)
   const receiver = new PublicKey(receiverAddress)
-  const sellMint = new PublicKey(params.sellTokenAddress)
+  const requestedSellMint = new PublicKey(params.sellTokenAddress)
+  const sellMint = toSplMint(requestedSellMint)
   const buyMint = new PublicKey(params.buyTokenAddress)
   const sellTokenProgram = sellTokenProgramId ? new PublicKey(sellTokenProgramId) : undefined
   const buyTokenProgram = buyTokenProgramId ? new PublicKey(buyTokenProgramId) : undefined
@@ -126,7 +149,10 @@ export async function getSolanaQuote(
   const tradeParameters: TradeParameters = {
     kind,
     owner: owner.toBase58(),
-    sellToken: sellTokenAddress,
+    // The mint the caller asked for, not the substituted one: callers compare the returned parameters
+    // against the ones they passed to decide whether a quote is still current, and reporting WSOL for a
+    // native-SOL request would read as a changed sell token and requote forever.
+    sellToken: requestedSellMint.toBase58(),
     sellTokenDecimals,
     buyToken: buyTokenAddress,
     buyTokenDecimals,

--- a/packages/sdk-trading-solana/src/getSolanaQuote.ts
+++ b/packages/sdk-trading-solana/src/getSolanaQuote.ts
@@ -1,16 +1,12 @@
 import { PublicKey } from '@solana/web3.js'
 import { getAssociatedTokenAddressSync } from '@solana/spl-token'
-import {
-  CowEnv,
-  SOL_NATIVE_CURRENCY_ADDRESS,
-  SupportedChainId,
-  WRAPPED_NATIVE_CURRENCIES,
-} from '@cowprotocol/sdk-config'
+import { CowEnv } from '@cowprotocol/sdk-config'
 import { getQuoteAmountsAndCosts, OrderKind, OrderParameters, OrderQuoteResponse } from '@cowprotocol/sdk-order-book'
 
 import { JupiterAPI } from './jupiterApi'
 import { encodeOrderIntent, hashOrderIntent, SolanaOrderIntent } from './orderIntent'
 import { findOrderPda } from './orderPda'
+import { toSplMint } from './splMint'
 import { getSolanaSettlementProgramId } from './statePda'
 import { SolanaQuote, SolanaQuoteParameters } from './types'
 import type { QuoteResults, TradeParameters } from '@cowprotocol/sdk-trading'
@@ -21,23 +17,6 @@ const DEFAULT_VALID_FOR_SECONDS = 30 * 60
 const ZERO_APP_DATA = new Uint8Array(32)
 
 const jupiterApi = new JupiterAPI()
-
-/** The chain's native-currency sentinel — the System Program address, which is not a token mint. */
-const NATIVE_SOL_MINT = new PublicKey(SOL_NATIVE_CURRENCY_ADDRESS)
-const WSOL_MINT = new PublicKey(WRAPPED_NATIVE_CURRENCIES[SupportedChainId.SOLANA].address)
-
-/**
- * Jupiter routes and the settlement intent both address tokens by SPL mint, and native SOL has none.
- * Callers pass the native sentinel, so substitute WSOL — the same adjustment `getQuote` makes for EVM
- * eth-flow orders via `adjustEthFlowOrderParams`. Both have 9 decimals, so amounts carry over unchanged.
- *
- * This has to happen before the intent is built, not just before the Jupiter call: the intent's
- * `sellTokenAccount` is the associated token account of this mint, and only the WSOL one can ever hold
- * the wrapped lamports the caller's wrap step produces.
- */
-function toSplMint(mint: PublicKey): PublicKey {
-  return mint.equals(NATIVE_SOL_MINT) ? WSOL_MINT : mint
-}
 
 export async function getSolanaQuote(
   params: SolanaQuoteParameters,

--- a/packages/sdk-trading-solana/src/splMint.test.ts
+++ b/packages/sdk-trading-solana/src/splMint.test.ts
@@ -1,0 +1,22 @@
+import { PublicKey } from '@solana/web3.js'
+import { SOL_NATIVE_CURRENCY_ADDRESS, SupportedChainId, WRAPPED_NATIVE_CURRENCIES } from '@cowprotocol/sdk-config'
+
+import { toSplMint } from './splMint'
+
+describe('toSplMint', () => {
+  const wsolMint = WRAPPED_NATIVE_CURRENCIES[SupportedChainId.SOLANA].address
+
+  it('substitutes WSOL for the native SOL sentinel', () => {
+    expect(toSplMint(new PublicKey(SOL_NATIVE_CURRENCY_ADDRESS)).toBase58()).toBe(wsolMint)
+  })
+
+  it('leaves an SPL mint untouched', () => {
+    const usdcMint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+
+    expect(toSplMint(new PublicKey(usdcMint)).toBase58()).toBe(usdcMint)
+  })
+
+  it('leaves WSOL itself untouched, so an explicit WSOL trade is not rewritten', () => {
+    expect(toSplMint(new PublicKey(wsolMint)).toBase58()).toBe(wsolMint)
+  })
+})

--- a/packages/sdk-trading-solana/src/splMint.ts
+++ b/packages/sdk-trading-solana/src/splMint.ts
@@ -1,0 +1,19 @@
+import { PublicKey } from '@solana/web3.js'
+import { SOL_NATIVE_CURRENCY_ADDRESS, SupportedChainId, WRAPPED_NATIVE_CURRENCIES } from '@cowprotocol/sdk-config'
+
+/** The chain's native-currency sentinel — the System Program address, which is not a token mint. */
+const NATIVE_SOL_MINT = new PublicKey(SOL_NATIVE_CURRENCY_ADDRESS)
+const WSOL_MINT = new PublicKey(WRAPPED_NATIVE_CURRENCIES[SupportedChainId.SOLANA].address)
+
+/**
+ * Jupiter routes and the settlement intent both address tokens by SPL mint, and native SOL has none.
+ * Callers pass the native sentinel, so substitute WSOL — the same adjustment `getQuote` makes for EVM
+ * eth-flow orders via `adjustEthFlowOrderParams`. Both have 9 decimals, so amounts carry over unchanged.
+ *
+ * This has to happen before the order intent is built, not just before the Jupiter call: the intent's
+ * `sellTokenAccount` is the associated token account of this mint, and only the WSOL one can ever hold
+ * the wrapped lamports the caller's wrap step produces.
+ */
+export function toSplMint(mint: PublicKey): PublicKey {
+  return mint.equals(NATIVE_SOL_MINT) ? WSOL_MINT : mint
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selling native SOL in Solana trading quotes.
  * Native SOL trades are automatically routed through the wrapped SOL representation while preserving the original SOL token in returned trade details.
* **Bug Fixes**
  * Improved quote and settlement handling for native SOL.
  * Existing SPL token and explicit wrapped SOL trading behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->